### PR TITLE
Fix: Update tools to be compatible with Cursor and other MCP clients

### DIFF
--- a/src/tools/analytics.ts
+++ b/src/tools/analytics.ts
@@ -79,14 +79,13 @@ export const ANALYTICS_HANDLERS: ToolHandlers = {
 
     const analyticsData = await analyticsResponse.json()
     return {
-      toolResult: {
-        content: [
-          {
-            type: 'text',
-            text: JSON.stringify(analyticsData, null, 2),
-          },
-        ],
-      },
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(analyticsData, null, 2),
+        },
+      ],
+      metadata: {}
     }
   },
 }

--- a/src/tools/d1.ts
+++ b/src/tools/d1.ts
@@ -189,9 +189,8 @@ export const D1_HANDLERS: ToolHandlers = {
   d1_list_databases: async (request) => {
     const results = await handleD1ListDatabases()
     return {
-      toolResult: {
-        content: [{ type: 'text', text: JSON.stringify(results, null, 2) }],
-      },
+      content: [{ type: 'text', text: JSON.stringify(results, null, 2) }],
+      metadata: {}
     }
   },
 
@@ -199,9 +198,8 @@ export const D1_HANDLERS: ToolHandlers = {
     const { name } = request.params.arguments as { name: string }
     const result = await handleD1CreateDatabase(name)
     return {
-      toolResult: {
-        content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-      },
+      content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+      metadata: {}
     }
   },
 
@@ -209,9 +207,8 @@ export const D1_HANDLERS: ToolHandlers = {
     const { databaseId } = request.params.arguments as { databaseId: string }
     await handleD1DeleteDatabase(databaseId)
     return {
-      toolResult: {
-        content: [{ type: 'text', text: `Successfully deleted database: ${databaseId}` }],
-      },
+      content: [{ type: 'text', text: `Successfully deleted database: ${databaseId}` }],
+      metadata: {}
     }
   },
 
@@ -223,9 +220,8 @@ export const D1_HANDLERS: ToolHandlers = {
     }
     const result = await handleD1Query(databaseId, query, params)
     return {
-      toolResult: {
-        content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-      },
+      content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+      metadata: {}
     }
   },
 }

--- a/src/tools/kv.ts
+++ b/src/tools/kv.ts
@@ -1,7 +1,7 @@
 import { config, log } from '../utils/helpers'
 import { fetch } from 'undici'
 import { ToolHandlers } from '../utils/types'
-import { Tool } from '@modelcontextprotocol/sdk/types.js'
+import { Tool } from '@modelcontextprotocol/sdk'
 
 interface CloudflareListResponse {
   result: Array<{
@@ -239,14 +239,13 @@ export const KV_HANDLERS: ToolHandlers = {
   get_kvs: async (request) => {
     const results = await handleGetKVs()
     return {
-      toolResult: {
-        content: [
-          {
-            type: 'text',
-            text: JSON.stringify(results, null, 2),
-          },
-        ],
-      },
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(results, null, 2),
+        },
+      ],
+      metadata: {}
     }
   },
 
@@ -254,14 +253,13 @@ export const KV_HANDLERS: ToolHandlers = {
     const { namespaceId, key } = request.params.arguments as { namespaceId: string; key: string }
     const value = await handleGet(namespaceId, key)
     return {
-      toolResult: {
-        content: [
-          {
-            type: 'text',
-            text: value,
-          },
-        ],
-      },
+      content: [
+        {
+          type: 'text',
+          text: value,
+        },
+      ],
+      metadata: {}
     }
   },
 
@@ -274,14 +272,13 @@ export const KV_HANDLERS: ToolHandlers = {
     }
     await handlePut(namespaceId, key, value, expirationTtl)
     return {
-      toolResult: {
-        content: [
-          {
-            type: 'text',
-            text: `Successfully stored value for key: ${key}`,
-          },
-        ],
-      },
+      content: [
+        {
+          type: 'text',
+          text: `Successfully stored value for key: ${key}`,
+        },
+      ],
+      metadata: {}
     }
   },
 
@@ -289,14 +286,13 @@ export const KV_HANDLERS: ToolHandlers = {
     const { namespaceId, key } = request.params.arguments as { namespaceId: string; key: string }
     await handleDelete(namespaceId, key)
     return {
-      toolResult: {
-        content: [
-          {
-            type: 'text',
-            text: `Successfully deleted key: ${key}`,
-          },
-        ],
-      },
+      content: [
+        {
+          type: 'text',
+          text: `Successfully deleted key: ${key}`,
+        },
+      ],
+      metadata: {}
     }
   },
 
@@ -308,14 +304,13 @@ export const KV_HANDLERS: ToolHandlers = {
     }
     const results = await handleList(namespaceId, prefix, limit)
     return {
-      toolResult: {
-        content: [
-          {
-            type: 'text',
-            text: JSON.stringify(results, null, 2),
-          },
-        ],
-      },
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(results, null, 2),
+        },
+      ],
+      metadata: {}
     }
   },
 }

--- a/src/tools/r2.ts
+++ b/src/tools/r2.ts
@@ -304,9 +304,8 @@ export const R2_HANDLERS: ToolHandlers = {
   r2_list_buckets: async (request) => {
     const results = await handleR2ListBuckets()
     return {
-      toolResult: {
-        content: [{ type: 'text', text: JSON.stringify(results, null, 2) }],
-      },
+      content: [{ type: 'text', text: JSON.stringify(results, null, 2) }],
+      metadata: {}
     }
   },
 
@@ -314,9 +313,8 @@ export const R2_HANDLERS: ToolHandlers = {
     const { name } = request.params.arguments as { name: string }
     await handleR2CreateBucket(name)
     return {
-      toolResult: {
-        content: [{ type: 'text', text: `Successfully created bucket: ${name}` }],
-      },
+      content: [{ type: 'text', text: `Successfully created bucket: ${name}` }],
+      metadata: {}
     }
   },
 
@@ -324,9 +322,8 @@ export const R2_HANDLERS: ToolHandlers = {
     const { name } = request.params.arguments as { name: string }
     await handleR2DeleteBucket(name)
     return {
-      toolResult: {
-        content: [{ type: 'text', text: `Successfully deleted bucket: ${name}` }],
-      },
+      content: [{ type: 'text', text: `Successfully deleted bucket: ${name}` }],
+      metadata: {}
     }
   },
 
@@ -339,9 +336,8 @@ export const R2_HANDLERS: ToolHandlers = {
     }
     const results = await handleR2ListObjects(bucket, prefix, delimiter, limit)
     return {
-      toolResult: {
-        content: [{ type: 'text', text: JSON.stringify(results, null, 2) }],
-      },
+      content: [{ type: 'text', text: JSON.stringify(results, null, 2) }],
+      metadata: {}
     }
   },
 
@@ -349,9 +345,8 @@ export const R2_HANDLERS: ToolHandlers = {
     const { bucket, key } = request.params.arguments as { bucket: string; key: string }
     const content = await handleR2GetObject(bucket, key)
     return {
-      toolResult: {
-        content: [{ type: 'text', text: content }],
-      },
+      content: [{ type: 'text', text: content }],
+      metadata: {}
     }
   },
 
@@ -364,9 +359,8 @@ export const R2_HANDLERS: ToolHandlers = {
     }
     await handleR2PutObject(bucket, key, content, contentType)
     return {
-      toolResult: {
-        content: [{ type: 'text', text: `Successfully stored object: ${key}` }],
-      },
+      content: [{ type: 'text', text: `Successfully stored object: ${key}` }],
+      metadata: {}
     }
   },
 
@@ -374,9 +368,8 @@ export const R2_HANDLERS: ToolHandlers = {
     const { bucket, key } = request.params.arguments as { bucket: string; key: string }
     await handleR2DeleteObject(bucket, key)
     return {
-      toolResult: {
-        content: [{ type: 'text', text: `Successfully deleted object: ${key}` }],
-      },
+      content: [{ type: 'text', text: `Successfully deleted object: ${key}` }],
+      metadata: {}
     }
   },
 }

--- a/src/tools/workers.ts
+++ b/src/tools/workers.ts
@@ -443,14 +443,13 @@ export const WORKERS_HANDLERS: ToolHandlers = {
   worker_list: async (request) => {
     const results = await handleWorkerList()
     return {
-      toolResult: {
-        content: [
-          {
-            type: 'text',
-            text: JSON.stringify(results, null, 2),
-          },
-        ],
-      },
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(results, null, 2),
+        },
+      ],
+      metadata: {}
     }
   },
 
@@ -458,14 +457,13 @@ export const WORKERS_HANDLERS: ToolHandlers = {
     const { name } = request.params.arguments as { name: string }
     const script = await handleWorkerGet(name)
     return {
-      toolResult: {
-        content: [
-          {
-            type: 'text',
-            text: script,
-          },
-        ],
-      },
+      content: [
+        {
+          type: 'text',
+          text: script,
+        },
+      ],
+      metadata: {}
     }
   },
 
@@ -500,14 +498,13 @@ export const WORKERS_HANDLERS: ToolHandlers = {
       !no_observability,
     )
     return {
-      toolResult: {
-        content: [
-          {
-            type: 'text',
-            text: `Successfully deployed worker: ${name}`,
-          },
-        ],
-      },
+      content: [
+        {
+          type: 'text',
+          text: `Successfully deployed worker: ${name}`,
+        },
+      ],
+      metadata: {}
     }
   },
 
@@ -515,14 +512,13 @@ export const WORKERS_HANDLERS: ToolHandlers = {
     const { name } = request.params.arguments as { name: string }
     await handleWorkerDelete(name)
     return {
-      toolResult: {
-        content: [
-          {
-            type: 'text',
-            text: `Successfully deleted worker: ${name}`,
-          },
-        ],
-      },
+      content: [
+        {
+          type: 'text',
+          text: `Successfully deleted worker: ${name}`,
+        },
+      ],
+      metadata: {}
     }
   },
 }


### PR DESCRIPTION
In our current implementation (e.g. in src/tools/workers.ts), handlers return responses with content nested under a toolResult property:
`worker_list: async (request) => {
  const results = await handleWorkerList()
  return {
    toolResult: {
      content: [
        {
          type: "text",
          text: JSON.stringify(results, null, 2)
        }
      ]
    }
  }
}`

However, Cursor expects the content array directly at the top level of the response object:
`worker_list: async (request) => {
  const results = await handleWorkerList()
  return {
    content: [{ type: "text", text: JSON.stringify(results, null, 2) }],
    metadata: {}
  }
}`

This PR updates all tool handlers to use the direct content format rather than nesting it under toolResult, making the MCP server compatible with Cursor. 