### PR TITLE
Feature: add Workers Analytics Engine (WAE) support

### DIFF
--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,0 +1,37 @@
+import { Tool } from '@modelcontextprotocol/sdk/types.js'
+import { KV_TOOLS, KV_HANDLERS } from './kv'
+import { R2_TOOLS, R2_HANDLERS } from './r2'
+import { WORKER_TOOLS, WORKERS_HANDLERS } from './workers'
+import { ANALYTICS_TOOLS, ANALYTICS_HANDLERS } from './analytics'
+import { D1_TOOLS, D1_HANDLERS } from './d1'
+import { WAE_TOOLS, WAE_HANDLERS } from './wae'
+import { log } from '../utils/helpers'
+
+// Debug log all tools being registered
+log('WAE_TOOLS:', WAE_TOOLS)
+log('All tools being registered:', [
+  ...KV_TOOLS,
+  ...R2_TOOLS,
+  ...WORKER_TOOLS,
+  ...ANALYTICS_TOOLS,
+  ...D1_TOOLS,
+  ...WAE_TOOLS,
+])
+
+export const TOOLS: Tool[] = [
+  ...KV_TOOLS,
+  ...R2_TOOLS,
+  ...WORKER_TOOLS,
+  ...ANALYTICS_TOOLS,
+  ...D1_TOOLS,
+  ...WAE_TOOLS,
+]
+
+export const HANDLERS = {
+  ...KV_HANDLERS,
+  ...R2_HANDLERS,
+  ...WORKERS_HANDLERS,
+  ...ANALYTICS_HANDLERS,
+  ...D1_HANDLERS,
+  ...WAE_HANDLERS,
+} 

--- a/src/tools/wae.ts
+++ b/src/tools/wae.ts
@@ -1,0 +1,180 @@
+import { Tool } from '@modelcontextprotocol/sdk/types.js'
+import { fetch } from 'undici'
+import { config, log } from '../utils/helpers'
+import { ToolHandlers } from '../utils/types'
+import z from 'zod'
+import { CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js'
+
+const WAE_QUERY_TOOL: Tool = {
+  name: 'wae_query',
+  description: 'Query Workers Analytics Engine data using SQL',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      query: {
+        type: 'string',
+        description: 'SQL query to execute against Analytics Engine'
+      },
+      dataset: {
+        type: 'string',
+        description: 'Name of the Analytics Engine dataset'
+      }
+    },
+    required: ['query', 'dataset']
+  }
+}
+
+// Debug log when module loads
+log('Initializing WAE tools...')
+
+export const WAE_TOOLS: Tool[] = [
+  WAE_QUERY_TOOL
+]
+
+log('WAE_TOOLS initialized:', WAE_TOOLS)
+
+interface WAEColumn {
+  name: string
+  type: string
+}
+
+interface WAEResponse {
+  meta: WAEColumn[]
+  data: Record<string, any>[]
+  rows: number
+  rows_before_limit_at_least: number
+  error?: string
+}
+
+async function queryWAE(dataset: string, query: string) {
+  if (!config.accountId || !config.apiToken) {
+    throw new Error('Missing required Cloudflare credentials')
+  }
+
+  const url = `https://api.cloudflare.com/client/v4/accounts/${config.accountId}/analytics_engine/sql`
+  
+  log('Querying Workers Analytics Engine:', { dataset, query, url })
+
+  try {
+    // Format query to use the dataset if not already specified
+    const fullQuery = query.toLowerCase().includes('from') ? 
+      query : 
+      `${query} FROM ${dataset}`
+    
+    log('Final query:', fullQuery)
+
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${config.apiToken}`,
+        'Content-Type': 'text/plain'
+      },
+      body: fullQuery
+    })
+
+    log('Response status:', response.status)
+
+    if (!response.ok) {
+      const text = await response.text()
+      throw new Error(`HTTP ${response.status}: ${text}`)
+    }
+
+    const text = await response.text()
+    log('Raw WAE response:', text)
+
+    try {
+      // Parse the response, handling the formatted JSON
+      const rawData = JSON.parse(text)
+      
+      // Validate response structure
+      if (!rawData.meta || !Array.isArray(rawData.meta)) {
+        throw new Error('Invalid response format: missing or invalid meta field')
+      }
+
+      if (rawData.error) {
+        throw new Error(rawData.error)
+      }
+
+      // Ensure data is an array
+      if (!Array.isArray(rawData.data)) {
+        throw new Error('Invalid response format: data field is not an array')
+      }
+
+      // Convert array data to object format if needed
+      const formattedData = rawData.data.map((row: any) => {
+        if (typeof row === 'object' && !Array.isArray(row)) {
+          return row
+        }
+        // If row is an array, convert it to object using meta columns
+        const formattedRow: Record<string, any> = {}
+        rawData.meta.forEach((col: WAEColumn, index: number) => {
+          formattedRow[col.name] = row[index]
+        })
+        return formattedRow
+      })
+
+      const result: WAEResponse = {
+        meta: rawData.meta,
+        data: formattedData,
+        rows: rawData.rows || formattedData.length,
+        rows_before_limit_at_least: rawData.rows_before_limit_at_least || formattedData.length
+      }
+
+      return result
+    } catch (parseError) {
+      log('Parse error:', parseError)
+      if (parseError instanceof Error) {
+        log('Parse error stack:', parseError.stack)
+      }
+      throw new Error('Failed to parse Analytics Engine response')
+    }
+  } catch (error) {
+    log('WAE query error:', error)
+    if (error instanceof Error) {
+      log('Error stack:', error.stack)
+    }
+    throw error
+  }
+}
+
+export const WAE_HANDLERS: ToolHandlers = {
+  wae_query: async (request: z.infer<typeof CallToolRequestSchema>) => {
+    const { query, dataset } = request.params.arguments as {
+      query: string
+      dataset: string
+    }
+
+    try {
+      const result = await queryWAE(dataset, query)
+      return {
+        content: [{
+          type: 'text',
+          text: JSON.stringify({
+            meta: result.meta,
+            data: result.data,
+            totalRows: result.rows,
+            totalRowsBeforeLimit: result.rows_before_limit_at_least
+          }, null, 2)
+        }],
+        metadata: { 
+          success: true,
+          rowCount: result.rows,
+          totalRowCount: result.rows_before_limit_at_least
+        }
+      }
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error'
+      log('Error in WAE handler:', errorMessage)
+      return {
+        content: [{
+          type: 'text',
+          text: `Error querying WAE: ${errorMessage}`
+        }],
+        metadata: { 
+          success: false, 
+          error: errorMessage
+        }
+      }
+    }
+  }
+} 


### PR DESCRIPTION
This PR adds support for Workers Analytics Engine (WAE) queries to the MCP server. It includes a new `wae.ts` file implementing the tool. 

This allows you to do the following from Claude, Cursor, or other MCP Clients:
- Query your Workers Analytics Engine datasets using SQL directly
- Track usage patterns and event frequencies
- Monitor Worker behavior over time
- Get insights from your analytics data without leaving your development environment