### PR TITLE
Add initial mocks for Cloudflare api client

### DIFF
--- a/packages/mcp-common/src/utils/cloudflare-mock.ts
+++ b/packages/mcp-common/src/utils/cloudflare-mock.ts
@@ -1,0 +1,24 @@
+import { vi } from 'vitest'
+
+import type { Account } from 'cloudflare/resources/accounts/accounts.mjs'
+
+/**
+ * Creates a mocked implementation of the Cloudflare client
+ */
+export const cloudflareClientMockImplementation = () => {
+	return {
+		accounts: {
+			list: vi.fn(async () => {
+				return {
+					success: true,
+					result: [
+						{
+							id: 'mock-account-id',
+							name: 'mock-account-name',
+						},
+					] satisfies Account[],
+				}
+			}),
+		},
+	}
+}

--- a/packages/mcp-common/tests/logs.spec.ts
+++ b/packages/mcp-common/tests/logs.spec.ts
@@ -1,9 +1,17 @@
 import { env, fetchMock } from 'cloudflare:test'
-import { afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 
 import { handleWorkerLogs, handleWorkerLogsKeys } from '../src/api/logs'
+import { cloudflareClientMockImplementation } from '../src/utils/cloudflare-mock'
 
 beforeAll(() => {
+	vi.mock('cloudflare', () => {
+		return {
+			Cloudflare: vi.fn().mockImplementation(() => {
+				return cloudflareClientMockImplementation()
+			}),
+		}
+	})
 	// Enable outbound request mocking...
 	fetchMock.activate()
 	// ...and throw errors if an outbound request isn't mocked


### PR DESCRIPTION
Mocks the Cloudflare API client using vitest mock implementation.

We can't use fetchMock due to api client not working in vitest, but this should be a good enough way to mock things for our purposes.

We just need to remember to add whatever methods we're testing to this mockImplementation