### PR TITLE
fix: set account id issue and add debugger config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,15 +1,15 @@
 {
-  "configurations": [
-    {
-      "name": "Wrangler",
-      "type": "node",
-      "request": "attach",
-      "port": 9229,
-      "cwd": "/",
-      "resolveSourceMapLocations": null,
-      "attachExistingChildren": false,
-      "autoAttachChildProcesses": false,
-      "sourceMaps": true // works with or without this line
-    }
-  ]
+	"configurations": [
+		{
+			"name": "Wrangler",
+			"type": "node",
+			"request": "attach",
+			"port": 9229,
+			"cwd": "/",
+			"resolveSourceMapLocations": null,
+			"attachExistingChildren": false,
+			"autoAttachChildProcesses": false,
+			"sourceMaps": true // works with or without this line
+		}
+	]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+  "configurations": [
+    {
+      "name": "Wrangler",
+      "type": "node",
+      "request": "attach",
+      "port": 9229,
+      "cwd": "/",
+      "resolveSourceMapLocations": null,
+      "attachExistingChildren": false,
+      "autoAttachChildProcesses": false,
+      "sourceMaps": true // works with or without this line
+    }
+  ]
+}

--- a/apps/workers-bindings/src/index.ts
+++ b/apps/workers-bindings/src/index.ts
@@ -31,10 +31,6 @@ export class WorkersBindingsMCP extends McpAgent<Env, WorkersBindingsMCPState, P
 		version: '1.0.0',
 	})
 
-	initialState: WorkersBindingsMCPState = {
-		activeAccountId: null,
-	}
-
 	async init() {
 		registerAccountTools(this)
 		registerKVTools(this)

--- a/apps/workers-observability/src/index.ts
+++ b/apps/workers-observability/src/index.ts
@@ -30,10 +30,6 @@ export class ObservabilityMCP extends McpAgent<Env, State, Props> {
 		version: '1.0.0',
 	})
 
-	initialState: State = {
-		activeAccountId: null,
-	}
-
 	async init() {
 		registerAccountTools(this)
 


### PR DESCRIPTION
This PR fixes an issue where we were having to set the active account id twice when the MCP Server. The reason the bug was happening is as follows

Here's the flow:
1. Define an McpAgent with an initialState property [like so](https://github.com/cloudflare/mcp-server-cloudflare/blob/main/apps/workers-bindings/src/index.ts#L34-L36)
2. Call the [setActiveAccountId tool](https://github.com/cloudflare/mcp-server-cloudflare/blob/main/packages/mcp-common/src/tools/account.ts#L65)
3. Spread this.state into the [setState call](https://github.com/cloudflare/mcp-server-cloudflare/blob/main/apps/workers-bindings/src/index.ts#L58)
4. this.state calls the getter which passes through to [this.#agent.state getter](https://github.com/cloudflare/agents/blob/main/packages/agents/src/mcp/index.ts#L226)
5. Since we overrode the state, the getter [drops through to this.setState](https://github.com/cloudflare/agents/blob/main/packages/agents/src/index.ts#L225) in the Agent class
6. Then we end up in [this.broadcast](https://github.com/cloudflare/agents/blob/main/packages/agents/src/index.ts#L403-L409)
7. Now we're in PartyServer at this method
```
/** Send a message to all connected clients, except connection ids listed in `without` */
  broadcast(
    msg: string | ArrayBuffer | ArrayBufferView,
    without?: string[] | undefined
  ): void {
    for (const connection of this.#connectionManager.getConnections()) {
      if (!without || !without.includes([connection.id](http://connection.id/))) {
        this.#sendMessageToConnection(connection, msg);
      }
    }
  }
```

```
The `[connection.id](http://connection.id/)` getter fails with this error Uncaught TypeError TypeError: Cannot read properties of null (reading '__pk')
    at get (/Users/delorey/code/mcp-server-cloudflare/node_modules/.pnpm/partyserver@0.0.66_@cloudflare+workers-types@4.20250410.0/node_modules/partyserver/src/connection.ts:100:34)
    at eval (repl:1:12)
```

Removing the `initialState` property from the McpAgent solves the problem because we return before the `this.setState` [here](https://github.com/cloudflare/agents/blob/main/packages/agents/src/index.ts#L221).

**The PR also adds a launch.json with a config to attach a debugger to assist in future MCP Server debugging.**