### PR TITLE
Update container server Dockerfile to work with monorepo

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+**/node_modules/
+**/.gitignore
+**/README.md
+**/.vscode/
+**/Dockerfile
+**/out/

--- a/apps/sandbox-container/Dockerfile
+++ b/apps/sandbox-container/Dockerfile
@@ -1,15 +1,21 @@
-# Use an official Ubuntu as a base image
-FROM ubuntu:20.04
+###
+# STAGE: BASE
+###
+FROM node:22 AS base
 
 # Set non-interactive mode to avoid prompts during package installation
 ARG DEBIAN_FRONTEND=noninteractive
+
+# Setup pnpm
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN corepack enable
 
 # Use bash for the shell
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Update and install useful CLI utilities
-RUN apt-get update && apt-get install -y \
-    curl \
+RUN apt-get update && apt-get install -y curl ca-certificates \
     git \
     htop \
     vim \
@@ -18,42 +24,35 @@ RUN apt-get update && apt-get install -y \
     build-essential \
     nmap \
     sudo \
-    ca-certificates \
     lsb-release \
-    nodejs \
-    npm \
     python3 \
     python3-pip \
+    python3-matplotlib \
+    python3-numpy \
+    python3-pandas \
     && apt-get clean
 
-RUN pip3 install matplotlib numpy pandas
-
-# Install Node.js and Corepack
-RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
-    && apt-get install -y nodejs \
-    && corepack enable
-
-# ENV NODE_VERSION 22.14.0
-
-# Download and install nvm
-# RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.2/install.sh | PROFILE="${BASH_ENV}" bash
-# RUN echo node > .nvmrc
-# RUN nvm install $NODE_VERSION
-# RUN nvm use $NODE_VERSION
-
-# Set working directory
+###
+# STAGE: PRUNE -  Generate a partial monorepo for the sandbox-container app. The output will be placed into a directory named "out"
+###
+FROM base AS prune
 WORKDIR /app
+RUN pnpm install turbo --global
+COPY . .
+RUN turbo prune containers-starter
+
+###
+# STAGE: INSTALL & RUN
+###
+FROM base AS installer
+WORKDIR /app
+
+COPY --from=prune /app/out/ .
+RUN pnpm install --frozen-lockfile 
+
+WORKDIR /app/apps/sandbox-container
 
 # Expose the port your Node.js server will run on
 EXPOSE 8080
 
-COPY . ./
-
-RUN npm i
-
-# add node and npm to path so the commands are available
-# ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-# ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
-
-# Default command (run your Node.js server here)
-CMD ["npm", "run", "start:container"]
+CMD ["pnpm", "run", "start:container"]

--- a/apps/sandbox-container/package.json
+++ b/apps/sandbox-container/package.json
@@ -7,7 +7,7 @@
 		"check:types": "run-tsc",
 		"deploy": "wrangler deploy",
 		"dev": "concurrently \"tsx container/index.ts\" \"wrangler dev --var \"ENVIRONMENT:dev\"\"",
-		"build": "docker build .",
+		"build": "docker build -f Dockerfile ../../",
 		"start": "wrangler dev",
 		"start:container": "tsx container/index.ts",
 		"postinstall": "mkdir -p workdir",


### PR DESCRIPTION
Updated the original Dockerfile for the container MCP server to work with the new monorepo setup
1. Base off a node image rather than ubuntu to simplify node installation side effects
2. Swap npm to pnpm
3. Separate the installation of ca-certificates from the other packages, because for whatever reason that seemed to get it to stop erroring on installation
4. Install all python libraries as apt packages to avoid error
5. Add turbo pruning to keep the lock file limited to only the needed packages for running the sandbox container 
6. Adjust build command to incorporate other needed files in the monorepo