### PR TITLE
Persist activeAccountId in UserDetails DO so we can persist activeAccountId selection across sessions

### DIFF
--- a/apps/docs-autorag/src/context.ts
+++ b/apps/docs-autorag/src/context.ts
@@ -3,8 +3,8 @@ import type { CloudflareDocumentationMCP } from './index'
 export interface Env {
 	ENVIRONMENT: 'development' | 'staging' | 'production'
 	AUTORAG_NAME: 'cloudflare-docs-autorag'
-	MCP_SERVER_NAME: 'PLACEHOLDER'
-	MCP_SERVER_VERSION: 'PLACEHOLDER'
+	MCP_SERVER_NAME: string
+	MCP_SERVER_VERSION: string
 	MCP_OBJECT: DurableObjectNamespace<CloudflareDocumentationMCP>
 	MCP_METRICS: AnalyticsEngineDataset
 	AI: Ai

--- a/apps/sandbox-container/server/context.ts
+++ b/apps/sandbox-container/server/context.ts
@@ -2,11 +2,11 @@ import type { ContainerManager, ContainerMcpAgent } from './index'
 
 export interface Env {
 	OAUTH_KV: KVNamespace
-	CLOUDFLARE_CLIENT_ID: '<PLACEHOLDER>'
-	CLOUDFLARE_CLIENT_SECRET: '<PLACEHOLDER>'
+	CLOUDFLARE_CLIENT_ID: string
+	CLOUDFLARE_CLIENT_SECRET: string
 	ENVIRONMENT: 'dev'
-	MCP_SERVER_NAME: '<PLACEHOLDER>'
-	MCP_SERVER_VERSION: '<PLACEHOLDER>'
+	MCP_SERVER_NAME: string
+	MCP_SERVER_VERSION: string
 	OPENAI_API_KEY: string
 	CONTAINER_MCP_AGENT: DurableObjectNamespace<ContainerMcpAgent>
 	CONTAINER_MANAGER: DurableObjectNamespace<ContainerManager>

--- a/apps/sandbox-container/server/index.ts
+++ b/apps/sandbox-container/server/index.ts
@@ -5,6 +5,7 @@ import {
 	handleTokenExchangeCallback,
 } from '@repo/mcp-common/src/cloudflare-oauth-handler'
 import { getEnv } from '@repo/mcp-common/src/env'
+import { RequiredScopes } from '@repo/mcp-common/src/scopes'
 import { MetricsTracker } from '@repo/mcp-observability'
 
 import { ContainerManager } from './containerManager'
@@ -32,12 +33,10 @@ export type Props = {
 }
 
 const ContainerScopes = {
+	...RequiredScopes,
 	'account:read': 'See your account info such as account details, analytics, and memberships.',
-	'user:read': 'See your user info such as name, email address, and account memberships.',
 	'workers:write':
 		'See and change Cloudflare Workers data such as zones, KV storage, namespaces, scripts, and routes.',
-	'workers_observability:read': 'See observability logs for your account',
-	offline_access: 'Grants refresh tokens for long-lived access.',
 } as const
 
 export default {
@@ -61,7 +60,6 @@ export default {
 
 		return new OAuthProvider({
 			apiRoute: '/sse',
-			// @ts-ignore
 			apiHandler: ContainerMcpAgent.mount('/sse', { binding: 'CONTAINER_MCP_AGENT' }),
 			// @ts-ignore
 			defaultHandler: createAuthHandlers({ scopes: ContainerScopes, metrics }),

--- a/apps/workers-bindings/src/context.ts
+++ b/apps/workers-bindings/src/context.ts
@@ -1,12 +1,14 @@
+import type { UserDetails } from '@repo/mcp-common/src/durable-objects/user_details'
 import type { WorkersBindingsMCP } from './index'
 
 export interface Env {
 	OAUTH_KV: KVNamespace
 	ENVIRONMENT: 'development' | 'staging' | 'production'
-	MCP_SERVER_NAME: '<PLACEHOLDER>'
-	MCP_SERVER_VERSION: '<PLACEHOLDER>'
-	CLOUDFLARE_CLIENT_ID: '<PLACEHOLDER>'
-	CLOUDFLARE_CLIENT_SECRET: '<PLACEHOLDER>'
+	MCP_SERVER_NAME: string
+	MCP_SERVER_VERSION: string
+	CLOUDFLARE_CLIENT_ID: string
+	CLOUDFLARE_CLIENT_SECRET: string
 	MCP_OBJECT: DurableObjectNamespace<WorkersBindingsMCP>
+	USER_DETAILS: DurableObjectNamespace<UserDetails>
 	MCP_METRICS: AnalyticsEngineDataset
 }

--- a/apps/workers-bindings/src/index.ts
+++ b/apps/workers-bindings/src/index.ts
@@ -6,6 +6,7 @@ import {
 	handleTokenExchangeCallback,
 } from '@repo/mcp-common/src/cloudflare-oauth-handler'
 import { getEnv } from '@repo/mcp-common/src/env'
+import { RequiredScopes } from '@repo/mcp-common/src/scopes'
 import { CloudflareMCPServer } from '@repo/mcp-common/src/server'
 import { registerAccountTools } from '@repo/mcp-common/src/tools/account'
 import { registerD1Tools } from '@repo/mcp-common/src/tools/d1'
@@ -95,19 +96,16 @@ export class WorkersBindingsMCP extends McpAgent<Env, WorkersBindingsMCPState, P
 }
 
 const BindingsScopes = {
+	...RequiredScopes,
 	'account:read': 'See your account info such as account details, analytics, and memberships.',
-	'user:read': 'See your user info such as name, email address, and account memberships.',
 	'workers:write':
 		'See and change Cloudflare Workers data such as zones, KV storage, namespaces, scripts, and routes.',
-	'workers_observability:read': 'See observability logs for your account',
 	'd1:write': 'Create, read, and write to D1 databases',
-	offline_access: 'Grants refresh tokens for long-lived access.',
 } as const
 
 // Export the OAuth handler as the default
 export default new OAuthProvider({
 	apiRoute: '/sse',
-	// @ts-ignore
 	apiHandler: WorkersBindingsMCP.mount('/sse'),
 	// @ts-ignore
 	defaultHandler: createAuthHandlers({ scopes: BindingsScopes, metrics }),

--- a/apps/workers-bindings/wrangler.jsonc
+++ b/apps/workers-bindings/wrangler.jsonc
@@ -19,6 +19,10 @@
 			{
 				"class_name": "WorkersBindingsMCP",
 				"name": "MCP_OBJECT"
+			},
+			{
+				"class_name": "UserDetails",
+				"name": "USER_DETAILS"
 			}
 		]
 	},
@@ -59,6 +63,11 @@
 					{
 						"class_name": "WorkersBindingsMCP",
 						"name": "MCP_OBJECT"
+					},
+					{
+						"class_name": "UserDetails",
+						"name": "USER_DETAILS",
+						"script_name": "mcp-cloudflare-workers-observability-staging"
 					}
 				]
 			},
@@ -69,7 +78,9 @@
 				}
 			],
 			"vars": {
-				"ENVIRONMENT": "staging"
+				"ENVIRONMENT": "staging",
+				"MCP_SERVER_NAME": "workers-bindings-staging",
+				"MCP_SERVER_VERSION": "1.0.0"
 			},
 			"analytics_engine_datasets": [
 				{
@@ -87,6 +98,11 @@
 					{
 						"class_name": "WorkersBindingsMCP",
 						"name": "MCP_OBJECT"
+					},
+					{
+						"class_name": "UserDetails",
+						"name": "USER_DETAILS",
+						"script_name": "mcp-cloudflare-workers-observability-production"
 					}
 				]
 			},
@@ -97,7 +113,9 @@
 				}
 			],
 			"vars": {
-				"ENVIRONMENT": "production"
+				"ENVIRONMENT": "production",
+				"MCP_SERVER_NAME": "workers-bindings",
+				"MCP_SERVER_VERSION": "1.0.0"
 			},
 			"analytics_engine_datasets": [
 				{

--- a/apps/workers-observability/src/context.ts
+++ b/apps/workers-observability/src/context.ts
@@ -1,16 +1,18 @@
+import type { UserDetails } from '@repo/mcp-common/src/durable-objects/user_details'
 import type { ObservabilityMCP } from './index'
 
 export interface Env {
 	OAUTH_KV: KVNamespace
 	ENVIRONMENT: 'development' | 'staging' | 'production'
-	MCP_SERVER_NAME: 'PLACEHOLDER'
-	MCP_SERVER_VERSION: 'PLACEHOLDER'
-	CLOUDFLARE_CLIENT_ID: 'PLACEHOLDER'
-	CLOUDFLARE_CLIENT_SECRET: 'PLACEHOLDER'
+	MCP_SERVER_NAME: string
+	MCP_SERVER_VERSION: string
+	CLOUDFLARE_CLIENT_ID: string
+	CLOUDFLARE_CLIENT_SECRET: string
 	MCP_OBJECT: DurableObjectNamespace<ObservabilityMCP>
+	USER_DETAILS: DurableObjectNamespace<UserDetails>
 	MCP_METRICS: AnalyticsEngineDataset
-	SENTRY_ACCESS_CLIENT_ID: 'PLACEHOLDER'
-	SENTRY_ACCESS_CLIENT_SECRET: 'PLACEHOLDER'
-	GIT_HASH: 'OVERRIDEN_DURING_DEPLOYMENT'
-	SENTRY_DSN: 'PLACEHOLDER'
+	SENTRY_ACCESS_CLIENT_ID: string
+	SENTRY_ACCESS_CLIENT_SECRET: string
+	GIT_HASH: string
+	SENTRY_DSN: string
 }

--- a/apps/workers-observability/src/index.ts
+++ b/apps/workers-observability/src/index.ts
@@ -6,6 +6,7 @@ import {
 	handleTokenExchangeCallback,
 } from '@repo/mcp-common/src/cloudflare-oauth-handler'
 import { getEnv } from '@repo/mcp-common/src/env'
+import { RequiredScopes } from '@repo/mcp-common/src/scopes'
 import { initSentryWithUser } from '@repo/mcp-common/src/sentry'
 import { CloudflareMCPServer } from '@repo/mcp-common/src/server'
 import { registerAccountTools } from '@repo/mcp-common/src/tools/account'
@@ -96,17 +97,15 @@ export class ObservabilityMCP extends McpAgent<Env, State, Props> {
 }
 
 const ObservabilityScopes = {
+	...RequiredScopes,
 	'account:read': 'See your account info such as account details, analytics, and memberships.',
-	'user:read': 'See your user info such as name, email address, and account memberships.',
 	'workers:write':
 		'See and change Cloudflare Workers data such as zones, KV storage, namespaces, scripts, and routes.',
 	'workers_observability:read': 'See observability logs for your account',
-	offline_access: 'Grants refresh tokens for long-lived access.',
 } as const
 
 export default new OAuthProvider({
 	apiRoute: '/sse',
-	// @ts-ignore
 	apiHandler: ObservabilityMCP.mount('/sse'),
 	// @ts-ignore
 	defaultHandler: createAuthHandlers({ scopes: ObservabilityScopes, metrics }),

--- a/apps/workers-observability/src/index.ts
+++ b/apps/workers-observability/src/index.ts
@@ -5,6 +5,7 @@ import {
 	createAuthHandlers,
 	handleTokenExchangeCallback,
 } from '@repo/mcp-common/src/cloudflare-oauth-handler'
+import { getUserDetails, UserDetails } from '@repo/mcp-common/src/durable-objects/user_details'
 import { getEnv } from '@repo/mcp-common/src/env'
 import { RequiredScopes } from '@repo/mcp-common/src/scopes'
 import { initSentryWithUser } from '@repo/mcp-common/src/sentry'
@@ -17,6 +18,8 @@ import { registerLogsTools } from './tools/logs'
 
 import type { AccountSchema, UserSchema } from '@repo/mcp-common/src/cloudflare-oauth-handler'
 import type { Env } from './context'
+
+export { UserDetails }
 
 const env = getEnv<Env>()
 
@@ -72,26 +75,24 @@ export class ObservabilityMCP extends McpAgent<Env, State, Props> {
 		registerLogsTools(this)
 	}
 
-	getActiveAccountId() {
-		// TODO: Figure out why this fail sometimes, and why we need to wrap this in a try catch
+	async getActiveAccountId() {
 		try {
-			return this.state.activeAccountId ?? null
+			// Get UserDetails Durable Object based off the userId and retrieve the activeAccountId from it
+			// we do this so we can persist activeAccountId across sessions
+			const userDetails = getUserDetails(env, this.props.user.id)
+			return await userDetails.getActiveAccountId()
 		} catch (e) {
 			this.server.recordError(e)
 			return null
 		}
 	}
 
-	setActiveAccountId(accountId: string) {
-		// TODO: Figure out why this fail sometimes, and why we need to wrap this in a try catch
+	async setActiveAccountId(accountId: string) {
 		try {
-			this.setState({
-				...this.state,
-				activeAccountId: accountId,
-			})
+			const userDetails = getUserDetails(env, this.props.user.id)
+			await userDetails.setActiveAccountId(accountId)
 		} catch (e) {
 			this.server.recordError(e)
-			return null
 		}
 	}
 }

--- a/apps/workers-observability/src/tools/logs.ts
+++ b/apps/workers-observability/src/tools/logs.ts
@@ -123,7 +123,7 @@ export function registerLogsTools(agent: ObservabilityMCP) {
 			rayId: rayIdParam,
 		},
 		async (params) => {
-			const accountId = agent.getActiveAccountId()
+			const accountId = await agent.getActiveAccountId()
 			if (!accountId) {
 				return {
 					content: [
@@ -188,7 +188,7 @@ export function registerLogsTools(agent: ObservabilityMCP) {
 			minutesAgoParam,
 		},
 		async (params) => {
-			const accountId = agent.getActiveAccountId()
+			const accountId = await agent.getActiveAccountId()
 			if (!accountId) {
 				return {
 					content: [
@@ -248,7 +248,7 @@ export function registerLogsTools(agent: ObservabilityMCP) {
 		'Get available telemetry keys for a Cloudflare Worker',
 		{ scriptName: workerNameParam, minutesAgoParam },
 		async (params) => {
-			const accountId = agent.getActiveAccountId()
+			const accountId = await agent.getActiveAccountId()
 			if (!accountId) {
 				return {
 					content: [

--- a/apps/workers-observability/wrangler.jsonc
+++ b/apps/workers-observability/wrangler.jsonc
@@ -10,7 +10,7 @@
 	"name": "mcp-cloudflare-workers-observability-dev",
 	"migrations": [
 		{
-			"new_sqlite_classes": ["ObservabilityMCP"],
+			"new_sqlite_classes": ["UserDetails", "ObservabilityMCP"],
 			"tag": "v1"
 		}
 	],
@@ -22,6 +22,10 @@
 			{
 				"class_name": "ObservabilityMCP",
 				"name": "MCP_OBJECT"
+			},
+			{
+				"class_name": "UserDetails",
+				"name": "USER_DETAILS"
 			}
 		]
 	},
@@ -59,6 +63,10 @@
 					{
 						"class_name": "ObservabilityMCP",
 						"name": "MCP_OBJECT"
+					},
+					{
+						"class_name": "UserDetails",
+						"name": "USER_DETAILS"
 					}
 				]
 			},
@@ -72,7 +80,7 @@
 				"ENVIRONMENT": "staging",
 				"GIT_HASH": "OVERRIDEN_DURING_DEPLOYMENT",
 				"SENTRY_DSN": "https://033e673c1b004626609d9a68a8b86b56@sentry10.cfdata.org/1764",
-				"MCP_SERVER_NAME": "workers-staging-observability",
+				"MCP_SERVER_NAME": "workers-observability-staging",
 				"MCP_SERVER_VERSION": "1.0.0"
 			},
 			"analytics_engine_datasets": [
@@ -91,6 +99,10 @@
 					{
 						"class_name": "ObservabilityMCP",
 						"name": "MCP_OBJECT"
+					},
+					{
+						"class_name": "UserDetails",
+						"name": "USER_DETAILS"
 					}
 				]
 			},

--- a/packages/mcp-common/src/durable-kv-store.ts
+++ b/packages/mcp-common/src/durable-kv-store.ts
@@ -1,0 +1,112 @@
+import type { ZodSchema } from 'zod'
+
+export type DurableKVStorageKeys = { [key: string]: ZodSchema }
+
+/**
+ * DurableKVStore is a type-safe key/value store backed by Durable Object storage.
+ *
+ * @example
+ *
+ * ```ts
+ * export class MyDurableObject extends DurableObject<Bindings> {
+ * 	readonly kv
+ * 	constructor(
+ * 		readonly state: DurableObjectState,
+ * 		env: Bindings
+ * 	) {
+ * 		super(state, env)
+ * 		this.kv = new DurableKVStore({
+ * 			state,
+ * 			prefix: 'meta',
+ * 			keys: {
+ * 				// Each key has a matching Zod schema enforcing what's stored
+ * 				date_key: z.coerce.date(),
+ * 				// While empty keys will always return null, adding
+ * 				// `nullable()` allows us to explicitly set it to null
+ * 				string_key: z.string().nullable(),
+ * 				number_key: z.number(),
+ * 			} as const satisfies StorageKeys,
+ * 		})
+ * 	}
+ *
+ * 	async example(): Promise<void> {
+ * 		await this.kv.get('number_key') // -> null
+ * 		this.kv.put('number_key', 5)
+ * 		await this.kv.get('number_key') // -> 5
+ * 	}
+ * }
+ *	```
+ */
+export class DurableKVStore<T extends DurableKVStorageKeys> {
+	private readonly prefix: string
+	private readonly keys: T
+	private readonly state: DurableObjectState
+
+	constructor({ state, prefix, keys }: { state: DurableObjectState; prefix: string; keys: T }) {
+		this.state = state
+		this.prefix = prefix
+		this.keys = keys
+	}
+
+	/** Add the prefix to a key (used for get/put operations) */
+	private addPrefix<K extends keyof T>(key: K): string {
+		if (this.prefix.length > 0) {
+			return `${this.prefix}/${key.toString()}`
+		}
+		return key.toString()
+	}
+
+	/**
+	 * Get a value from KV storage. Returns `null` if the value
+	 * is not set (or if it's explicitly set to `null`)
+	 */
+	async get<K extends keyof T>(key: K): Promise<T[K]['_output'] | null>
+	/**
+	 * Get a value from KV storage or return the provided
+	 * default if they value in storage is unset (undefined).
+	 * The default value must match the schema for the given key.
+	 *
+	 * If defaultValue is explicitly set to undefined, it will still return null (avoid this).
+	 *
+	 * If the value in storage is null then this will return null instead of the default.
+	 */
+	async get<K extends keyof T>(key: K, defaultValue: T[K]['_output']): Promise<T[K]['_output']>
+	async get<K extends keyof T>(
+		key: K,
+		defaultValue?: T[K]['_output']
+	): Promise<T[K]['_output'] | null> {
+		const schema = this.keys[key]
+		if (schema === undefined) {
+			throw new TypeError(`key ${key.toString()} has no matching schema`)
+		}
+
+		const res = await this.state.storage.get(this.addPrefix(key))
+		if (res === undefined) {
+			if (defaultValue !== undefined) {
+				return schema.parse(defaultValue)
+			}
+			return null
+		}
+
+		return schema.parse(res)
+	}
+
+	/** Write value to KV storage */
+	put<K extends keyof T>(key: K, value: T[K]['_input']): void {
+		const schema = this.keys[key]
+		if (schema === undefined) {
+			throw new TypeError(`key ${key.toString()} has no matching schema`)
+		}
+		const parsedValue = schema.parse(value)
+		void this.state.storage.put(this.addPrefix(key), parsedValue)
+	}
+
+	/**
+	 * Delete value in KV storage. **Does not need to be awaited**
+	 *
+	 * @returns `true` if a value was deleted, or `false` if it did not.
+	 */
+	async delete<K extends keyof T>(key: K): Promise<boolean> {
+		return this.state.storage.delete(this.addPrefix(key))
+	}
+}

--- a/packages/mcp-common/src/durable-objects/user_details.ts
+++ b/packages/mcp-common/src/durable-objects/user_details.ts
@@ -1,0 +1,45 @@
+import { DurableObject } from 'cloudflare:workers'
+import { z } from 'zod'
+
+import { DurableKVStore } from '../durable-kv-store'
+
+import type { DurableKVStorageKeys } from '../durable-kv-store'
+
+// Durable Object for persisting UserDetails in DO storage across sessions based off the userId
+export class UserDetails extends DurableObject {
+	private readonly kv: DurableKVStore<UserDetailsKeys>
+	constructor(state: DurableObjectState, env: unknown) {
+		super(state, env)
+		this.env = env
+		this.kv = new DurableKVStore({
+			state,
+			prefix: 'meta',
+			keys: UserDetailsKeys,
+		})
+	}
+
+	public async getActiveAccountId() {
+		return await this.kv.get('active_account_id')
+	}
+
+	public async setActiveAccountId(activeAccountId: string) {
+		this.kv.put('active_account_id', activeAccountId)
+	}
+}
+
+/**
+ * Storage keys used by UserDetails
+ */
+type UserDetailsKeys = typeof UserDetailsKeys
+const UserDetailsKeys = {
+	active_account_id: z.string(),
+} as const satisfies DurableKVStorageKeys
+
+/** Get the UserDetails instance */
+export function getUserDetails(
+	env: { USER_DETAILS: DurableObjectNamespace<UserDetails> },
+	user_id: string
+): DurableObjectStub<UserDetails> {
+	const id = env.USER_DETAILS.idFromName(user_id)
+	return env.USER_DETAILS.get(id)
+}

--- a/packages/mcp-common/src/env.ts
+++ b/packages/mcp-common/src/env.ts
@@ -1,6 +1,6 @@
 import { env } from 'cloudflare:workers'
 
 // Helper to cast env as any generic Env type
-export function getEnv<T>() {
-	return env as T
+export function getEnv<Env>() {
+	return env as Env
 }

--- a/packages/mcp-common/src/scopes.ts
+++ b/packages/mcp-common/src/scopes.ts
@@ -1,0 +1,5 @@
+// These scopes are required for Cloudflare auth
+export const RequiredScopes = {
+	'user:read': 'See your user info such as name, email address, and account memberships.',
+	offline_access: 'Grants refresh tokens for long-lived access.',
+} as const

--- a/packages/mcp-common/src/sentry.ts
+++ b/packages/mcp-common/src/sentry.ts
@@ -76,7 +76,7 @@ function initSentry<T extends BaseBindings>(
 				'content-type',
 				'host',
 			],
-			// Allow ONLY the “scope” param in order to recording jwt, code, state and any other callback params
+			// Allow ONLY the “scope” param in order to avoid recording jwt, code, state and any other callback params
 			allowedSearchParams: /^scope$/,
 		},
 		integrations: [

--- a/packages/mcp-common/src/tools/account.ts
+++ b/packages/mcp-common/src/tools/account.ts
@@ -58,7 +58,7 @@ export function registerAccountTools(agent: CloudflareMcpAgent) {
 		async (params) => {
 			try {
 				const { activeAccountIdParam: activeAccountId } = params
-				agent.setActiveAccountId(activeAccountId)
+				await agent.setActiveAccountId(activeAccountId)
 				return {
 					content: [
 						{

--- a/packages/mcp-common/src/tools/d1.ts
+++ b/packages/mcp-common/src/tools/d1.ts
@@ -21,7 +21,7 @@ export function registerD1Tools(agent: CloudflareMcpAgent) {
 			per_page: PaginationPerPageParam,
 		},
 		async ({ name, page, per_page }) => {
-			const account_id = agent.getActiveAccountId()
+			const account_id = await agent.getActiveAccountId()
 			if (!account_id) {
 				return MISSING_ACCOUNT_ID_RESPONSE
 			}
@@ -66,7 +66,7 @@ export function registerD1Tools(agent: CloudflareMcpAgent) {
 			primary_location_hint: D1DatabasePrimaryLocationHintParam.nullable().optional(),
 		},
 		async ({ name, primary_location_hint }) => {
-			const account_id = agent.getActiveAccountId()
+			const account_id = await agent.getActiveAccountId()
 			if (!account_id) {
 				return MISSING_ACCOUNT_ID_RESPONSE
 			}
@@ -104,7 +104,7 @@ export function registerD1Tools(agent: CloudflareMcpAgent) {
 		'Delete a d1 database in your Cloudflare account',
 		{ database_id: z.string() },
 		async ({ database_id }) => {
-			const account_id = agent.getActiveAccountId()
+			const account_id = await agent.getActiveAccountId()
 			if (!account_id) {
 				return MISSING_ACCOUNT_ID_RESPONSE
 			}
@@ -139,7 +139,7 @@ export function registerD1Tools(agent: CloudflareMcpAgent) {
 		'Get a D1 database in your Cloudflare account',
 		{ database_id: z.string() },
 		async ({ database_id }) => {
-			const account_id = agent.getActiveAccountId()
+			const account_id = await agent.getActiveAccountId()
 			if (!account_id) {
 				return MISSING_ACCOUNT_ID_RESPONSE
 			}
@@ -179,7 +179,7 @@ export function registerD1Tools(agent: CloudflareMcpAgent) {
 			params: D1DatabaseQueryParamsParam.nullable(),
 		},
 		async ({ database_id, sql, params }) => {
-			const account_id = agent.getActiveAccountId()
+			const account_id = await agent.getActiveAccountId()
 			if (!account_id) {
 				return MISSING_ACCOUNT_ID_RESPONSE
 			}

--- a/packages/mcp-common/src/tools/kv_namespace.ts
+++ b/packages/mcp-common/src/tools/kv_namespace.ts
@@ -16,7 +16,7 @@ export function registerKVTools(agent: CloudflareMcpAgent) {
 		'List all of the kv namespaces in your Cloudflare account',
 		{ params: KvNamespacesListParamsSchema.optional() },
 		async ({ params }) => {
-			const account_id = agent.getActiveAccountId()
+			const account_id = await agent.getActiveAccountId()
 			if (!account_id) {
 				return MISSING_ACCOUNT_ID_RESPONSE
 			}
@@ -63,7 +63,7 @@ export function registerKVTools(agent: CloudflareMcpAgent) {
 			title: KvNamespaceTitleSchema,
 		},
 		async ({ title }) => {
-			const account_id = agent.getActiveAccountId()
+			const account_id = await agent.getActiveAccountId()
 			if (!account_id) {
 				return MISSING_ACCOUNT_ID_RESPONSE
 			}
@@ -101,7 +101,7 @@ export function registerKVTools(agent: CloudflareMcpAgent) {
 			namespace_id: KvNamespaceIdSchema,
 		},
 		async ({ namespace_id }) => {
-			const account_id = agent.getActiveAccountId()
+			const account_id = await agent.getActiveAccountId()
 			if (!account_id) {
 				return MISSING_ACCOUNT_ID_RESPONSE
 			}
@@ -139,7 +139,7 @@ export function registerKVTools(agent: CloudflareMcpAgent) {
 			namespace_id: KvNamespaceIdSchema,
 		},
 		async ({ namespace_id }) => {
-			const account_id = agent.getActiveAccountId()
+			const account_id = await agent.getActiveAccountId()
 			if (!account_id) {
 				return MISSING_ACCOUNT_ID_RESPONSE
 			}
@@ -178,7 +178,7 @@ export function registerKVTools(agent: CloudflareMcpAgent) {
 			title: KvNamespaceTitleSchema,
 		},
 		async ({ namespace_id, title }) => {
-			const account_id = agent.getActiveAccountId()
+			const account_id = await agent.getActiveAccountId()
 			if (!account_id) {
 				return MISSING_ACCOUNT_ID_RESPONSE
 			}

--- a/packages/mcp-common/src/tools/r2_bucket.ts
+++ b/packages/mcp-common/src/tools/r2_bucket.ts
@@ -22,7 +22,7 @@ export function registerR2BucketTools(agent: CloudflareMcpAgent) {
 			start_after: BucketListStartAfterParam,
 		},
 		async ({ cursor, direction, name_contains, per_page, start_after }) => {
-			const account_id = agent.getActiveAccountId()
+			const account_id = await agent.getActiveAccountId()
 			if (!account_id) {
 				return MISSING_ACCOUNT_ID_RESPONSE
 			}
@@ -66,7 +66,7 @@ export function registerR2BucketTools(agent: CloudflareMcpAgent) {
 		'Create a new r2 bucket in your Cloudflare account',
 		{ name: BucketNameSchema },
 		async ({ name }) => {
-			const account_id = agent.getActiveAccountId()
+			const account_id = await agent.getActiveAccountId()
 			if (!account_id) {
 				return MISSING_ACCOUNT_ID_RESPONSE
 			}
@@ -102,7 +102,7 @@ export function registerR2BucketTools(agent: CloudflareMcpAgent) {
 		'Get details about a specific R2 bucket',
 		{ name: BucketNameSchema },
 		async ({ name }) => {
-			const account_id = agent.getActiveAccountId()
+			const account_id = await agent.getActiveAccountId()
 			if (!account_id) {
 				return MISSING_ACCOUNT_ID_RESPONSE
 			}
@@ -135,7 +135,7 @@ export function registerR2BucketTools(agent: CloudflareMcpAgent) {
 		'Delete an R2 bucket',
 		{ name: BucketNameSchema },
 		async ({ name }) => {
-			const account_id = agent.getActiveAccountId()
+			const account_id = await agent.getActiveAccountId()
 			if (!account_id) {
 				return MISSING_ACCOUNT_ID_RESPONSE
 			}
@@ -172,7 +172,7 @@ export function registerR2BucketTools(agent: CloudflareMcpAgent) {
 	// 		params: CorsGetParamsSchema.optional(),
 	// 	},
 	// 	async ({ name, params }) => {
-	// 		const account_id = agent.getActiveAccountId()
+	// 		const account_id = await agent.getActiveAccountId()
 	// 		if (!account_id) {
 	// 			return MISSING_ACCOUNT_ID_RESPONSE
 	// 		}
@@ -211,7 +211,7 @@ export function registerR2BucketTools(agent: CloudflareMcpAgent) {
 	// 		cors_config: CorsRulesSchema,
 	// 	},
 	// 	async ({ name, cors_config }) => {
-	// 		const account_id = agent.getActiveAccountId()
+	// 		const account_id = await agent.getActiveAccountId()
 	// 		if (!account_id) {
 	// 			return MISSING_ACCOUNT_ID_RESPONSE
 	// 		}
@@ -250,7 +250,7 @@ export function registerR2BucketTools(agent: CloudflareMcpAgent) {
 	// 		params: CorsDeleteParamsSchema.optional(),
 	// 	},
 	// 	async ({ name, params }) => {
-	// 		const account_id = agent.getActiveAccountId()
+	// 		const account_id = await agent.getActiveAccountId()
 	// 		if (!account_id) {
 	// 			return MISSING_ACCOUNT_ID_RESPONSE
 	// 		}
@@ -286,7 +286,7 @@ export function registerR2BucketTools(agent: CloudflareMcpAgent) {
 	// 	'List all of the domains for an R2 bucket',
 	// 	{ name: BucketNameSchema, params: CustomDomainListParamsSchema.optional() },
 	// 	async ({ name, params }) => {
-	// 		const account_id = agent.getActiveAccountId()
+	// 		const account_id = await agent.getActiveAccountId()
 	// 		if (!account_id) {
 	// 			return MISSING_ACCOUNT_ID_RESPONSE
 	// 		}
@@ -323,7 +323,7 @@ export function registerR2BucketTools(agent: CloudflareMcpAgent) {
 	// 		params: CustomDomainGetParamsSchema.optional(),
 	// 	},
 	// 	async ({ name, domain, params }) => {
-	// 		const account_id = agent.getActiveAccountId()
+	// 		const account_id = await agent.getActiveAccountId()
 	// 		if (!account_id) {
 	// 			return MISSING_ACCOUNT_ID_RESPONSE
 	// 		}
@@ -359,7 +359,7 @@ export function registerR2BucketTools(agent: CloudflareMcpAgent) {
 	// 	'Create a new domain for an R2 bucket',
 	// 	{ name: BucketNameSchema, params: CustomDomainCreateParamsSchema },
 	// 	async ({ name, params }) => {
-	// 		const account_id = agent.getActiveAccountId()
+	// 		const account_id = await agent.getActiveAccountId()
 	// 		if (!account_id) {
 	// 			return MISSING_ACCOUNT_ID_RESPONSE
 	// 		}
@@ -399,7 +399,7 @@ export function registerR2BucketTools(agent: CloudflareMcpAgent) {
 	// 		params: CustomDomainDeleteParamsSchema.optional(),
 	// 	},
 	// 	async ({ name, domain, params }) => {
-	// 		const account_id = agent.getActiveAccountId()
+	// 		const account_id = await agent.getActiveAccountId()
 	// 		if (!account_id) {
 	// 			return MISSING_ACCOUNT_ID_RESPONSE
 	// 		}
@@ -439,7 +439,7 @@ export function registerR2BucketTools(agent: CloudflareMcpAgent) {
 	// 		params: CustomDomainUpdateParamsSchema,
 	// 	},
 	// 	async ({ name, domain, params }) => {
-	// 		const account_id = agent.getActiveAccountId()
+	// 		const account_id = await agent.getActiveAccountId()
 	// 		if (!account_id) {
 	// 			return MISSING_ACCOUNT_ID_RESPONSE
 	// 		}
@@ -475,7 +475,7 @@ export function registerR2BucketTools(agent: CloudflareMcpAgent) {
 	// 	'Get event notifications for an R2 bucket',
 	// 	{ name: BucketNameSchema, params: EventNotificationGetParamsSchema.optional() },
 	// 	async ({ name, params }) => {
-	// 		const account_id = agent.getActiveAccountId()
+	// 		const account_id = await agent.getActiveAccountId()
 	// 		if (!account_id) {
 	// 			return MISSING_ACCOUNT_ID_RESPONSE
 	// 		}
@@ -515,7 +515,7 @@ export function registerR2BucketTools(agent: CloudflareMcpAgent) {
 	// 		params: EventNotificationUpdateParamsSchema.optional(),
 	// 	},
 	// 	async ({ name, queueId, params }) => {
-	// 		const account_id = agent.getActiveAccountId()
+	// 		const account_id = await agent.getActiveAccountId()
 	// 		if (!account_id) {
 	// 			return MISSING_ACCOUNT_ID_RESPONSE
 	// 		}
@@ -555,7 +555,7 @@ export function registerR2BucketTools(agent: CloudflareMcpAgent) {
 	// 		params: EventNotificationDeleteParamsSchema.optional(),
 	// 	},
 	// 	async ({ name, queueId, params }) => {
-	// 		const account_id = agent.getActiveAccountId()
+	// 		const account_id = await agent.getActiveAccountId()
 	// 		if (!account_id) {
 	// 			return MISSING_ACCOUNT_ID_RESPONSE
 	// 		}
@@ -591,7 +591,7 @@ export function registerR2BucketTools(agent: CloudflareMcpAgent) {
 	// 	'Get locks for an R2 bucket',
 	// 	{ name: BucketNameSchema, params: LockGetParamsSchema.optional() },
 	// 	async ({ name, params }) => {
-	// 		const account_id = agent.getActiveAccountId()
+	// 		const account_id = await agent.getActiveAccountId()
 	// 		if (!account_id) {
 	// 			return MISSING_ACCOUNT_ID_RESPONSE
 	// 		}
@@ -624,7 +624,7 @@ export function registerR2BucketTools(agent: CloudflareMcpAgent) {
 	// 	'Update locks for an R2 bucket',
 	// 	{ name: BucketNameSchema, params: LockUpdateParamsSchema },
 	// 	async ({ name, params }) => {
-	// 		const account_id = agent.getActiveAccountId()
+	// 		const account_id = await agent.getActiveAccountId()
 	// 		if (!account_id) {
 	// 			return MISSING_ACCOUNT_ID_RESPONSE
 	// 		}
@@ -657,7 +657,7 @@ export function registerR2BucketTools(agent: CloudflareMcpAgent) {
 	// 	'Create temporary credentials for an R2 bucket',
 	// 	{ params: TemporaryCredentialsCreateParamsSchema },
 	// 	async ({ params }) => {
-	// 		const account_id = agent.getActiveAccountId()
+	// 		const account_id = await agent.getActiveAccountId()
 	// 		if (!account_id) {
 	// 			return MISSING_ACCOUNT_ID_RESPONSE
 	// 		}
@@ -689,7 +689,7 @@ export function registerR2BucketTools(agent: CloudflareMcpAgent) {
 	// )
 
 	// agent.server.tool('r2_metrics_list', 'List metrics for an R2 bucket', async () => {
-	// 	const account_id = agent.getActiveAccountId()
+	// 	const account_id = await agent.getActiveAccountId()
 	// 	if (!account_id) {
 	// 		return MISSING_ACCOUNT_ID_RESPONSE
 	// 	}
@@ -721,7 +721,7 @@ export function registerR2BucketTools(agent: CloudflareMcpAgent) {
 	// 	'Get configuration for sippy for an R2 bucket',
 	// 	{ bucketName: BucketNameSchema, params: SippyGetParamsSchema.optional() },
 	// 	async ({ bucketName, params }) => {
-	// 		const account_id = agent.getActiveAccountId()
+	// 		const account_id = await agent.getActiveAccountId()
 	// 		if (!account_id) {
 	// 			return MISSING_ACCOUNT_ID_RESPONSE
 	// 		}
@@ -755,7 +755,7 @@ export function registerR2BucketTools(agent: CloudflareMcpAgent) {
 	// 	'Update configuration for sippy for an R2 bucket',
 	// 	{ bucketName: BucketNameSchema, params: SippyUpdateParamsSchema },
 	// 	async ({ bucketName, params }) => {
-	// 		const account_id = agent.getActiveAccountId()
+	// 		const account_id = await agent.getActiveAccountId()
 	// 		if (!account_id) {
 	// 			return MISSING_ACCOUNT_ID_RESPONSE
 	// 		}
@@ -788,7 +788,7 @@ export function registerR2BucketTools(agent: CloudflareMcpAgent) {
 	// 	'Delete sippy for an R2 bucket',
 	// 	{ bucketName: BucketNameSchema },
 	// 	async ({ bucketName }) => {
-	// 		const account_id = agent.getActiveAccountId()
+	// 		const account_id = await agent.getActiveAccountId()
 	// 		if (!account_id) {
 	// 			return MISSING_ACCOUNT_ID_RESPONSE
 	// 		}

--- a/packages/mcp-common/src/tools/worker.ts
+++ b/packages/mcp-common/src/tools/worker.ts
@@ -16,7 +16,7 @@ const workerNameParam = z.string().describe('The name of the worker script to re
 export function registerWorkersTools(agent: CloudflareMcpAgent) {
 	// Tool to list all workers
 	agent.server.tool('workers_list', 'List all Workers in your Cloudflare account', async () => {
-		const accountId = agent.getActiveAccountId()
+		const accountId = await agent.getActiveAccountId()
 		if (!accountId) {
 			return {
 				content: [
@@ -76,7 +76,7 @@ export function registerWorkersTools(agent: CloudflareMcpAgent) {
 		'Get the source code of a Cloudflare Worker',
 		{ scriptName: workerNameParam },
 		async (params) => {
-			const accountId = agent.getActiveAccountId()
+			const accountId = await agent.getActiveAccountId()
 			if (!accountId) {
 				return {
 					content: [

--- a/packages/mcp-common/src/types/cloudflare-mcp-agent.ts
+++ b/packages/mcp-common/src/types/cloudflare-mcp-agent.ts
@@ -20,6 +20,6 @@ type McpAgentWithoutServer<EnvType = unknown> = Omit<
 
 export interface CloudflareMcpAgent<EnvType = unknown> extends McpAgentWithoutServer<EnvType> {
 	server: CloudflareMCPServer
-	setActiveAccountId(accountId: string): void
-	getActiveAccountId(): string | null
+	setActiveAccountId(accountId: string): Promise<void>
+	getActiveAccountId(): Promise<string | null>
 }


### PR DESCRIPTION
Introduces a new "UserDetails" Durable Object for persisting UserDetails in DO storage across sessions based off the userId