### PR TITLE
Remove unused fields from list accounts mcp tool

### DIFF
--- a/packages/mcp-common/src/tools/account.ts
+++ b/packages/mcp-common/src/tools/account.ts
@@ -20,6 +20,14 @@ export function registerAccountTools(agent: CloudflareMcpAgent) {
 					if (!b.created_on) return -1
 					return new Date(b.created_on).getTime() - new Date(a.created_on).getTime()
 				})
+				// Remove fields not needed by the LLM
+				.map((account) => {
+					return {
+						id: account.id,
+						name: account.name,
+						created_on: account.created_on,
+					}
+				})
 
 			return {
 				content: [


### PR DESCRIPTION
Users with a lot of accounts are wasting a lot of llm tokens on unused information, this pr makes sure only required (id + name) fields are returned to the LLM
