### PR TITLE
chore: add job to build Workers for branches and fix entrypoint

### DIFF
--- a/.changeset/new-zebras-relax.md
+++ b/.changeset/new-zebras-relax.md
@@ -1,0 +1,5 @@
+---
+'workers-observability': patch
+---
+
+fix: set correct entrypoint in wrangler.jsonc

--- a/.github/workflows/branches.yml
+++ b/.github/workflows/branches.yml
@@ -31,3 +31,15 @@ jobs:
       - name: Run tests
         run: pnpm test
 
+  build-workers:
+    name: Build Workers
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+
+      - name: Build Workers
+        run: pnpm turbo deploy -- -e staging --dry-run

--- a/apps/workers-observability/wrangler.jsonc
+++ b/apps/workers-observability/wrangler.jsonc
@@ -4,7 +4,7 @@
  */
 {
 	"$schema": "node_modules/wrangler/config-schema.json",
-	"main": "src/wobs.app.ts",
+	"main": "src/workers-observability.app.ts",
 	"compatibility_date": "2025-03-10",
 	"compatibility_flags": ["nodejs_compat"],
 	"name": "mcp-cloudflare-workers-observability-dev",


### PR DESCRIPTION
A bad entrypoint slipped through because we don't do `wrangler deploy --dry-run` for branches, so I added a branch job to do it.

Also fixed the entrypoint issue that this would have caught.