### PR TITLE
Add open mcp marketplace api support

### DIFF
--- a/apps/ai-gateway/README.md
+++ b/apps/ai-gateway/README.md
@@ -50,3 +50,28 @@ Replace the content with the following configuration:
 Once you've set up your configuration file, restart MCP client and a browser window will open showing your OAuth login page. Proceed through the authentication flow to grant the client access to your MCP server. After you grant access, the tools will become available for you to use.
 
 Interested in contributing, and running this server locally? See [CONTRIBUTING.md](CONTRIBUTING.md) to get started.
+
+### Resources 
+
+<details>
+<summary><b>Open MCP Marketplace API Support</b></summary>
+
+![MCP Marketplace User Review Rating Badge](http://www.deepnlp.org/api/marketplace/svg?cloudflare/mcp-server-cloudflare)|[Reviews](http://www.deepnlp.org/store/ai-agent/mcp-server/pub-cloudflare/mcp-server-cloudflare)|[GitHub](https://github.com/AI-Agent-Hub/mcp-marketplace)|[Doc](http://www.deepnlp.org/doc/mcp_marketplace)|[MCP Marketplace](http://www.deepnlp.org/store/ai-agent/mcp-server)
+
+Allow AI/Agent/LLM to find this MCP Server via common python/typescript API, search and explore relevant servers and tools
+
+***Example: Search Server and Tools***
+```python
+import anthropic
+import mcp_marketplace as mcpm
+
+result_q = mcpm.search(query="mcp server cloudflare", mode="list", page_id=0, count_per_page=100, config_name="deepnlp") # search server by category choose various endpoint
+result_id = mcpm.search(id="cloudflare/mcp-server-cloudflare", mode="list", page_id=0, count_per_page=100, config_name="deepnlp")      # search server by id choose various endpoint 
+tools = mcpm.list_tools(id="cloudflare/mcp-server-cloudflare", config_name="deepnlp_tool")
+# Call Claude to Choose Tools Function Calls 
+# client = anthropic.Anthropic()
+# response = client.messages.create(model="claude-opus-4-20250514", max_tokens=1024, tools=tools, messages=[])
+```
+
+</details>
+


### PR DESCRIPTION
Hi mcp-server-cloudflare team,
I would like to introduce MCP Marketplace Python and Typescript API and add support to your MCP Server, which allow any LLM AI Agent to integrate your MCP servers easily into the workflow, by searching relevant servers and tools meta and schemas, and give LLM more chances to know more about your MCP tools, increase usage from thousands of AI Agents or Applications. And here is a demo backend codes in python to integrate your servers tools for Claude function calls API...


## Resources 

<details>
<summary><b>Open MCP Marketplace API Support</b></summary>

![MCP Marketplace User Review Rating Badge](http://www.deepnlp.org/api/marketplace/svg?cloudflare/mcp-server-cloudflare)|[Reviews](http://www.deepnlp.org/store/ai-agent/mcp-server/pub-cloudflare/mcp-server-cloudflare)|[GitHub](https://github.com/AI-Agent-Hub/mcp-marketplace)|[Doc](http://www.deepnlp.org/doc/mcp_marketplace)|[MCP Marketplace](http://www.deepnlp.org/store/ai-agent/mcp-server)

Allow AI/Agent/LLM to find this MCP Server via common python/typescript API, search and explore relevant servers and tools

***Example: Search Server and Tools***
```python
import anthropic
import mcp_marketplace as mcpm

result_q = mcpm.search(query="mcp server cloudflare", mode="list", page_id=0, count_per_page=100, config_name="deepnlp") # search server by category choose various endpoint
result_id = mcpm.search(id="cloudflare/mcp-server-cloudflare", mode="list", page_id=0, count_per_page=100, config_name="deepnlp")      # search server by id choose various endpoint 
tools = mcpm.list_tools(id="cloudflare/mcp-server-cloudflare", config_name="deepnlp_tool")
# Call Claude to Choose Tools Function Calls 
# client = anthropic.Anthropic()
# response = client.messages.create(model="claude-opus-4-20250514", max_tokens=1024, tools=tools, messages=[])
```

</details>
