### PR TITLE
Support AOT tokens

### DIFF
--- a/.changeset/breezy-ideas-accept.md
+++ b/.changeset/breezy-ideas-accept.md
@@ -1,0 +1,26 @@
+---
+'workers-observability': minor
+'@repo/mcp-observability': minor
+'@repo/typescript-config': minor
+'cloudflare-casb-mcp-server': minor
+'cloudflare-browser-mcp-server': minor
+'containers-mcp': minor
+'workers-bindings': minor
+'docs-vectorize': minor
+'workers-builds': minor
+'@repo/eval-tools': minor
+'@repo/mcp-common': minor
+'dns-analytics': minor
+'dex-analysis': minor
+'docs-autorag': minor
+'cloudflare-ai-gateway-mcp-server': minor
+'auditlogs': minor
+'@repo/tools': minor
+'demo-day': minor
+'cloudflare-autorag-mcp-server': minor
+'graphql-mcp-server': minor
+'logpush': minor
+'cloudflare-radar-mcp-server': minor
+---
+
+Support AOT tokens

--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ If your client does not yet support remote MCP servers, you will need to set up 
 
 ## Using Cloudflare's MCP servers from the OpenAI Responses API
 
-To use one of Cloudflare's MCP servers with [OpenAI's responses API](https://openai.com/index/new-tools-and-features-in-the-responses-api/), you will need to provide the Responses API with a **user** API token (not an Account API token) that has the scopes (permissions) required for that particular MCP server.
+To use one of Cloudflare's MCP servers with [OpenAI's responses API](https://openai.com/index/new-tools-and-features-in-the-responses-api/), you will need to provide the Responses API with an API token that has the scopes (permissions) required for that particular MCP server.
 
-For example, to use the [Browser Rendering MCP server](https://github.com/cloudflare/mcp-server-cloudflare/tree/main/apps/browser-rendering) with OpenAI, create a user API token in the Cloudflare dashboard [here](https://dash.cloudflare.com/profile/api-tokens), with the following permissions:
+For example, to use the [Browser Rendering MCP server](https://github.com/cloudflare/mcp-server-cloudflare/tree/main/apps/browser-rendering) with OpenAI, create an API token in the Cloudflare dashboard [here](https://dash.cloudflare.com/profile/api-tokens), with the following permissions:
 
 <img width="937" alt="Screenshot 2025-05-21 at 10 38 02 AM" src="https://github.com/user-attachments/assets/872e253f-23ce-43b3-983c-45f9d0f66100" />
 

--- a/apps/ai-gateway/src/ai-gateway.app.ts
+++ b/apps/ai-gateway/src/ai-gateway.app.ts
@@ -50,8 +50,11 @@ export class AIGatewayMCP extends McpAgent<Env, State, Props> {
 	}
 
 	async init() {
+		// TODO: Probably we'll want to track account tokens usage through an account identifier at some point
+		const userId = this.props.type === 'user_token' ? this.props.user.id : undefined
+
 		this.server = new CloudflareMCPServer({
-			userId: this.props.user.id,
+			userId,
 			wae: this.env.MCP_METRICS,
 			serverInfo: {
 				name: this.env.MCP_SERVER_NAME,
@@ -67,6 +70,10 @@ export class AIGatewayMCP extends McpAgent<Env, State, Props> {
 
 	async getActiveAccountId() {
 		try {
+			// account tokens are scoped to one account
+			if (this.props.type === 'account_token') {
+				return this.props.account.id
+			}
 			// Get UserDetails Durable Object based off the userId and retrieve the activeAccountId from it
 			// we do this so we can persist activeAccountId across sessions
 			const userDetails = getUserDetails(env, this.props.user.id)
@@ -79,6 +86,10 @@ export class AIGatewayMCP extends McpAgent<Env, State, Props> {
 
 	async setActiveAccountId(accountId: string) {
 		try {
+			// account tokens are scoped to one account
+			if (this.props.type === 'account_token') {
+				return
+			}
 			const userDetails = getUserDetails(env, this.props.user.id)
 			await userDetails.setActiveAccountId(accountId)
 		} catch (e) {

--- a/apps/auditlogs/src/auditlogs.app.ts
+++ b/apps/auditlogs/src/auditlogs.app.ts
@@ -51,8 +51,11 @@ export class AuditlogMCP extends McpAgent<Env, State, Props> {
 	}
 
 	async init() {
+		// TODO: Probably we'll want to track account tokens usage through an account identifier at some point
+		const userId = this.props.type === 'user_token' ? this.props.user.id : undefined
+
 		this.server = new CloudflareMCPServer({
-			userId: this.props.user.id,
+			userId,
 			wae: this.env.MCP_METRICS,
 			serverInfo: {
 				name: this.env.MCP_SERVER_NAME,
@@ -67,6 +70,10 @@ export class AuditlogMCP extends McpAgent<Env, State, Props> {
 
 	async getActiveAccountId() {
 		try {
+			// account tokens are scoped to one account
+			if (this.props.type === 'account_token') {
+				return this.props.account.id
+			}
 			// Get UserDetails Durable Object based off the userId and retrieve the activeAccountId from it
 			// we do this so we can persist activeAccountId across sessions
 			const userDetails = getUserDetails(env, this.props.user.id)
@@ -79,6 +86,10 @@ export class AuditlogMCP extends McpAgent<Env, State, Props> {
 
 	async setActiveAccountId(accountId: string) {
 		try {
+			// account tokens are scoped to one account
+			if (this.props.type === 'account_token') {
+				return
+			}
 			const userDetails = getUserDetails(env, this.props.user.id)
 			await userDetails.setActiveAccountId(accountId)
 		} catch (e) {

--- a/apps/autorag/src/autorag.app.ts
+++ b/apps/autorag/src/autorag.app.ts
@@ -50,8 +50,11 @@ export class AutoRAGMCP extends McpAgent<Env, State, Props> {
 	}
 
 	async init() {
+		// TODO: Probably we'll want to track account tokens usage through an account identifier at some point
+		const userId = this.props.type === 'user_token' ? this.props.user.id : undefined
+
 		this.server = new CloudflareMCPServer({
-			userId: this.props.user.id,
+			userId,
 			wae: this.env.MCP_METRICS,
 			serverInfo: {
 				name: this.env.MCP_SERVER_NAME,
@@ -67,6 +70,10 @@ export class AutoRAGMCP extends McpAgent<Env, State, Props> {
 
 	async getActiveAccountId() {
 		try {
+			// account tokens are scoped to one account
+			if (this.props.type === 'account_token') {
+				return this.props.account.id
+			}
 			// Get UserDetails Durable Object based off the userId and retrieve the activeAccountId from it
 			// we do this so we can persist activeAccountId across sessions
 			const userDetails = getUserDetails(env, this.props.user.id)
@@ -79,6 +86,10 @@ export class AutoRAGMCP extends McpAgent<Env, State, Props> {
 
 	async setActiveAccountId(accountId: string) {
 		try {
+			// account tokens are scoped to one account
+			if (this.props.type === 'account_token') {
+				return
+			}
 			const userDetails = getUserDetails(env, this.props.user.id)
 			await userDetails.setActiveAccountId(accountId)
 		} catch (e) {

--- a/apps/browser-rendering/src/browser.app.ts
+++ b/apps/browser-rendering/src/browser.app.ts
@@ -50,8 +50,11 @@ export class BrowserMCP extends McpAgent<Env, State, Props> {
 	}
 
 	async init() {
+		// TODO: Probably we'll want to track account tokens usage through an account identifier at some point
+		const userId = this.props.type === 'user_token' ? this.props.user.id : undefined
+
 		this.server = new CloudflareMCPServer({
-			userId: this.props.user.id,
+			userId,
 			wae: this.env.MCP_METRICS,
 			serverInfo: {
 				name: this.env.MCP_SERVER_NAME,
@@ -67,6 +70,10 @@ export class BrowserMCP extends McpAgent<Env, State, Props> {
 
 	async getActiveAccountId() {
 		try {
+			// account tokens are scoped to one account
+			if (this.props.type === 'account_token') {
+				return this.props.account.id
+			}
 			// Get UserDetails Durable Object based off the userId and retrieve the activeAccountId from it
 			// we do this so we can persist activeAccountId across sessions
 			const userDetails = getUserDetails(env, this.props.user.id)
@@ -79,6 +86,10 @@ export class BrowserMCP extends McpAgent<Env, State, Props> {
 
 	async setActiveAccountId(accountId: string) {
 		try {
+			// account tokens are scoped to one account
+			if (this.props.type === 'account_token') {
+				return
+			}
 			const userDetails = getUserDetails(env, this.props.user.id)
 			await userDetails.setActiveAccountId(accountId)
 		} catch (e) {

--- a/apps/cloudflare-one-casb/src/cf1-casb.app.ts
+++ b/apps/cloudflare-one-casb/src/cf1-casb.app.ts
@@ -51,8 +51,11 @@ export class CASBMCP extends McpAgent<Env, State, Props> {
 	}
 
 	async init() {
+		// TODO: Probably we'll want to track account tokens usage through an account identifier at some point
+		const userId = this.props.type === 'user_token' ? this.props.user.id : undefined
+
 		this.server = new CloudflareMCPServer({
-			userId: this.props.user.id,
+			userId,
 			wae: this.env.MCP_METRICS,
 			serverInfo: {
 				name: this.env.MCP_SERVER_NAME,
@@ -66,6 +69,10 @@ export class CASBMCP extends McpAgent<Env, State, Props> {
 
 	async getActiveAccountId() {
 		try {
+			// account tokens are scoped to one account
+			if (this.props.type === 'account_token') {
+				return this.props.account.id
+			}
 			// Get UserDetails Durable Object based off the userId and retrieve the activeAccountId from it
 			// we do this so we can persist activeAccountId across sessions
 			const userDetails = getUserDetails(env, this.props.user.id)
@@ -78,6 +85,10 @@ export class CASBMCP extends McpAgent<Env, State, Props> {
 
 	async setActiveAccountId(accountId: string) {
 		try {
+			// account tokens are scoped to one account
+			if (this.props.type === 'account_token') {
+				return
+			}
 			const userDetails = getUserDetails(env, this.props.user.id)
 			await userDetails.setActiveAccountId(accountId)
 		} catch (e) {

--- a/apps/dex-analysis/src/dex-analysis.app.ts
+++ b/apps/dex-analysis/src/dex-analysis.app.ts
@@ -52,8 +52,11 @@ export class CloudflareDEXMCP extends McpAgent<Env, State, Props> {
 	}
 
 	async init() {
+		// TODO: Probably we'll want to track account tokens usage through an account identifier at some point
+		const userId = this.props.type === 'user_token' ? this.props.user.id : undefined
+
 		this.server = new CloudflareMCPServer({
-			userId: this.props.user.id,
+			userId,
 			wae: this.env.MCP_METRICS,
 			serverInfo: {
 				name: this.env.MCP_SERVER_NAME,
@@ -67,6 +70,10 @@ export class CloudflareDEXMCP extends McpAgent<Env, State, Props> {
 
 	async getActiveAccountId() {
 		try {
+			// account tokens are scoped to one account
+			if (this.props.type === 'account_token') {
+				return this.props.account.id
+			}
 			// Get UserDetails Durable Object based off the userId and retrieve the activeAccountId from it
 			// we do this so we can persist activeAccountId across sessions
 			const userDetails = getUserDetails(env, this.props.user.id)
@@ -79,6 +86,10 @@ export class CloudflareDEXMCP extends McpAgent<Env, State, Props> {
 
 	async setActiveAccountId(accountId: string) {
 		try {
+			// account tokens are scoped to one account
+			if (this.props.type === 'account_token') {
+				return
+			}
 			const userDetails = getUserDetails(env, this.props.user.id)
 			await userDetails.setActiveAccountId(accountId)
 		} catch (e) {

--- a/apps/dns-analytics/src/dns-analytics.app.ts
+++ b/apps/dns-analytics/src/dns-analytics.app.ts
@@ -53,8 +53,11 @@ export class DNSAnalyticsMCP extends McpAgent<Env, State, Props> {
 	}
 
 	async init() {
+		// TODO: Probably we'll want to track account tokens usage through an account identifier at some point
+		const userId = this.props.type === 'user_token' ? this.props.user.id : undefined
+
 		this.server = new CloudflareMCPServer({
-			userId: this.props.user.id,
+			userId,
 			wae: this.env.MCP_METRICS,
 			serverInfo: {
 				name: this.env.MCP_SERVER_NAME,
@@ -72,6 +75,10 @@ export class DNSAnalyticsMCP extends McpAgent<Env, State, Props> {
 
 	async getActiveAccountId() {
 		try {
+			// account tokens are scoped to one account
+			if (this.props.type === 'account_token') {
+				return this.props.account.id
+			}
 			// Get UserDetails Durable Object based off the userId and retrieve the activeAccountId from it
 			// we do this so we can persist activeAccountId across sessions
 			const userDetails = getUserDetails(env, this.props.user.id)
@@ -84,6 +91,10 @@ export class DNSAnalyticsMCP extends McpAgent<Env, State, Props> {
 
 	async setActiveAccountId(accountId: string) {
 		try {
+			// account tokens are scoped to one account
+			if (this.props.type === 'account_token') {
+				return
+			}
 			const userDetails = getUserDetails(env, this.props.user.id)
 			await userDetails.setActiveAccountId(accountId)
 		} catch (e) {

--- a/apps/graphql/src/graphql.app.ts
+++ b/apps/graphql/src/graphql.app.ts
@@ -53,14 +53,21 @@ export class GraphQLMCP extends McpAgent<Env, State, Props> {
 	}
 
 	async init() {
+		// TODO: Probably we'll want to track account tokens usage through an account identifier at some point
+		const userId = this.props.type === 'user_token' ? this.props.user.id : undefined
+		const sentry =
+			this.props.type === 'user_token'
+				? initSentryWithUser(env, this.ctx, this.props.user.id)
+				: undefined
+
 		this.server = new CloudflareMCPServer({
-			userId: this.props.user.id,
+			userId,
 			wae: this.env.MCP_METRICS,
 			serverInfo: {
 				name: this.env.MCP_SERVER_NAME,
 				version: this.env.MCP_SERVER_VERSION,
 			},
-			sentry: initSentryWithUser(env, this.ctx, this.props.user.id),
+			sentry,
 		})
 
 		// Register account tools
@@ -75,6 +82,10 @@ export class GraphQLMCP extends McpAgent<Env, State, Props> {
 
 	async getActiveAccountId() {
 		try {
+			// account tokens are scoped to one account
+			if (this.props.type === 'account_token') {
+				return this.props.account.id
+			}
 			// Get UserDetails Durable Object based off the userId and retrieve the activeAccountId from it
 			// we do this so we can persist activeAccountId across sessions
 			const userDetails = getUserDetails(env, this.props.user.id)
@@ -87,6 +98,10 @@ export class GraphQLMCP extends McpAgent<Env, State, Props> {
 
 	async setActiveAccountId(accountId: string) {
 		try {
+			// account tokens are scoped to one account
+			if (this.props.type === 'account_token') {
+				return
+			}
 			const userDetails = getUserDetails(env, this.props.user.id)
 			await userDetails.setActiveAccountId(accountId)
 		} catch (e) {

--- a/apps/logpush/src/logpush.app.ts
+++ b/apps/logpush/src/logpush.app.ts
@@ -50,8 +50,11 @@ export class LogsMCP extends McpAgent<Env, State, Props> {
 	}
 
 	async init() {
+		// TODO: Probably we'll want to track account tokens usage through an account identifier at some point
+		const userId = this.props.type === 'user_token' ? this.props.user.id : undefined
+
 		this.server = new CloudflareMCPServer({
-			userId: this.props.user.id,
+			userId,
 			wae: this.env.MCP_METRICS,
 			serverInfo: {
 				name: this.env.MCP_SERVER_NAME,
@@ -67,6 +70,10 @@ export class LogsMCP extends McpAgent<Env, State, Props> {
 
 	async getActiveAccountId() {
 		try {
+			// account tokens are scoped to one account
+			if (this.props.type === 'account_token') {
+				return this.props.account.id
+			}
 			// Get UserDetails Durable Object based off the userId and retrieve the activeAccountId from it
 			// we do this so we can persist activeAccountId across sessions
 			const userDetails = getUserDetails(env, this.props.user.id)
@@ -79,6 +86,10 @@ export class LogsMCP extends McpAgent<Env, State, Props> {
 
 	async setActiveAccountId(accountId: string) {
 		try {
+			// account tokens are scoped to one account
+			if (this.props.type === 'account_token') {
+				return
+			}
 			const userDetails = getUserDetails(env, this.props.user.id)
 			await userDetails.setActiveAccountId(accountId)
 		} catch (e) {

--- a/apps/radar/src/radar.app.ts
+++ b/apps/radar/src/radar.app.ts
@@ -52,8 +52,11 @@ export class RadarMCP extends McpAgent<Env, State, Props> {
 	}
 
 	async init() {
+		// TODO: Probably we'll want to track account tokens usage through an account identifier at some point
+		const userId = this.props.type === 'user_token' ? this.props.user.id : undefined
+
 		this.server = new CloudflareMCPServer({
-			userId: this.props.user.id,
+			userId,
 			wae: this.env.MCP_METRICS,
 			serverInfo: {
 				name: this.env.MCP_SERVER_NAME,
@@ -69,6 +72,10 @@ export class RadarMCP extends McpAgent<Env, State, Props> {
 
 	async getActiveAccountId() {
 		try {
+			// account tokens are scoped to one account
+			if (this.props.type === 'account_token') {
+				return this.props.account.id
+			}
 			// Get UserDetails Durable Object based off the userId and retrieve the activeAccountId from it
 			// we do this so we can persist activeAccountId across sessions
 			const userDetails = getUserDetails(env, this.props.user.id)
@@ -81,6 +88,10 @@ export class RadarMCP extends McpAgent<Env, State, Props> {
 
 	async setActiveAccountId(accountId: string) {
 		try {
+			// account tokens are scoped to one account
+			if (this.props.type === 'account_token') {
+				return
+			}
 			const userDetails = getUserDetails(env, this.props.user.id)
 			await userDetails.setActiveAccountId(accountId)
 		} catch (e) {

--- a/apps/workers-bindings/src/bindings.app.ts
+++ b/apps/workers-bindings/src/bindings.app.ts
@@ -59,8 +59,11 @@ export class WorkersBindingsMCP extends McpAgent<Env, WorkersBindingsMCPState, P
 	}
 
 	async init() {
+		// TODO: Probably we'll want to track account tokens usage through an account identifier at some point
+		const userId = this.props.type === 'user_token' ? this.props.user.id : undefined
+
 		this.server = new CloudflareMCPServer({
-			userId: this.props.user.id,
+			userId,
 			wae: this.env.MCP_METRICS,
 			serverInfo: {
 				name: this.env.MCP_SERVER_NAME,
@@ -78,6 +81,10 @@ export class WorkersBindingsMCP extends McpAgent<Env, WorkersBindingsMCPState, P
 
 	async getActiveAccountId() {
 		try {
+			// account tokens are scoped to one account
+			if (this.props.type === 'account_token') {
+				return this.props.account.id
+			}
 			// Get UserDetails Durable Object based off the userId and retrieve the activeAccountId from it
 			// we do this so we can persist activeAccountId across sessions
 			const userDetails = getUserDetails(env, this.props.user.id)
@@ -90,6 +97,10 @@ export class WorkersBindingsMCP extends McpAgent<Env, WorkersBindingsMCPState, P
 
 	async setActiveAccountId(accountId: string) {
 		try {
+			// account tokens are scoped to one account
+			if (this.props.type === 'account_token') {
+				return
+			}
 			const userDetails = getUserDetails(env, this.props.user.id)
 			await userDetails.setActiveAccountId(accountId)
 		} catch (e) {

--- a/apps/workers-builds/src/workers-builds.app.ts
+++ b/apps/workers-builds/src/workers-builds.app.ts
@@ -53,14 +53,21 @@ export class BuildsMCP extends McpAgent<Env, State, Props> {
 	}
 
 	async init() {
+		// TODO: Probably we'll want to track account tokens usage through an account identifier at some point
+		const userId = this.props.type === 'user_token' ? this.props.user.id : undefined
+		const sentry =
+			this.props.type === 'user_token'
+				? initSentryWithUser(env, this.ctx, this.props.user.id)
+				: undefined
+
 		this.server = new CloudflareMCPServer({
-			userId: this.props.user.id,
+			userId,
 			wae: this.env.MCP_METRICS,
 			serverInfo: {
 				name: this.env.MCP_SERVER_NAME,
 				version: this.env.MCP_SERVER_VERSION,
 			},
-			sentry: initSentryWithUser(env, this.ctx, this.props.user.id),
+			sentry,
 			options: {
 				instructions: fmt.trim(`
 					# Cloudflare Workers Builds Tool
@@ -88,6 +95,10 @@ export class BuildsMCP extends McpAgent<Env, State, Props> {
 
 	async getActiveAccountId() {
 		try {
+			// account tokens are scoped to one account
+			if (this.props.type === 'account_token') {
+				return this.props.account.id
+			}
 			// Get UserDetails Durable Object based off the userId and retrieve the activeAccountId from it
 			// we do this so we can persist activeAccountId across sessions
 			const userDetails = getUserDetails(env, this.props.user.id)
@@ -100,6 +111,10 @@ export class BuildsMCP extends McpAgent<Env, State, Props> {
 
 	async setActiveAccountId(accountId: string) {
 		try {
+			// account tokens are scoped to one account
+			if (this.props.type === 'account_token') {
+				return
+			}
 			const userDetails = getUserDetails(env, this.props.user.id)
 			await userDetails.setActiveAccountId(accountId)
 		} catch (e) {

--- a/packages/mcp-common/src/api-token-mode.ts
+++ b/packages/mcp-common/src/api-token-mode.ts
@@ -58,10 +58,23 @@ export async function handleApiTokenMode<
 	}
 
 	const { user, accounts } = await getUserAndAccounts(token, opts)
-	ctx.props = {
-		accessToken: token,
-		user,
-		accounts,
-	} as AuthProps
+
+	// If user is null, handle API token mode
+	if (user === null) {
+		ctx.props = {
+			type: 'account_token',
+			accessToken: token,
+			// we always select the first account from the response,
+			// this assumes that account owned tokens can only access one account
+			account: accounts[0],
+		} satisfies AuthProps
+	} else {
+		ctx.props = {
+			type: 'user_token',
+			accessToken: token,
+			user,
+			accounts,
+		} satisfies AuthProps
+	}
 	return agent.mount('/sse').fetch(req, env, ctx)
 }

--- a/packages/mcp-common/src/types/cloudflare-mcp-agent.types.ts
+++ b/packages/mcp-common/src/types/cloudflare-mcp-agent.types.ts
@@ -1,16 +1,11 @@
 import { type McpAgent } from 'agents/mcp'
 
-import { type AccountSchema, type UserSchema } from '../cloudflare-oauth-handler'
-
+import type { AuthProps } from '../cloudflare-oauth-handler'
 import type { CloudflareMCPServer } from '../server'
 
 export type CloudflareMCPAgentState = { activeAccountId: string | null }
 
-export type CloudflareMCPAgentProps = {
-	accessToken: string
-	user: UserSchema['result']
-	accounts: AccountSchema['result']
-}
+export type CloudflareMCPAgentProps = AuthProps
 
 // We omit server in this type, so that we can later use our own CloudflareMCPServer type ( which extends McpServer )
 type McpAgentWithoutServer<EnvType = unknown> = Omit<


### PR DESCRIPTION
#176 

This refactors our auth logic so that we can now support account-owned tokens, which aren't associated with a particular user.