### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ Model Context Protocol (MCP) is a [new, standardized protocol](https://modelcont
 
 These MCP servers allow your [MCP Client](https://modelcontextprotocol.io/clients) to read configurations from your account, process information, make suggestions based on data, and even make those suggested changes for you. All of these actions can happen across Cloudflare's many services including application development, security and performance.
 
+<a href="https://glama.ai/mcp/servers/@cloudflare/mcp-server-cloudflare">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@cloudflare/mcp-server-cloudflare/badge" alt="mcp-server-cloudflare MCP server" />
+</a>
+
 The following servers are included in this repository:
 
 | Server Name                                                    | Description                                                                                     | Server URL                                     |


### PR DESCRIPTION
This PR adds a badge for the [mcp-server-cloudflare](https://glama.ai/mcp/servers/@cloudflare/mcp-server-cloudflare) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@cloudflare/mcp-server-cloudflare">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@cloudflare/mcp-server-cloudflare/badge" alt="mcp-server-cloudflare MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.