### PR TITLE
feat: update mcp urls to use /mcp from sse

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,27 +2,29 @@
 
 Model Context Protocol (MCP) is a [new, standardized protocol](https://modelcontextprotocol.io/introduction) for managing context between large language models (LLMs) and external systems. In this repository, you can find several MCP servers allowing you to connect to Cloudflare's service from an MCP client (e.g. Cursor, Claude) and use natural language to accomplish tasks through your Cloudflare account.
 
-These MCP servers allow your [MCP Client](https://modelcontextprotocol.io/clients) to read configurations from your account, process information, make suggestions based on data, and even make those suggested changes for you. All of these actions can happen across Cloudflare's many services including application development, security and performance.
+These MCP servers allow your [MCP Client](https://modelcontextprotocol.io/clients) to read configurations from your account, process information, make suggestions based on data, and even make those suggested changes for you. All of these actions can happen across Cloudflare's many services including application development, security and performance. 
+
+They support both the `streamble-http` transport via `/mcp` and the `sse` transport (deprecated) via `/sse`.
 
 The following servers are included in this repository:
 
 | Server Name                                                    | Description                                                                                     | Server URL                                     |
 | -------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- | ---------------------------------------------- |
-| [**Documentation server**](/apps/docs-vectorize)               | Get up to date reference information on Cloudflare                                              | `https://docs.mcp.cloudflare.com/sse`          |
-| [**Workers Bindings server**](/apps/workers-bindings)          | Build Workers applications with storage, AI, and compute primitives                             | `https://bindings.mcp.cloudflare.com/sse`      |
-| [**Workers Builds server**](/apps/workers-builds)              | Get insights and manage your Cloudflare Workers Builds                                          | `https://builds.mcp.cloudflare.com/sse`        |
-| [**Observability server**](/apps/workers-observability)        | Debug and get insight into your application's logs and analytics                                | `https://observability.mcp.cloudflare.com/sse` |
-| [**Radar server**](/apps/radar)                                | Get global Internet traffic insights, trends, URL scans, and other utilities                    | `https://radar.mcp.cloudflare.com/sse`         |
-| [**Container server**](/apps/sandbox-container)                | Spin up a sandbox development environment                                                       | `https://containers.mcp.cloudflare.com/sse`    |
-| [**Browser rendering server**](/apps/browser-rendering)        | Fetch web pages, convert them to markdown and take screenshots                                  | `https://browser.mcp.cloudflare.com/sse`       |
-| [**Logpush server**](/apps/logpush)                            | Get quick summaries for Logpush job health                                                      | `https://logs.mcp.cloudflare.com/sse`          |
-| [**AI Gateway server**](/apps/ai-gateway)                      | Search your logs, get details about the prompts and responses                                   | `https://ai-gateway.mcp.cloudflare.com/sse`    |
-| [**AutoRAG server**](/apps/autorag)                            | List and search documents on your AutoRAGs                                                      | `https://autorag.mcp.cloudflare.com/sse`       |
-| [**Audit Logs server**](/apps/auditlogs)                       | Query audit logs and generate reports for review                                                | `https://auditlogs.mcp.cloudflare.com/sse`     |
-| [**DNS Analytics server**](/apps/dns-analytics)                | Optimize DNS performance and debug issues based on current set up                               | `https://dns-analytics.mcp.cloudflare.com/sse` |
-| [**Digital Experience Monitoring server**](/apps/dex-analysis) | Get quick insight on critical applications for your organization                                | `https://dex.mcp.cloudflare.com/sse`           |
-| [**Cloudflare One CASB server**](/apps/cloudflare-one-casb)    | Quickly identify any security misconfigurations for SaaS applications to safeguard users & data | `https://casb.mcp.cloudflare.com/sse`          |
-| [**GraphQL server**](/apps/graphql/)                           | Get analytics data using Cloudflare’s GraphQL API                                               | `https://graphql.mcp.cloudflare.com/sse`       |
+| [**Documentation server**](/apps/docs-vectorize)               | Get up to date reference information on Cloudflare                                              | `https://docs.mcp.cloudflare.com/mcp`          |
+| [**Workers Bindings server**](/apps/workers-bindings)          | Build Workers applications with storage, AI, and compute primitives                             | `https://bindings.mcp.cloudflare.com/mcp`      |
+| [**Workers Builds server**](/apps/workers-builds)              | Get insights and manage your Cloudflare Workers Builds                                          | `https://builds.mcp.cloudflare.com/mcp`        |
+| [**Observability server**](/apps/workers-observability)        | Debug and get insight into your application's logs and analytics                                | `https://observability.mcp.cloudflare.com/mcp` |
+| [**Radar server**](/apps/radar)                                | Get global Internet traffic insights, trends, URL scans, and other utilities                    | `https://radar.mcp.cloudflare.com/mcp`         |
+| [**Container server**](/apps/sandbox-container)                | Spin up a sandbox development environment                                                       | `https://containers.mcp.cloudflare.com/mcp`    |
+| [**Browser rendering server**](/apps/browser-rendering)        | Fetch web pages, convert them to markdown and take screenshots                                  | `https://browser.mcp.cloudflare.com/mcp`       |
+| [**Logpush server**](/apps/logpush)                            | Get quick summaries for Logpush job health                                                      | `https://logs.mcp.cloudflare.com/mcp`          |
+| [**AI Gateway server**](/apps/ai-gateway)                      | Search your logs, get details about the prompts and responses                                   | `https://ai-gateway.mcp.cloudflare.com/mcp`    |
+| [**AutoRAG server**](/apps/autorag)                            | List and search documents on your AutoRAGs                                                      | `https://autorag.mcp.cloudflare.com/mcp`       |
+| [**Audit Logs server**](/apps/auditlogs)                       | Query audit logs and generate reports for review                                                | `https://auditlogs.mcp.cloudflare.com/mcp`     |
+| [**DNS Analytics server**](/apps/dns-analytics)                | Optimize DNS performance and debug issues based on current set up                               | `https://dns-analytics.mcp.cloudflare.com/mcp` |
+| [**Digital Experience Monitoring server**](/apps/dex-analysis) | Get quick insight on critical applications for your organization                                | `https://dex.mcp.cloudflare.com/mcp`           |
+| [**Cloudflare One CASB server**](/apps/cloudflare-one-casb)    | Quickly identify any security misconfigurations for SaaS applications to safeguard users & data | `https://casb.mcp.cloudflare.com/mcp`          |
+| [**GraphQL server**](/apps/graphql/)                           | Get analytics data using Cloudflare’s GraphQL API                                               | `https://graphql.mcp.cloudflare.com/mcp`       |
 
 ## Access the remote MCP server from any MCP client
 
@@ -35,11 +37,11 @@ If your client does not yet support remote MCP servers, you will need to set up 
 	"mcpServers": {
 		"cloudflare-observability": {
 			"command": "npx",
-			"args": ["mcp-remote", "https://observability.mcp.cloudflare.com/sse"]
+			"args": ["mcp-remote", "https://observability.mcp.cloudflare.com/mcp"]
 		},
 		"cloudflare-bindings": {
 			"command": "npx",
-			"args": ["mcp-remote", "https://bindings.mcp.cloudflare.com/sse"]
+			"args": ["mcp-remote", "https://bindings.mcp.cloudflare.com/mcp"]
 		}
 	}
 }

--- a/apps/ai-gateway/CONTRIBUTING.md
+++ b/apps/ai-gateway/CONTRIBUTING.md
@@ -27,7 +27,7 @@ If you'd like to iterate and test your MCP server, you can do so in local develo
    npx wrangler dev
    ```
 
-3. To test locally, open Inspector, and connect to `http://localhost:8976/sse`.
+3. To test locally, open Inspector, and connect to `http://localhost:8976/mcp`.
    Once you follow the prompts, you'll be able to "List Tools". You can also connect with any MCP client.
 
 ## Deploying the Worker ( Cloudflare employees only )

--- a/apps/ai-gateway/README.md
+++ b/apps/ai-gateway/README.md
@@ -41,7 +41,7 @@ Replace the content with the following configuration:
 	"mcpServers": {
 		"cloudflare": {
 			"command": "npx",
-			"args": ["mcp-remote", "https://ai-gateway.mcp.cloudflare.com/sse"]
+			"args": ["mcp-remote", "https://ai-gateway.mcp.cloudflare.com/mcp"]
 		}
 	}
 }

--- a/apps/auditlogs/README.md
+++ b/apps/auditlogs/README.md
@@ -20,7 +20,7 @@ Currently available tools:
 
 ## Access the remote MCP server from any MCP Client
 
-If your MCP client has first class support for remote MCP servers, the client will provide a way to accept the server URL (`https://auditlogs.mcp.cloudflare.com/sse`) directly within its interface (for example in [Cloudflare AI Playground](https://playground.ai.cloudflare.com/)).
+If your MCP client has first class support for remote MCP servers, the client will provide a way to accept the server URL (`https://auditlogs.mcp.cloudflare.com/mcp`) directly within its interface (for example in [Cloudflare AI Playground](https://playground.ai.cloudflare.com/)).
 
 If your client does not yet support remote MCP servers, you will need to set up its respective configuration file using [mcp-remote](https://www.npmjs.com/package/mcp-remote) to specify which servers your client can access.
 
@@ -31,7 +31,7 @@ Replace the content with the following configuration:
 	"mcpServers": {
 		"cloudflare": {
 			"command": "npx",
-			"args": ["mcp-remote", "https://auditlogs.mcp.cloudflare.com/sse"]
+			"args": ["mcp-remote", "https://auditlogs.mcp.cloudflare.com/mcp"]
 		}
 	}
 }

--- a/apps/autorag/CONTRIBUTING.md
+++ b/apps/autorag/CONTRIBUTING.md
@@ -27,7 +27,7 @@ If you'd like to iterate and test your MCP server, you can do so in local develo
    npx wrangler dev
    ```
 
-3. To test locally, open Inspector, and connect to `http://localhost:8976/sse`.
+3. To test locally, open Inspector, and connect to `http://localhost:8976/mcp`.
    Once you follow the prompts, you'll be able to "List Tools". You can also connect with any MCP client.
 
 ## Deploying the Worker ( Cloudflare employees only )

--- a/apps/autorag/README.md
+++ b/apps/autorag/README.md
@@ -36,7 +36,7 @@ Replace the content with the following configuration:
 	"mcpServers": {
 		"cloudflare": {
 			"command": "npx",
-			"args": ["mcp-remote", "https://autorag.mcp.cloudflare.com/sse"]
+			"args": ["mcp-remote", "https://autorag.mcp.cloudflare.com/mcp"]
 		}
 	}
 }

--- a/apps/browser-rendering/CONTRIBUTING.md
+++ b/apps/browser-rendering/CONTRIBUTING.md
@@ -27,7 +27,7 @@ If you'd like to iterate and test your MCP server, you can do so in local develo
    npx wrangler dev
    ```
 
-3. To test locally, open Inspector, and connect to `http://localhost:8976/sse`.
+3. To test locally, open Inspector, and connect to `http://localhost:8976/mcp`.
    Once you follow the prompts, you'll be able to "List Tools". You can also connect with any MCP client.
 
 ## Deploying the Worker ( Cloudflare employees only )

--- a/apps/browser-rendering/README.md
+++ b/apps/browser-rendering/README.md
@@ -39,7 +39,7 @@ Replace the content with the following configuration:
 	"mcpServers": {
 		"cloudflare": {
 			"command": "npx",
-			"args": ["mcp-remote", "https://browser.mcp.cloudflare.com/sse"]
+			"args": ["mcp-remote", "https://browser.mcp.cloudflare.com/mcp"]
 		}
 	}
 }

--- a/apps/dex-analysis/README.md
+++ b/apps/dex-analysis/README.md
@@ -56,7 +56,7 @@ Replace the content with the following configuration:
 	"mcpServers": {
 		"cloudflare": {
 			"command": "npx",
-			"args": ["mcp-remote", "https://dex.mcp.cloudflare.com/sse"]
+			"args": ["mcp-remote", "https://dex.mcp.cloudflare.com/mcp"]
 		}
 	}
 }

--- a/apps/dns-analytics/CONTRIBUTING.md
+++ b/apps/dns-analytics/CONTRIBUTING.md
@@ -29,7 +29,7 @@ If you'd like to iterate and test your MCP server, you can do so in local develo
    npx wrangler dev
    ```
 
-3. To test locally, open Inspector, and connect to `http://localhost:8976/sse`.
+3. To test locally, open Inspector, and connect to `http://localhost:8976/mcp`.
    Once you follow the prompts, you'll be able to "List Tools". You can also connect with any MCP client.
 
 ## Deploying the Worker ( Cloudflare employees only )

--- a/apps/dns-analytics/README.md
+++ b/apps/dns-analytics/README.md
@@ -41,7 +41,7 @@ Replace the content with the following configuration:
 	"mcpServers": {
 		"cloudflare": {
 			"command": "npx",
-			"args": ["mcp-remote", "https://dns-analytics.mcp.cloudflare.com/sse"]
+			"args": ["mcp-remote", "https://dns-analytics.mcp.cloudflare.com/mcp"]
 		}
 	}
 }

--- a/apps/docs-autorag/README.md
+++ b/apps/docs-autorag/README.md
@@ -12,7 +12,7 @@ The Cloudflare account this worker is deployed on already has this Autorag insta
 pnpm run start
 ```
 
-Then connect to the server via remote MCP at `http://localhost:8976/sse`
+Then connect to the server via remote MCP at `http://localhost:8976/mcp`
 
 ## Deploying
 

--- a/apps/docs-vectorize/README.md
+++ b/apps/docs-vectorize/README.md
@@ -31,7 +31,7 @@ Replace the content with the following configuration:
 	"mcpServers": {
 		"cloudflare": {
 			"command": "npx",
-			"args": ["mcp-remote", "https://docs.mcp.cloudflare.com/sse"]
+			"args": ["mcp-remote", "https://docs.mcp.cloudflare.com/mcp"]
 		}
 	}
 }

--- a/apps/graphql/README.md
+++ b/apps/graphql/README.md
@@ -25,7 +25,7 @@ Currently available tools:
 
 ## Access the remote MCP server from Claude Desktop
 
-If your MCP client has first class support for remote MCP servers, the client will provide a way to accept the server URL (`https://graphql.mcp.cloudflare.com/sse`) directly within its interface (for example in [Cloudflare AI Playground](https://playground.ai.cloudflare.com/)).
+If your MCP client has first class support for remote MCP servers, the client will provide a way to accept the server URL (`https://graphql.mcp.cloudflare.com/mcp`) directly within its interface (for example in [Cloudflare AI Playground](https://playground.ai.cloudflare.com/)).
 
 If your client does not yet support remote MCP servers, you will need to set up its respective configuration file using [mcp-remote](https://www.npmjs.com/package/mcp-remote) to specify which servers your client can access.
 
@@ -36,7 +36,7 @@ Replace the content with the following configuration:
 	"mcpServers": {
 		"cloudflare": {
 			"command": "npx",
-			"args": ["mcp-remote", "https://graphql.mcp.cloudflare.com/sse"]
+			"args": ["mcp-remote", "https://graphql.mcp.cloudflare.com/mcp"]
 		}
 	}
 }

--- a/apps/logpush/README.md
+++ b/apps/logpush/README.md
@@ -34,7 +34,7 @@ Replace the content with the following configuration:
 	"mcpServers": {
 		"cloudflare": {
 			"command": "npx",
-			"args": ["mcp-remote", "https://logs.mcp.cloudflare.com/sse"]
+			"args": ["mcp-remote", "https://logs.mcp.cloudflare.com/mcp"]
 		}
 	}
 }

--- a/apps/radar/CONTRIBUTING.md
+++ b/apps/radar/CONTRIBUTING.md
@@ -28,7 +28,7 @@ If you'd like to iterate and test your MCP server, you can do so in local develo
    npx wrangler dev
    ```
 
-3. To test locally, open Inspector, and connect to `http://localhost:8976/sse`.
+3. To test locally, open Inspector, and connect to `http://localhost:8976/mcp`.
    Once you follow the prompts, you'll be able to "List Tools". You can also connect with any MCP client.
 
 ## Deploying the Worker ( Cloudflare employees only )

--- a/apps/radar/README.md
+++ b/apps/radar/README.md
@@ -58,7 +58,7 @@ Replace the content with the following configuration:
 	"mcpServers": {
 		"cloudflare": {
 			"command": "npx",
-			"args": ["mcp-remote", "https://radar.mcp.cloudflare.com/sse"]
+			"args": ["mcp-remote", "https://radar.mcp.cloudflare.com/mcp"]
 		}
 	}
 }

--- a/apps/sandbox-container/CONTRIBUTING.md
+++ b/apps/sandbox-container/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Do the following from within the sandbox-container app:
 2. Get the Cloudflare client id and secret from a team member and add them to the `.dev.vars` file.
 3. Run `pnpm i` then `pnpm dev` to start the MCP server.
 4. Run `pnpx @modelcontextprotocol/inspector` to start the MCP inspector client.
-5. Open the inspector client in your browser and connect to the server via `http://localhost:8976/sse`.
+5. Open the inspector client in your browser and connect to the server via `http://localhost:8976/mcp`.
 
 Note: Temporary files created through files tool calls are stored in the workdir folder of this app.
 
@@ -36,7 +36,7 @@ npx https://prerelease-registry.devprod.cloudflare.dev/workers-sdk/runs/14387504
             "args": [
                 "mcp-remote",
                 // this is my deployed instance
-                "https://container-starter-2.cmsparks.workers.dev/sse"
+                "https://container-starter-2.cmsparks.workers.dev/mcp"
             ]
         }
     }

--- a/apps/sandbox-container/README.md
+++ b/apps/sandbox-container/README.md
@@ -37,7 +37,7 @@ Replace the content with the following configuration:
 	"mcpServers": {
 		"cloudflare": {
 			"command": "npx",
-			"args": ["mcp-remote", "https://containers.mcp.cloudflare.com/sse"]
+			"args": ["mcp-remote", "https://containers.mcp.cloudflare.com/mcp"]
 		}
 	}
 }

--- a/apps/workers-bindings/CONTRIBUTING.md
+++ b/apps/workers-bindings/CONTRIBUTING.md
@@ -28,7 +28,7 @@ If you'd like to iterate and test your MCP server, you can do so in local develo
    npx wrangler dev
    ```
 
-3. To test locally, open Inspector, and connect to `http://localhost:8976/sse`.
+3. To test locally, open Inspector, and connect to `http://localhost:8976/mcp`.
    Once you follow the prompts, you'll be able to "List Tools". You can also connect with any MCP client.
 
 ## Deploying the Worker ( Cloudflare employees only )

--- a/apps/workers-bindings/README.md
+++ b/apps/workers-bindings/README.md
@@ -76,7 +76,7 @@ Replace the content with the following configuration:
 	"mcpServers": {
 		"cloudflare": {
 			"command": "npx",
-			"args": ["mcp-remote", "https://bindings.mcp.cloudflare.com/sse"]
+			"args": ["mcp-remote", "https://bindings.mcp.cloudflare.com/mcp"]
 		}
 	}
 }

--- a/apps/workers-builds/CONTRIBUTING.md
+++ b/apps/workers-builds/CONTRIBUTING.md
@@ -28,7 +28,7 @@ If you'd like to iterate and test your MCP server, you can do so in local develo
 pnpm dev
 ```
 
-3. To test locally, open Inspector, and connect to `http://localhost:8976/sse`.
+3. To test locally, open Inspector, and connect to `http://localhost:8976/mcp`.
    Once you follow the prompts, you'll be able to "List Tools". You can also connect with any MCP client.
 
 ## Deploying the Worker ( Cloudflare employees only )

--- a/apps/workers-builds/README.md
+++ b/apps/workers-builds/README.md
@@ -39,7 +39,7 @@ Replace the content with the following configuration:
 	"mcpServers": {
 		"cloudflare": {
 			"command": "npx",
-			"args": ["mcp-remote@latest", "https://builds.mcp.cloudflare.com/sse"]
+			"args": ["mcp-remote@latest", "https://builds.mcp.cloudflare.com/mcp"]
 		}
 	}
 }

--- a/apps/workers-observability/CONTRIBUTING.md
+++ b/apps/workers-observability/CONTRIBUTING.md
@@ -28,7 +28,7 @@ If you'd like to iterate and test your MCP server, you can do so in local develo
    npx wrangler dev
    ```
 
-3. To test locally, open Inspector, and connect to `http://localhost:8976/sse`.
+3. To test locally, open Inspector, and connect to `http://localhost:8976/mcp`.
    Once you follow the prompts, you'll be able to "List Tools". You can also connect with any MCP client.
 
 ## Deploying the Worker ( Cloudflare employees only )

--- a/apps/workers-observability/README.md
+++ b/apps/workers-observability/README.md
@@ -39,7 +39,7 @@ Replace the content with the following configuration:
 	"mcpServers": {
 		"cloudflare": {
 			"command": "npx",
-			"args": ["mcp-remote", "https://observability.mcp.cloudflare.com/sse"]
+			"args": ["mcp-remote", "https://observability.mcp.cloudflare.com/mcp"]
 		}
 	}
 }


### PR DESCRIPTION
It is hard to know we even support /mcp without looking at the code for these servers. The SSE transport is flaky and deprecated and we should remove references to it over time.

Matching PR in the docs repo: https://github.com/cloudflare/cloudflare-docs/pull/25815