### PR TITLE
Move docs-vectorize MCP server to be stateless

### DIFF
--- a/.changeset/cold-teeth-repeat.md
+++ b/.changeset/cold-teeth-repeat.md
@@ -1,0 +1,5 @@
+---
+'docs-vectorize': minor
+---
+
+Moved Docs MCP server to be stateless for /mcp

--- a/apps/docs-vectorize/wrangler.jsonc
+++ b/apps/docs-vectorize/wrangler.jsonc
@@ -8,6 +8,7 @@
 	"compatibility_date": "2025-03-10",
 	"compatibility_flags": ["nodejs_compat"],
 	"name": "mcp-cloudflare-docs-vectorize-dev",
+	"minify": true,
 	"migrations": [
 		{
 			"new_sqlite_classes": ["CloudflareDocumentationMCP"],

--- a/apps/workers-bindings/src/bindings.app.ts
+++ b/apps/workers-bindings/src/bindings.app.ts
@@ -83,8 +83,8 @@ export class WorkersBindingsMCP extends McpAgent<Env, WorkersBindingsMCPState, P
 		registerHyperdriveTools(this)
 
 		// Add docs tools
-		registerDocsTools(this, this.env)
-		registerPrompts(this)
+		registerDocsTools(this.server, this.env)
+		registerPrompts(this.server)
 	}
 
 	async getActiveAccountId() {

--- a/apps/workers-observability/src/workers-observability.app.ts
+++ b/apps/workers-observability/src/workers-observability.app.ts
@@ -87,8 +87,8 @@ export class ObservabilityMCP extends McpAgent<Env, State, Props> {
 		registerObservabilityTools(this)
 
 		// Add docs tools
-		registerDocsTools(this, this.env)
-		registerPrompts(this)
+		registerDocsTools(this.server, this.env)
+		registerPrompts(this.server)
 	}
 
 	async getActiveAccountId() {

--- a/packages/mcp-common/src/prompts/docs-vectorize.prompts.ts
+++ b/packages/mcp-common/src/prompts/docs-vectorize.prompts.ts
@@ -1,11 +1,11 @@
-import type { CloudflareMcpAgentNoAccount } from '../types/cloudflare-mcp-agent.types'
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 
 /**
  * Registers developer-platform-related prompts with the MCP server
- * @param agent The MCP server instance
+ * @param server The MCP server instance
  */
-export function registerPrompts(agent: CloudflareMcpAgentNoAccount) {
-	agent.server.prompt(
+export function registerPrompts(server: McpServer) {
+	server.prompt(
 		'workers-prompt-full',
 		'Detailed prompt for generating Cloudflare Workers code (and other developer platform products) from https://developers.cloudflare.com/workers/prompt.txt',
 		async () => ({

--- a/packages/mcp-common/src/tools/docs-vectorize.tools.ts
+++ b/packages/mcp-common/src/tools/docs-vectorize.tools.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 
-import type { CloudflareMcpAgentNoAccount } from '../types/cloudflare-mcp-agent.types'
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 
 interface RequiredEnv {
 	AI: Ai
@@ -12,10 +12,10 @@ const TOP_K = 10
 
 /**
  * Registers the docs search tool with the MCP server
- * @param agent The MCP server instance
+ * @param server The MCP server instance
  */
-export function registerDocsTools(agent: CloudflareMcpAgentNoAccount, env: RequiredEnv) {
-	agent.server.tool(
+export function registerDocsTools(server: McpServer, env: RequiredEnv) {
+	server.tool(
 		'search_cloudflare_documentation',
 		`Search the Cloudflare documentation.
 
@@ -57,7 +57,7 @@ ${result.text}
 
 	// Note: this is a tool instead of a prompt because
 	// prompt support is much less common than tools.
-	agent.server.tool(
+	server.tool(
 		'migrate_pages_to_workers_guide',
 		`ALWAYS read this guide before migrating Pages projects to Workers.`,
 		{},


### PR DESCRIPTION
Still keeping the old serving method on /sse – but for /mcp it no longer has a DO as a bottleneck.
