### PR TITLE
Fix: use blob field for binary resources in sandbox container

### DIFF
--- a/apps/sandbox-container/server/containerMcp.ts
+++ b/apps/sandbox-container/server/containerMcp.ts
@@ -165,7 +165,10 @@ export class ContainerMcpAgent extends McpAgent<Env, never, Props> {
 						{
 							type: 'resource',
 							resource: {
-								text: readFile.type === 'text' ? readFile.textOutput : readFile.base64Output,
+								...(readFile.type === 'text' 
+									? { text: readFile.textOutput }
+									: { blob: readFile.base64Output }
+								),
 								uri: `file://${path}`,
 								mimeType: readFile.mimeType,
 							},


### PR DESCRIPTION
Binary content (images, etc.) in `container_file_read` tool was using the `text` field, causing MCP hosts like Claude Desktop to display base64-encoded strings as both text message and image content in the conversation, which floods the context window with meaningless data.

This PR changed `container_file_read` to use the `blob` field for binary data instead of `text` field, in compliance with the MCP 2025-06-18 specification for resource contents.

Per MCP spec:
- [Text Content](https://modelcontextprotocol.io/specification/2025-06-18/server/resources#text-content): uses `text` field
- [Binary Content](https://modelcontextprotocol.io/specification/2025-06-18/server/resources#binary-content): uses `blob` field
