### PR TITLE
feat(radar): add BGP IP space timeseries and real-time routes tools

### DIFF
--- a/apps/radar/README.md
+++ b/apps/radar/README.md
@@ -28,6 +28,8 @@ Currently available tools:
 |                              | `get_bgp_top_prefixes`              | Gets top IP prefixes by BGP update count                                                                             |
 |                              | `get_bgp_moas`                      | Gets Multi-Origin AS (MOAS) prefixes                                                                                 |
 |                              | `get_bgp_pfx2as`                    | Gets prefix-to-ASN mapping                                                                                           |
+|                              | `get_bgp_ip_space_timeseries`       | Retrieves announced IP address space over time (IPv4 /24s and IPv6 /48s) - useful for detecting route withdrawals    |
+|                              | `get_bgp_routes_realtime`           | Gets real-time BGP routes for a prefix using RouteViews and RIPE RIS collectors                                      |
 | **Bots**                     | `get_bots_data`                     | Retrieves bot traffic data by name, operator, category (AI crawlers, search engines, etc.)                           |
 |                              | `list_bots`                         | Lists known bots with details (AI crawlers, search engines, monitoring bots)                                         |
 |                              | `get_bot_details`                   | Gets detailed information about a specific bot by slug                                                               |
@@ -82,6 +84,10 @@ Currently available tools:
 - `Show me recent BGP hijack events.`
 - `Which prefixes have the most BGP updates?`
 - `What AS announces the prefix 1.1.1.0/24?`
+- `Show me IPv6 announced address space for Portugal over the last 30 days.`
+- `Compare IPv4 vs IPv6 BGP address space trends for AS13335.`
+- `Get real-time BGP routes for prefix 1.1.1.0/24.`
+- `Monitor announced IPv6 space changes for a specific country to detect route withdrawals.`
 
 **Security & Attacks**
 

--- a/apps/radar/src/tools/radar.tools.ts
+++ b/apps/radar/src/tools/radar.tools.ts
@@ -22,6 +22,7 @@ import {
 	BgpInvalidOnlyParam,
 	BgpInvolvedAsnParam,
 	BgpInvolvedCountryParam,
+	BgpIpVersionParam,
 	BgpLeakAsnParam,
 	BgpLongestPrefixMatchParam,
 	BgpMaxConfidenceParam,
@@ -2391,6 +2392,84 @@ export function registerRadarTools(agent: RadarMCP) {
 						{
 							type: 'text' as const,
 							text: `Error getting BGP pfx2as: ${error instanceof Error ? error.message : String(error)}`,
+						},
+					],
+				}
+			}
+		}
+	)
+
+	agent.server.tool(
+		'get_bgp_ip_space_timeseries',
+		'Retrieve announced IP address space time series data. Shows the count of announced IPv4 /24s and IPv6 /48s over time. Essential for monitoring BGP route withdrawals, IPv6 address space changes, and detecting significant routing events by ASN or country.',
+		{
+			dateRange: DateRangeArrayParam.optional(),
+			dateStart: DateStartArrayParam.optional(),
+			dateEnd: DateEndArrayParam.optional(),
+			asn: AsnArrayParam,
+			location: LocationArrayParam,
+			ipVersion: BgpIpVersionParam,
+		},
+		async ({ dateRange, dateStart, dateEnd, asn, location, ipVersion }) => {
+			try {
+				const props = getProps(agent)
+				const result = await fetchRadarApi(props.accessToken, '/bgp/ips/timeseries', {
+					dateRange,
+					dateStart,
+					dateEnd,
+					asn,
+					location,
+					ipVersion,
+				})
+
+				return {
+					content: [
+						{
+							type: 'text' as const,
+							text: JSON.stringify({ result }),
+						},
+					],
+				}
+			} catch (error) {
+				return {
+					content: [
+						{
+							type: 'text' as const,
+							text: `Error getting BGP IP space timeseries: ${error instanceof Error ? error.message : String(error)}`,
+						},
+					],
+				}
+			}
+		}
+	)
+
+	agent.server.tool(
+		'get_bgp_routes_realtime',
+		'Get real-time BGP routes for a specific IP prefix using public route collectors (RouteViews and RIPE RIS). Shows current routing state including AS paths, RPKI validation status, and visibility across peers. Useful for troubleshooting routing issues and verifying route announcements.',
+		{
+			prefix: BgpPrefixParam,
+		},
+		async ({ prefix }) => {
+			try {
+				const props = getProps(agent)
+				const result = await fetchRadarApi(props.accessToken, '/bgp/routes/realtime', {
+					prefix,
+				})
+
+				return {
+					content: [
+						{
+							type: 'text' as const,
+							text: JSON.stringify({ result }),
+						},
+					],
+				}
+			} catch (error) {
+				return {
+					content: [
+						{
+							type: 'text' as const,
+							text: `Error getting real-time BGP routes: ${error instanceof Error ? error.message : String(error)}`,
 						},
 					],
 				}

--- a/apps/radar/src/types/radar.ts
+++ b/apps/radar/src/types/radar.ts
@@ -852,6 +852,13 @@ export const BgpInvalidOnlyParam = z
 	.optional()
 	.describe('Only return invalid MOAS prefixes.')
 
+export const BgpIpVersionParam = z
+	.array(z.enum(['IPv4', 'IPv6']))
+	.optional()
+	.describe(
+		'Filters results by IP version (IPv4 vs. IPv6). Useful for monitoring IPv6 address space specifically.'
+	)
+
 // ============================================================
 // Geolocation Parameters
 // ============================================================


### PR DESCRIPTION
## Summary

This PR adds two new BGP tools to the Radar MCP server that address gaps in IPv6 address space monitoring and real-time route visibility:

- **`get_bgp_ip_space_timeseries`**: Retrieves announced IP address space over time (IPv4 /24s and IPv6 /48s)
- **`get_bgp_routes_realtime`**: Gets real-time BGP routes for a prefix using RouteViews and RIPE RIS collectors

## Motivation

The existing BGP tools (`get_bgp_route_stats`, `get_bgp_hijacks`, etc.) provide point-in-time statistics and event detection, but were missing:

1. **Real-time IPv6 address space monitoring** - Ability to track announced IPv6 /48s over time by country or ASN
2. **Proactive BGP route withdrawal detection** - See address space changes that indicate route withdrawals before they trigger anomaly detection
3. **Real-time route visibility** - Check current routing state for a prefix across public route collectors

## Changes

### New Tools

| Tool                          | Endpoint               | Description                                                                           |
| ----------------------------- | ---------------------- | ------------------------------------------------------------------------------------- |
| `get_bgp_ip_space_timeseries` | `/bgp/ips/timeseries`  | Time series of announced IPv4 /24s and IPv6 /48s. Filter by ASN, location, IP version |
| `get_bgp_routes_realtime`     | `/bgp/routes/realtime` | Real-time BGP routes showing AS paths, RPKI validation, peer visibility               |

### New Parameters

- `BgpIpVersionParam`: Filter by `IPv4` or `IPv6` for IP space timeseries

### Documentation

- Added both tools to the README tools table
- Added example prompts for IPv6 monitoring use cases