### PR TITLE
feat(radar): add new tools, bug fixes, and improve README prompts

### DIFF
--- a/apps/radar/README.md
+++ b/apps/radar/README.md
@@ -15,7 +15,9 @@ Currently available tools:
 | **AI**                                  | `get_ai_data`                       | Retrieves AI-related data, including traffic from AI user agents, as well as popular models and model tasks          |
 | **Events, Outages & Traffic Anomalies** | `get_annotations`                   | Retrieves annotations including Internet events, outages, and anomalies from various Cloudflare data sources         |
 |                                         | `get_outages`                       | Retrieves Internet outages and anomalies with detected connectivity issues                                           |
+|                                         | `get_outages_by_location`           | Gets outage counts aggregated by location - identify which countries have the most outages                           |
 |                                         | `get_traffic_anomalies`             | Lists traffic anomalies and outages; filter by AS, location, start date, and end date                                |
+|                                         | `get_traffic_anomalies_by_location` | Gets traffic anomalies aggregated by location - shows which countries have the most detected outage signals          |
 | **AS112**                               | `get_as112_data`                    | Retrieves AS112 DNS sink hole data for reverse DNS lookups of private IP addresses (RFC 1918)                        |
 | **Autonomous Systems**                  | `list_autonomous_systems`           | Lists ASes; filter by location and sort by population size                                                           |
 |                                         | `get_as_details`                    | Retrieves detailed info for a specific ASN                                                                           |
@@ -31,6 +33,8 @@ Currently available tools:
 |                                         | `get_bgp_pfx2as`                    | Gets prefix-to-ASN mapping                                                                                           |
 |                                         | `get_bgp_ip_space_timeseries`       | Retrieves announced IP address space over time (IPv4 /24s and IPv6 /48s) - useful for detecting route withdrawals    |
 |                                         | `get_bgp_routes_realtime`           | Gets real-time BGP routes for a prefix using RouteViews and RIPE RIS collectors                                      |
+|                                         | `get_bgp_routing_table_ases`        | Lists all ASes in global routing tables with routing statistics (prefix counts, RPKI status)                         |
+|                                         | `get_bgp_top_ases_by_prefixes`      | Gets top ASes ordered by announced prefix count - shows which networks have the largest routing footprint            |
 | **Bots**                                | `get_bots_data`                     | Retrieves bot traffic data by name, operator, category (AI crawlers, search engines, etc.)                           |
 |                                         | `list_bots`                         | Lists known bots with details (AI crawlers, search engines, monitoring bots)                                         |
 |                                         | `get_bot_details`                   | Gets detailed information about a specific bot by slug                                                               |
@@ -52,12 +56,13 @@ Currently available tools:
 | **Geolocations**                        | `list_geolocations`                 | Lists available geolocations (ADM1 - states/provinces) with GeoNames IDs                                             |
 |                                         | `get_geolocation_details`           | Gets details for a specific geolocation by GeoNames ID                                                               |
 | **HTTP**                                | `get_http_data`                     | Retrieves HTTP request data with geoId filtering for ADM1 (states/provinces)                                         |
-| **IP Addresses**                        | `get_ip_details`                    | Provides details about a specific IP address                                                                         |
+| **IP Addresses**                        | `get_ip_details`                    | Provides details about a specific IP address including full ASN details (name, country, population estimates)        |
 | **Internet Services**                   | `get_internet_services_ranking`     | Gets top Internet services                                                                                           |
+|                                         | `get_internet_services_timeseries`  | Tracks internet service ranking changes over time (e.g., how ChatGPT ranks over months)                              |
 | **Internet Quality & Speed**            | `get_internet_quality_data`         | Retrieves a summary or time series of bandwidth, latency, or DNS response time from the Radar Internet Quality Index |
 |                                         | `get_internet_speed_data`           | Retrieves summary of bandwidth, latency, jitter, and packet loss, from the previous 90 days of Cloudflare Speed Test |
 |                                         | `get_speed_histogram`               | Gets speed test histogram data showing distribution of results for bandwidth, latency, or jitter                     |
-| **Layer 3 Attacks**                     | `get_l3_attack_data`                | Retrieves L3 attack data, including timeseries, top attacks, and breakdowns by dimensions like `protocol`            |
+| **Layer 3 Attacks**                     | `get_l3_attack_data`                | Retrieves network layer (L3/DDoS) attack data, including timeseries, top attacks, and breakdowns by dimensions       |
 | **Layer 7 Attacks**                     | `get_l7_attack_data`                | Retrieves L7 attack data, including timeseries, top attacks, and breakdowns by dimensions like `mitigationProduct`   |
 | **Leaked Credentials**                  | `get_leaked_credentials_data`       | Retrieves trends in HTTP auth requests and compromised credential detection                                          |
 | **NetFlows**                            | `get_netflows_data`                 | Retrieves network traffic patterns with geoId filtering for ADM1 (states/provinces)                                  |
@@ -76,22 +81,26 @@ Currently available tools:
 **Traffic & Network Analysis**
 
 - `What are the most used operating systems?`
-- `Show me HTTP traffic trends from Lisbon, Portugal (use geoId).`
+- `Show me HTTP traffic trends from Lisbon, Portugal.`
 - `What is the TCP reset and timeout rate globally?`
 - `Show me network traffic patterns for California.`
+- `Compare HTTP traffic between mobile and desktop devices.`
+- `What percentage of traffic uses IPv6 vs IPv4?`
 
 **Autonomous Systems & BGP**
 
 - `What are the top 5 ASes in Portugal?`
 - `Get information about ASN 13335.`
 - `What are the relationships (peers, upstreams) for Cloudflare's AS?`
-- `Show me recent BGP hijack events.`
+- `Show me recent BGP hijack events with high confidence.`
 - `Which prefixes have the most BGP updates?`
 - `What AS announces the prefix 1.1.1.0/24?`
 - `Show me IPv6 announced address space for Portugal over the last 30 days.`
 - `Compare IPv4 vs IPv6 BGP address space trends for AS13335.`
 - `Get real-time BGP routes for prefix 1.1.1.0/24.`
-- `Monitor announced IPv6 space changes for a specific country to detect route withdrawals.`
+- `List the top ASes by prefix count in Germany.`
+- `Which ASes have the most IPv6 address space globally?`
+- `Show me BGP route leak events from the last week.`
 
 **Security & Attacks**
 
@@ -99,6 +108,7 @@ Currently available tools:
 - `What are the top L3 attack vectors?`
 - `Show me leaked credential detection trends.`
 - `Scan https://example.com for security analysis.`
+- `Which industries are most targeted by DDoS attacks?`
 
 **Bots & Crawlers**
 
@@ -106,62 +116,67 @@ Currently available tools:
 - `List all known AI crawler bots.`
 - `How are websites configuring robots.txt for AI crawlers?`
 - `What percentage of sites block vs allow AI crawlers?`
-- `Show me crawler traffic by industry vertical.`
+- `Show me crawler traffic by industry.`
 
-**DNS & Email**
+**DNS**
 
 - `What are the most common DNS query types to 1.1.1.1?`
-- `Show me AS112 DNS sink hole data by protocol.`
-- `What are the email security threat trends?`
+- `Show me AS112 DNS queries by protocol.`
+- `What is the DNSSEC adoption rate?`
+- `Show me DNS query trends by response code.`
 
-**Certificates & TLS**
+**Email**
+
+- `What are the email security threat trends?`
+- `Show me email routing data by encryption status.`
+- `What percentage of emails fail DMARC validation?`
+- `Which TLDs send the most malicious emails?`
+
+**Certificate Transparency**
 
 - `What are the most active Certificate Authorities?`
 - `List Certificate Transparency logs.`
 - `Show me certificate issuance trends by validation level.`
+- `Get details for the CT log argon2026h1.`
+- `What is the top Certificate Authority and show me its details.`
 
-**Rankings & Services**
+**Rankings & Internet Services**
 
 - `What are the top trending domains?`
 - `Compare domain rankings in the US and UK.`
-- `Give me rank details for google.com in March 2025.`
 - `What are the top Internet services in the E-commerce category?`
-- `Track how google.com and facebook.com rank over the last 30 days.`
+- `Track how google.com ranks over the last 30 days.`
+- `How has ChatGPT's ranking changed over the last 6 months?`
 
 **TLDs**
 
-- `List all generic TLDs.`
+- `List all country-code TLDs.`
 - `Show me details about the .io TLD.`
 - `Give me a ranking of TLDs based on DNS magnitude.`
 
 **Speed & Quality**
 
 - `Show me the bandwidth distribution histogram for the US.`
-- `What is the latency histogram for Portugal?`
-- `Compare speed test distributions across different regions.`
+- `What is the average latency in Portugal?`
+- `Which countries have the fastest internet speeds?`
+- `Show me top ASes by download bandwidth.`
 
 **Outages & Events**
 
-- `List me traffic anomalies in Syria over the last year.`
 - `Show me recent Internet outages.`
-- `What outages affected Portugal in the last 30 days?`
+- `Which countries have the most Internet outages?`
+- `Show me verified traffic anomalies by location.`
 
 **Cloud & Infrastructure**
 
-- `What are the top 5 AWS regions in terms of traffic?`
+- `What are the top AWS regions by traffic?`
 - `Compare latency between Azure and GCP regions.`
 - `What is the connection success rate for cloud providers?`
 
-**Geolocations**
-
-- `List available geolocations for Portugal.`
-- `What is the GeoNames ID for Lisbon?`
-- `Show me HTTP traffic specifically for the Lisbon area.`
-
 **IP Information**
 
-- `What are the details of IP address 1.1.1.1?`
-- `What ASN owns this IP address?`
+- `What are the details of IP address 8.8.8.8?`
+- `Give me full information about IP 1.1.1.1 including ASN details.`
 
 ## Access the remote MCP server from any MCP Client
 

--- a/apps/radar/src/types/radar.ts
+++ b/apps/radar/src/types/radar.ts
@@ -947,3 +947,23 @@ export const BucketSizeParam = z
 	.positive()
 	.optional()
 	.describe('Specifies the width for every bucket in the histogram.')
+
+// ============================================================
+// BGP Routes ASes Parameters
+// ============================================================
+
+export const BgpRoutesAsesSortByParam = z
+	.enum(['cone', 'pfxs', 'ipv4', 'ipv6', 'rpki_valid', 'rpki_invalid', 'rpki_unknown'])
+	.optional()
+	.describe(
+		'Sort ASes by: cone (customer cone size), pfxs (total prefixes), ipv4/ipv6 (address count), or rpki_* (RPKI validation status).'
+	)
+
+// ============================================================
+// Traffic Anomalies Parameters
+// ============================================================
+
+export const TrafficAnomalyStatusParam = z
+	.enum(['VERIFIED', 'UNVERIFIED'])
+	.optional()
+	.describe('Filter by anomaly verification status.')


### PR DESCRIPTION
## Summary

This PR adds 5 new tools to the Radar MCP server, fixes 3 bugs, enhances an existing tool, and reorganizes the README prompt examples.

## Tool Enhancements

- **`get_ip_details`** - Now fetches both IP details and full ASN information in parallel, returning ASN name, country, and population estimates from APNIC

## New Tools

| Tool                                | Endpoint                                       | Description                                                                          |
| ----------------------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------------ |
| `get_internet_services_timeseries`  | `/ranking/internet_services/timeseries_groups` | Track internet service ranking changes over time (e.g., ChatGPT ranking over months) |
| `get_outages_by_location`           | `/annotations/outages/locations`               | Get outage counts aggregated by location                                             |
| `get_traffic_anomalies_by_location` | `/traffic_anomalies/locations`                 | Get traffic anomalies aggregated by location                                         |
| `get_bgp_routing_table_ases`        | `/bgp/routes/ases`                             | List all ASes in global routing tables with routing statistics                       |
| `get_bgp_top_ases_by_prefixes`      | `/bgp/top/ases/prefixes`                       | Get top ASes ordered by announced prefix count                                       |