### PR TITLE
Add pull_request trigger to CI workflow

### DIFF
--- a/.github/workflows/branches.yml
+++ b/.github/workflows/branches.yml
@@ -1,7 +1,9 @@
-name: Branches
+name: CI
 on:
   push:
     branches-ignore: ['main']
+  pull_request:
+    branches: ['main']
 
 env:
   FORCE_COLOR: 1


### PR DESCRIPTION
## Summary
- The CI workflow (`.github/workflows/branches.yml`) only triggers on `push` events to non-main branches
- PRs from forks don't create push events in the upstream repo, so fork PRs never get CI
- Adds a `pull_request` trigger targeting `main` so all PRs get CI regardless of origin

## Test plan
- [ ] Verify this PR itself triggers CI (it should, since the workflow change is in the PR head)
- [ ] Confirm future fork PRs trigger CI automatically