### PR TITLE
Remove push trigger from CI to fix duplicate runs

### DIFF
--- a/.github/workflows/branches.yml
+++ b/.github/workflows/branches.yml
@@ -1,7 +1,5 @@
 name: CI
 on:
-  push:
-    branches-ignore: ['main']
   pull_request:
     branches: ['main']
 


### PR DESCRIPTION
## Summary
- PR #299 added a `pull_request` trigger but kept the existing `push` trigger
- This causes duplicate CI runs on upstream branch PRs (both `push` and `pull_request` fire)
- Removes the `push` trigger — `pull_request` alone covers both fork and upstream PRs

## Test plan
- [ ] Verify this PR only shows one set of CI checks, not duplicates