### PR TITLE
fix: correct descriptions, URLs, and broken links across READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Model Context Protocol (MCP) is a [new, standardized protocol](https://modelcont
 
 These MCP servers allow your [MCP Client](https://modelcontextprotocol.io/clients) to read configurations from your account, process information, make suggestions based on data, and even make those suggested changes for you. All of these actions can happen across Cloudflare's many services including application development, security and performance.
 
-They support both the `streamble-http` transport via `/mcp` and the `sse` transport (deprecated) via `/sse`.
+They support both the `streamable-http` transport via `/mcp` and the `sse` transport (deprecated) via `/sse`.
 
 The following servers are included in this repository:
 

--- a/apps/ai-gateway/README.md
+++ b/apps/ai-gateway/README.md
@@ -3,8 +3,8 @@
 This is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction) server that supports remote MCP
 connections, with Cloudflare OAuth built-in.
 
-It integrates tools powered by the [Cloudflare AI Gateway API](https://developers.cloudflare.com/ai-gateway/) to provide global
-Internet traffic insights, trends and other utilities.
+It integrates tools powered by the [Cloudflare AI Gateway API](https://developers.cloudflare.com/ai-gateway/) to search
+your AI Gateway logs, inspect prompts and responses, and get details about gateway usage.
 
 ## 🔨 Available Tools
 

--- a/apps/browser-rendering/README.md
+++ b/apps/browser-rendering/README.md
@@ -3,8 +3,8 @@
 This is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction) server that supports remote MCP
 connections, with Cloudflare OAuth built-in.
 
-It integrates tools powered by the [Cloudflare Browser Rendering API](https://developers.cloudflare.com/browser-rendering/) to provide global
-Internet traffic insights, trends and other utilities.
+It integrates tools powered by the [Cloudflare Browser Rendering API](https://developers.cloudflare.com/browser-rendering/) to fetch
+web pages, convert them to markdown, and take screenshots.
 
 ## 🔨 Available Tools
 

--- a/apps/docs-ai-search/README.md
+++ b/apps/docs-ai-search/README.md
@@ -39,4 +39,4 @@ Replace the content with the following configuration:
 
 Once you've set up your configuration file, restart MCP client and a browser window will open showing your OAuth login page. Proceed through the authentication flow to grant the client access to your MCP server. After you grant access, the tools will become available for you to use.
 
-Interested in contributing, and running this server locally? See [CONTRIBUTING.md](CONTRIBUTING.md) to get started.
+Interested in contributing, and running this server locally? See the [CONTRIBUTING.md](../../CONTRIBUTING.md) in the repo root to get started.

--- a/apps/docs-vectorize/README.md
+++ b/apps/docs-vectorize/README.md
@@ -39,4 +39,4 @@ Replace the content with the following configuration:
 
 Once you've set up your configuration file, restart MCP client and a browser window will open showing your OAuth login page. Proceed through the authentication flow to grant the client access to your MCP server. After you grant access, the tools will become available for you to use.
 
-Interested in contributing, and running this server locally? See [CONTRIBUTING.md](CONTRIBUTING.md) to get started.
+Interested in contributing, and running this server locally? See the [CONTRIBUTING.md](../../CONTRIBUTING.md) in the repo root to get started.

--- a/apps/sandbox-container/README.md
+++ b/apps/sandbox-container/README.md
@@ -26,7 +26,7 @@ This MCP server is still a work in progress, and we plan to add more tools in th
 
 ## Access the remote MCP server from any MCP Client
 
-If your MCP client has first class support for remote MCP servers, the client will provide a way to accept the server URL (`https://bindings.mcp.cloudflare.com`) directly within its interface (for example in [Cloudflare AI Playground](https://playground.ai.cloudflare.com/)).
+If your MCP client has first class support for remote MCP servers, the client will provide a way to accept the server URL (`https://containers.mcp.cloudflare.com`) directly within its interface (for example in [Cloudflare AI Playground](https://playground.ai.cloudflare.com/)).
 
 If your client does not yet support remote MCP servers, you will need to set up its respective configuration file using [mcp-remote](https://www.npmjs.com/package/mcp-remote) to specify which servers your client can access.
 

--- a/apps/workers-observability/README.md
+++ b/apps/workers-observability/README.md
@@ -3,8 +3,8 @@
 This is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction) server that supports remote MCP
 connections, with Cloudflare OAuth built-in.
 
-It integrates tools powered by [Workers Observability](https://developers.cloudflare.com/workers/observability/) to provide global
-Internet traffic insights, trends and other utilities.
+It integrates tools powered by [Workers Observability](https://developers.cloudflare.com/workers/observability/) to debug
+and get insight into your Workers' logs and analytics.
 
 ## 🔨 Available Tools
 


### PR DESCRIPTION
This PR fixes several small documentation bugs across the repo:

- Fix copy-paste description bugs in ai-gateway, browser-rendering, and workers-observability READMEs that incorrectly said "Internet traffic insights, trends" (the Radar description). Same class of bug as #135 which fixed only AutoRAG.
- Fix wrong URL in sandbox-container README (`bindings.mcp.cloudflare.com` -> `containers.mcp.cloudflare.com`)
- Fix `streamble-http` typo in root README
- Fix broken CONTRIBUTING.md links in docs-vectorize and docs-ai-search to point to the repo root

Fixes #304. Fixes #305.