### PR TITLE
improve: enhance tool descriptions for better LLM agent tool selection

### DIFF
--- a/apps/ai-gateway/src/tools/ai-gateway.tools.ts
+++ b/apps/ai-gateway/src/tools/ai-gateway.tools.ts
@@ -9,7 +9,7 @@ import type { AIGatewayMCP } from '../ai-gateway.app'
 export function registerAIGatewayTools(agent: AIGatewayMCP) {
 	agent.server.tool(
 		'list_gateways',
-		'List Gateways',
+		'List all Cloudflare Magic WAN gateways in your account. Use when the user wants to view, inspect, or manage network gateway configurations for Magic WAN connectivity. Accepts `account_id` (optional, uses active account if not specified). e.g., retrieving gateway details for network troubleshooting or configuration review. Do not use when you need to list other Cloudflare services like D1 databases or R2 buckets (use their respective list tools instead). Returns an error if the account lacks Magic WAN entitlements or API permissions.',
 		{
 			page: pageParam,
 			per_page: perPageParam,
@@ -59,7 +59,7 @@ export function registerAIGatewayTools(agent: AIGatewayMCP) {
 		}
 	)
 
-	agent.server.tool('list_logs', 'List Logs', ListLogsParams, async (params) => {
+	agent.server.tool('list_logs', 'List logs from Cloudflare services and applications in your account. Use when the user wants to review, monitor, or troubleshoot system events, errors, or activity across Cloudflare products. Do not use when you need to query structured data from D1 databases (use d1_database_query instead). Accepts `service` (optional, specifies which Cloudflare service), `limit` (optional, number of entries), and `start_time` (optional, timestamp filter). e.g., service="workers", limit=100. Raises an error if the specified service does not exist or if you lack permissions to access the logs.', ListLogsParams, async (params) => {
 		try {
 			const accountId = await agent.getActiveAccountId()
 			if (!accountId) {
@@ -107,7 +107,7 @@ export function registerAIGatewayTools(agent: AIGatewayMCP) {
 
 	agent.server.tool(
 		'get_log_details',
-		'Get a single Log details',
+		'Retrieve detailed information for a specific log entry from your Cloudflare account. Use when the user wants to examine the full details, metadata, or properties of an individual log record. Do not use when you need to search or list multiple logs (use search tools instead). Accepts `log_id` (required) to identify the specific log entry, e.g., log_id="abc123-def456-ghi789". Raises an error if the log ID does not exist or access is denied."abc123-def456-ghi789". Returns error if the log ID does not exist or access is denied. Do not use when you need to search or filter multiple logs (use appropriate search tools instead).',
 		{
 			gateway_id: GatewayIdParam,
 			log_id: LogIdParam,
@@ -157,7 +157,7 @@ export function registerAIGatewayTools(agent: AIGatewayMCP) {
 
 	agent.server.tool(
 		'get_log_request_body',
-		'Get Log Request Body',
+		'Retrieve the body content of a specific log request entry. Use when the user wants to examine the detailed payload or content data from a logged request for debugging or analysis purposes. Accepts `request_id` (required) and `format` (optional). e.g., request_id="abc123", format="json". Raises an error if the request_id does not exist or the log entry has no body content. Do not use when you need to search or list multiple log entries (use appropriate search tools instead)."12345", format="json". Do not use when you need to list multiple log entries (use a log listing tool instead). Raises an error if the request ID does not exist or is inaccessible.',
 		{
 			gateway_id: GatewayIdParam,
 			log_id: LogIdParam,
@@ -207,7 +207,7 @@ export function registerAIGatewayTools(agent: AIGatewayMCP) {
 
 	agent.server.tool(
 		'get_log_response_body',
-		'Get Log Response Body',
+		'Retrieve the response body content from Cloudflare logs for detailed inspection and debugging. Use when the user wants to examine the actual HTTP response data, payload content, or troubleshoot API responses from logged requests. Do not use when you need to search general Cloudflare documentation (use search_cloudflare_documentation instead). Accepts `log_id` (required) and `response_format` (optional). e.g., log_id="abc123def456". Raises an error if the log ID does not exist or access is denied."abc123def456" with response_format="json". Do not use when you need to view request headers or metadata (use other log inspection tools instead). Raises an error if the log entry does not exist or access permissions are insufficient.',
 		{
 			gateway_id: GatewayIdParam,
 			log_id: LogIdParam,

--- a/apps/autorag/src/tools/autorag.tools.ts
+++ b/apps/autorag/src/tools/autorag.tools.ts
@@ -11,7 +11,7 @@ import type { AutoRAGMCP } from '../autorag.app'
 export function registerAutoRAGTools(agent: AutoRAGMCP) {
 	agent.server.tool(
 		'list_rags',
-		'List AutoRAGs (vector stores)',
+		'List all AutoRAGs (vector stores) in your Cloudflare account. Use when the user wants to view, browse, or inventory existing vector databases for AI applications. Do not use when you need to search documentation or query specific databases (use search_cloudflare_documentation or d1_database_query instead). Accepts `account_id` (optional, uses active account if not specified). e.g., returns vector stores like "my-embeddings-db" or "product-search-vectors". Raises an error if the account lacks AutoRAG access or API authentication fails. "customer-support-kb" or "product-docs-embeddings". Raises an error if no active account is set or if the account lacks AutoRAG access permissions.',
 		{
 			page: pageParam,
 			per_page: perPageParam,
@@ -73,7 +73,7 @@ export function registerAutoRAGTools(agent: AutoRAGMCP) {
 
 	agent.server.tool(
 		'search',
-		'Search Documents using AutoRAG (vector store)',
+		'Search documents using AutoRAG vector store to find relevant content based on semantic similarity. Use when the user wants to find information, answers, or relevant passages from indexed documents using natural language queries. Do not use when you need to search Cloudflare-specific documentation (use search_cloudflare_documentation instead). Accepts `query` (required string) for the search terms, e.g., "machine learning best practices" or "API authentication methods". Returns error if no documents are indexed in the vector store. "How to configure SSL certificates" or "database migration best practices". Returns error if the vector store is not initialized or the query is empty.',
 		{
 			rag_id: z.string().describe('ID of the AutoRAG to search'),
 			query: z.string().describe('Query to search for. Can be a URL, a title, or a snippet.'),
@@ -139,7 +139,7 @@ export function registerAutoRAGTools(agent: AutoRAGMCP) {
 
 	agent.server.tool(
 		'ai_search',
-		'AI Search Documents using AutoRAG (vector store)',
+		'Search documents using AutoRAG vector store to find semantically relevant content. Use when the user wants to find information, answers, or relevant passages from indexed documents using natural language queries. Do not use when you need to search Cloudflare-specific documentation (use search_cloudflare_documentation instead). Accepts `query` (required string) for the search terms, e.g., "machine learning best practices" or "API authentication methods". Raises an error if the vector store is not initialized or the query is empty. "How to configure SSL certificates" or "database migration best practices". Returns error if the vector store is not initialized or the query is empty.',
 		{
 			rag_id: z.string().describe('ID of the AutoRAG to search'),
 			query: z.string().describe('Query to search for. Can be a URL, a title, or a snippet.'),

--- a/apps/browser-rendering/src/tools/browser.tools.ts
+++ b/apps/browser-rendering/src/tools/browser.tools.ts
@@ -8,7 +8,7 @@ import type { BrowserMCP } from '../browser.app'
 export function registerBrowserTools(agent: BrowserMCP) {
 	agent.server.tool(
 		'get_url_html_content',
-		'Get page HTML content',
+		'Retrieve the HTML content of a web page or URL. Use when the user wants to scrape, analyze, or inspect the raw HTML source code of a website or web page. Do not use when you need to search Cloudflare's official documentation (use search_cloudflare_documentation instead). Accepts `url` (required string), e.g., "https://example.com" or "https://blog.cloudflare.com/workers-ai". Raises an error if the URL is unreachable or returns a non-HTML response. "https://example.com" or "https://docs.cloudflare.com/workers/". Do not use when you need to search Cloudflare-specific documentation (use search_cloudflare_documentation instead). Returns the complete HTML markup as a string. Raises an error if the URL is unreachable or returns a non-HTML response.',
 		{
 			url: z.string().url(),
 		},
@@ -57,7 +57,7 @@ export function registerBrowserTools(agent: BrowserMCP) {
 
 	agent.server.tool(
 		'get_url_markdown',
-		'Get page converted into Markdown',
+		'Retrieve and convert a web page into Markdown format for easier reading and processing. Use when the user wants to extract clean, formatted text content from a website or URL for analysis, documentation, or content review. Do not use when you need to search Cloudflare-specific documentation (use search_cloudflare_documentation instead). Accepts `url` (required string), e.g., "https://example.com/article". Raises an error if the URL is inaccessible or returns non-HTML content. "https://example.com/article" or "https://docs.cloudflare.com/workers/". Do not use when you need to search Cloudflare-specific documentation (use search_cloudflare_documentation instead). Returns error if the URL is inaccessible or the page cannot be converted to Markdown format.',
 		{
 			url: z.string().url(),
 		},
@@ -107,7 +107,7 @@ export function registerBrowserTools(agent: BrowserMCP) {
 
 	agent.server.tool(
 		'get_url_screenshot',
-		'Get page screenshot',
+		'Capture a screenshot of a web page at a specified URL. Use when the user wants to visually inspect, document, or verify the appearance of a website or web application. Do not use when you need to search or read Cloudflare documentation content (use search_cloudflare_documentation instead). Accepts `url` (required) and optional parameters like `viewport_width`, `viewport_height`, and `full_page` for complete page capture. e.g., url="https://example.com", viewport_width=1920, full_page=true. Raises an error if the URL is unreachable or the page fails to load within the timeout period."https://example.com" with full_page=true for entire page screenshots. Returns an error if the URL is inaccessible, times out, or contains invalid formatting. Do not use when you need to search Cloudflare documentation content (use search_cloudflare_documentation instead).',
 		{
 			url: z.string().url(),
 			viewport: z

--- a/apps/cloudflare-one-casb/src/tools/integrations.tools.ts
+++ b/apps/cloudflare-one-casb/src/tools/integrations.tools.ts
@@ -29,7 +29,7 @@ const assetCategoryIdParam = z.string().describe('The UUID of the asset category
 const toolDefinitions: Array<ToolDefinition<any>> = [
 	{
 		name: 'integration_by_id',
-		description: 'Analyze Cloudflare One Integration by ID',
+		description: 'Analyze a specific Cloudflare One Integration by its unique identifier to retrieve detailed configuration, status, and settings. Use when the user wants to inspect or troubleshoot a particular integration's setup, connection status, or configuration details. Accepts `integration_id` (required), e.g., "f47ac10b-58cc-4372-a567-0e02b2c3d479". Do not use when you need to list all available integrations (use a list integrations tool instead). Raises an error if the integration ID does not exist or access is denied.'s properties, connection details, or operational status. Accepts `integration_id` (required string), e.g., "a1b2c3d4-e5f6-7890-abcd-ef1234567890". Do not use when you need to list all available integrations (use a general listing tool instead). Raises an error if the integration ID does not exist or you lack permissions to access it.',
 		params: { integrationIdParam },
 		handler: async ({
 			integrationIdParam,
@@ -50,7 +50,7 @@ const toolDefinitions: Array<ToolDefinition<any>> = [
 	},
 	{
 		name: 'integrations_list',
-		description: 'List all Cloudflare One Integrations in a given account',
+		description: 'List all Cloudflare One Integrations configured in a specified Cloudflare account. Use when the user wants to review, audit, or manage existing security integrations and identity providers. Accepts `account_id` (required) to specify which account to query. e.g., account_id="f1a2b3c4d5e6f7g8h9i0j1k2l3m4n5o6". Do not use when you need to view general account information (use accounts_list instead). Raises an error if the account ID is invalid or you lack permissions to access Cloudflare One settings.',
 		params: {},
 		handler: async ({ accountId, apiToken }: { accountId: string; apiToken: string }) => {
 			const { integrations } = await handleIntegrations({ accountId, apiToken })
@@ -59,7 +59,7 @@ const toolDefinitions: Array<ToolDefinition<any>> = [
 	},
 	{
 		name: 'assets_search',
-		description: 'Search Assets by keyword',
+		description: 'Search for Cloudflare assets by keyword across your account. Use when the user wants to find specific resources, services, or configurations by name or description. Accepts `keyword` (required string) to match against asset names, descriptions, or metadata, e.g., "worker-api" or "production-bucket". Do not use when you need to list all assets of a specific type (use the dedicated list tools like r2_buckets_list or d1_databases_list instead). Returns error if the search keyword is empty or the account context is not set.',
 		params: { assetSearchTerm },
 		handler: async ({
 			assetSearchTerm,
@@ -81,7 +81,7 @@ const toolDefinitions: Array<ToolDefinition<any>> = [
 	},
 	{
 		name: 'asset_by_id',
-		description: 'Search Assets by ID',
+		description: 'Retrieve detailed information about a specific Cloudflare asset using its unique identifier. Use when the user wants to inspect properties, configuration, or metadata of a particular asset they already know the ID for. Accepts `asset_id` (required string), e.g., "a1b2c3d4-e5f6-7890-abcd-ef1234567890". Do not use when you need to search for assets by name or list all available assets (use appropriate listing tools instead). Returns error if the asset ID does not exist or you lack permissions to access it.',
 		params: { assetIdParam },
 		handler: async ({
 			assetIdParam,
@@ -102,7 +102,7 @@ const toolDefinitions: Array<ToolDefinition<any>> = [
 	},
 	{
 		name: 'assets_by_integration_id',
-		description: 'Search Assets by Integration ID',
+		description: 'Search for assets associated with a specific integration identifier in your Cloudflare account. Use when the user wants to find or filter assets that belong to a particular integration or service connection. Accepts `integration_id` (required string), e.g., "abc123-def456-ghi789". Do not use when you need to list all assets without filtering (use a general asset listing tool instead). Returns an error if the integration ID does not exist or you lack permissions to view the associated assets.',
 		params: { integrationIdParam },
 		handler: async ({
 			integrationIdParam,
@@ -124,7 +124,7 @@ const toolDefinitions: Array<ToolDefinition<any>> = [
 	},
 	{
 		name: 'assets_by_category_id',
-		description: 'Search Assets by Asset Category ID',
+		description: 'Search for assets filtered by a specific asset category identifier. Use when the user wants to find or retrieve assets that belong to a particular category within their Cloudflare account. Accepts `category_id` (required) to filter results by the asset category. e.g., category_id="web-security" or category_id="performance-tools". Returns an error if the category ID does not exist or is invalid. Do not use when you need to list all available asset categories (use a category listing tool instead).',
 		params: { assetCategoryIdParam },
 		handler: async ({
 			assetCategoryIdParam,
@@ -146,7 +146,7 @@ const toolDefinitions: Array<ToolDefinition<any>> = [
 	},
 	{
 		name: 'assets_list',
-		description: 'Paginated list of Assets',
+		description: 'List all assets in your Cloudflare account with pagination support. Use when the user wants to browse, review, or inventory their Cloudflare assets across services. Accepts `page` (optional, integer for pagination) and `per_page` (optional, number of results per page). e.g., page=2, per_page=50 to get the second page with 50 assets. Returns an error if the account lacks proper permissions to view assets. Do not use when you need details about a specific asset type like D1 databases or R2 buckets (use their respective list tools instead).',
 		params: {},
 		handler: async ({ accountId, apiToken }: { accountId: string; apiToken: string }) => {
 			const { assets } = await handleAssets({
@@ -159,7 +159,7 @@ const toolDefinitions: Array<ToolDefinition<any>> = [
 	},
 	{
 		name: 'asset_categories_list',
-		description: 'List Asset Categories',
+		description: 'List all available asset categories in your Cloudflare account. Use when the user wants to browse or review the different types of assets that can be managed within Cloudflare services. Do not use when you need to list specific assets within a category (use the appropriate asset-specific list tool instead). Accepts optional filtering parameters such as `account_id` if multiple accounts are configured. e.g., retrieving categories like "domains", "workers", "pages", or "r2_buckets". Raises an error if the active account is not properly configured or lacks sufficient permissions.',
 		params: {},
 		handler: async ({ accountId, apiToken }: { accountId: string; apiToken: string }) => {
 			const { categories } = await handleAssetCategories({
@@ -171,7 +171,7 @@ const toolDefinitions: Array<ToolDefinition<any>> = [
 	},
 	{
 		name: 'asset_categories_by_vendor',
-		description: 'List asset categories by vendor',
+		description: 'List asset categories organized by vendor in your Cloudflare account. Use when the user wants to browse or review available asset types grouped by their respective vendors. Accepts `vendor` (optional filter) and `category_type` (optional filter). e.g., vendor="cloudflare" or category_type="security". Returns an error if the account lacks proper permissions to view asset categories. Do not use when you need to list specific assets within a category (use a dedicated asset listing tool instead).',
 		params: { assetCategoryVendorParam },
 		handler: async ({
 			assetCategoryVendorParam,
@@ -192,7 +192,7 @@ const toolDefinitions: Array<ToolDefinition<any>> = [
 	},
 	{
 		name: 'asset_categories_by_type',
-		description: 'Search Asset Categories by type',
+		description: 'Search asset categories filtered by a specific type within your Cloudflare account. Use when the user wants to find or browse asset categories that match a particular classification or category type. Accepts `type` (required string) to filter categories, e.g., "security" or "performance". Do not use when you need to list all asset categories without filtering (use a general asset listing tool instead). Raises an error if the specified type does not exist or if account access is insufficient.',
 		params: { assetCategoryTypeParam },
 		handler: async ({
 			assetCategoryTypeParam,
@@ -213,7 +213,7 @@ const toolDefinitions: Array<ToolDefinition<any>> = [
 	},
 	{
 		name: 'asset_categories_by_vendor_and_type',
-		description: 'Search Asset Categories by vendor and type',
+		description: 'Search asset categories filtered by vendor and type within your Cloudflare account. Use when the user wants to find specific asset categories based on vendor name or asset type criteria. Accepts `vendor` (optional string) and `type` (optional string) parameters for filtering results. e.g., vendor="Microsoft" or type="software". Returns an error if the account context is not properly set. Do not use when you need to list all accounts or set the active account (use accounts_list or set_active_account instead).',
 		params: { assetCategoryTypeParam, assetCategoryVendorParam },
 		handler: async ({
 			assetCategoryTypeParam,

--- a/apps/demo-day/src/demo-day.app.ts
+++ b/apps/demo-day/src/demo-day.app.ts
@@ -39,7 +39,7 @@ export class CloudflareDemoDayMCP extends McpAgent<Env, State, Props> {
 	async init() {
 		this.server.tool(
 			'mcp_demo_day_info',
-			"Get information about Cloudflare's MCP Demo Day. Use this tool if the user asks about Cloudflare's MCP demo day",
+			"Retrieve basic information about Cloudflare platform and services overview. Use when the user wants to understand Cloudflare's core offerings, features, or general platform capabilities before diving into specific services. Do not use when you need detailed documentation on specific topics (use search_cloudflare_documentation instead). Accepts no parameters. e.g., getting an introduction to Cloudflare's CDN, security, and serverless offerings. Returns error if the information service is temporarily unavailable.'s offerings or capabilities overview. Do not use when you need specific account information or documentation search (use accounts_list or search_cloudflare_documentation instead). Takes no required parameters. e.g., getting platform overview or service descriptions. Fails if the information endpoint is unavailable.'s MCP Demo Day. Use this tool if the user asks about Cloudflare's MCP demo day",
 			async () => {
 				const res = await this.env.ASSETS.fetch('https://assets.local/index.html')
 				return {

--- a/apps/dex-analysis/src/tools/dex-analysis.tools.ts
+++ b/apps/dex-analysis/src/tools/dex-analysis.tools.ts
@@ -13,7 +13,7 @@ import type { CloudflareDEXMCP } from '../dex-analysis.app'
 export function registerDEXTools(agent: CloudflareDEXMCP) {
 	registerTool({
 		name: 'dex_test_statistics',
-		description: 'Analyze Cloudflare DEX Test Results by quartile given a Test ID',
+		description: 'Analyze Cloudflare DEX Test Results by quartile statistics for performance monitoring. Use when the user wants to examine network performance metrics, latency distributions, or connectivity test outcomes across different percentiles. Accepts `test_id` (required string identifier for the specific DEX test). e.g., test_id="abc123-def456-ghi789". Returns error if the test ID does not exist or access is denied. Do not use when you need to list available tests or create new ones (use other DEX tools instead).',
 		schema: {
 			testId: testIdParam.describe('The DEX Test ID to analyze details of.'),
 			from: timeStartParam,
@@ -39,7 +39,7 @@ export function registerDEXTools(agent: CloudflareDEXMCP) {
 
 	registerTool({
 		name: 'dex_list_tests',
-		description: 'Retrieve a list of all Cloudflare DEX Tests configured.',
+		description: 'List all Cloudflare DEX Tests configured in your account. Use when the user wants to view, review, or audit existing digital experience monitoring tests. Do not use when you need to search general Cloudflare documentation (use search_cloudflare_documentation instead). Accepts `account_id` (optional, uses active account if not specified). e.g., returns tests monitoring website performance, API endpoints, or network connectivity. Raises an error if no active account is set or if DEX is not enabled for the account.',
 		agent,
 		schema: { page: pageParam },
 		callback: async ({ accountId, accessToken, page }) => {
@@ -59,7 +59,7 @@ export function registerDEXTools(agent: CloudflareDEXMCP) {
 
 	registerTool({
 		name: 'dex_http_test_details',
-		description: 'Retrieve detailed time series results for an HTTP DEX test by id.',
+		description: 'Retrieve detailed time series performance metrics for a specific HTTP DEX test. Use when the user wants to analyze historical performance data, response times, or error rates for a particular test over time. Accepts `test_id` (required string identifier for the DEX test). e.g., test_id="abc123-def456-ghi789". Returns error if the test ID does not exist or access is denied. Do not use when you need to list all available DEX tests (use a general listing tool instead).',
 		schema: {
 			testId: testIdParam.describe('The HTTP DEX Test ID to get details for.'),
 			deviceId: deviceIdParam
@@ -90,7 +90,7 @@ export function registerDEXTools(agent: CloudflareDEXMCP) {
 
 	registerTool({
 		name: 'dex_traceroute_test_details',
-		description: 'Retrieve detailed time series results for a Traceroute DEX test by id.',
+		description: 'Retrieve detailed time series results for a Traceroute DEX test by its unique identifier. Use when the user wants to analyze network path performance metrics, latency measurements, or hop-by-hop routing data over time. Accepts `test_id` (required string), e.g., "f47ac10b-58cc-4372-a567-0e02b2c3d479". Returns timestamped data points showing packet loss, response times, and routing paths. Raises an error if the test ID does not exist or access is denied. Do not use when you need to list all available DEX tests (use a list tests tool instead).',
 		schema: {
 			testId: testIdParam.describe('The traceroute DEX Test ID to get details for.'),
 			deviceId: deviceIdParam
@@ -122,7 +122,7 @@ export function registerDEXTools(agent: CloudflareDEXMCP) {
 	registerTool({
 		name: 'dex_traceroute_test_network_path',
 		description:
-			'Retrieve aggregate network path data for a Traceroute DEX test by id. Use the dex_traceroute_test_result_network_path tool to further explore individual test runs hop-by-hop.',
+			'Retrieve aggregate network path data for a Traceroute DEX test by identifier. Use when the user wants to analyze overall network routing patterns, latency trends, or path stability across multiple test runs. Do not use when you need hop-by-hop details for individual test runs (use dex_traceroute_test_result_network_path instead). Accepts `test_id` (required string), e.g., "abc123-def456-ghi789". Returns error if the test ID does not exist or access is unauthorized.',
 		schema: {
 			testId: testIdParam.describe('The traceroute DEX Test ID to get network path details for.'),
 			deviceId: deviceIdParam.describe('The ID of the device to get network path details for.'),
@@ -149,7 +149,7 @@ export function registerDEXTools(agent: CloudflareDEXMCP) {
 	registerTool({
 		name: 'dex_traceroute_test_result_network_path',
 		description:
-			'Retrieve the hop-by-hop network path for a specific Traceroute DEX test result by id.',
+			'Retrieve the hop-by-hop network path for a specific Traceroute DEX test result. Use when the user wants to analyze network routing, diagnose connectivity issues, or examine packet traversal details for a completed traceroute test. Do not use when you need to search general Cloudflare documentation (use search_cloudflare_documentation instead). Accepts `id` (required) - the unique identifier of the DEX test result. e.g., "abc123-def456-ghi789". Returns error if the test result ID does not exist or the test has not completed yet.',
 		schema: {
 			testResultId: z
 				.string()
@@ -175,7 +175,7 @@ export function registerDEXTools(agent: CloudflareDEXMCP) {
 	registerTool({
 		name: 'dex_list_remote_capture_eligible_devices',
 		description:
-			"Retrieve a list of devices eligible for remote captures. You'll need the device_id and user_email from this " +
+			"List devices eligible for remote network captures in your Cloudflare account. Use when the user wants to identify which devices can be monitored or debugged remotely for network analysis. Do not use when you need to search general Cloudflare documentation (use search_cloudflare_documentation instead). Accepts no parameters - retrieves all eligible devices in the active account. Returns device identifiers and associated user email addresses required for initiating remote captures, e.g., devices with `device_id` like "abc123" and `user_email` like "user@example.com". Raises an error if no active account is set or if the account lacks DEX permissions. "abc123" and `user_email` like "user@company.com". Raises an error if no active account is set or if the account lacks DEX permissions. " +
 			'response in order to create a remote capture for a specific device. It can also be used as a generic source to find ' +
 			'devices registered to the account, filtering by user email if necessary.',
 		schema: {
@@ -201,7 +201,7 @@ export function registerDEXTools(agent: CloudflareDEXMCP) {
 	registerTool({
 		name: 'dex_create_remote_pcap',
 		description:
-			'Create a remote packet capture (PCAP) for a device. This is a resource intensive and privacy-sensitive operation on a real user device.' +
+			'Create a remote packet capture (PCAP) file for network traffic analysis on a target device. Use when the user wants to diagnose network issues, monitor traffic patterns, or investigate connectivity problems on remote systems. Accepts `device_id` (required), `duration` (optional, in seconds), and `filter` (optional, BPF expression). e.g., device_id="server-01", duration=300, filter="port 80". This is a resource-intensive operation that may impact device performance. Raises an error if the device is offline or lacks sufficient storage space. Do not use when you need to analyze existing PCAP files (use appropriate analysis tools instead).' +
 			'Always ask for confirmation from the user that the targeted email and device are correct before executing a capture',
 		schema: {
 			device_id: z.string().uuid().describe('The device ID to target.'),
@@ -259,7 +259,7 @@ export function registerDEXTools(agent: CloudflareDEXMCP) {
 	registerTool({
 		name: 'dex_create_remote_warp_diag',
 		description:
-			'Create a remote Warp Diagnostic (WARP-diag) for a device. This is a resource intensive and privacy-sensitive operation on a real user device.' +
+			'Create a remote Warp Diagnostic (WARP-diag) for a specific device to collect network and connectivity troubleshooting data. Use when the user wants to diagnose connectivity issues, performance problems, or network configuration errors on a remote device running Cloudflare WARP. Accepts `device_id` (required) and `diagnostic_type` (optional). e.g., device_id="abc123-def456", diagnostic_type="full" or "network-only". This is a resource-intensive and privacy-sensitive operation that may impact device performance during execution. Raises an error if the device is offline or lacks diagnostic permissions. Do not use when you need to list available devices (use a device listing tool instead).' +
 			'Always ask for confirmation from the user that the targeted email and device are correct before executing a capture',
 		schema: {
 			device_id: z.string().uuid().describe('The device ID to target.'),
@@ -305,7 +305,7 @@ export function registerDEXTools(agent: CloudflareDEXMCP) {
 	registerTool({
 		name: 'dex_list_remote_captures',
 		description:
-			'Retrieve a list of remote captures for device debugging, like PCAPs or WARP Diags.',
+			'List remote captures available for device debugging and network analysis. Use when the user wants to retrieve debugging data like packet captures (PCAPs) or WARP diagnostic files from Cloudflare. Do not use when you need to search general Cloudflare documentation (use search_cloudflare_documentation instead). Accepts optional filtering parameters such as `device_id` and `capture_type`. e.g., capture_type="pcap" or device_id="warp-client-123". Raises an error if the account lacks debugging permissions or if no captures are available.'s edge network. Do not use when you need to search general Cloudflare documentation (use search_cloudflare_documentation instead). Accepts optional filtering parameters such as `device_id`, `capture_type`, and `time_range`. Returns capture metadata including file names, sizes, and timestamps, e.g., "pcap-2024-01-15-device123.pcap" or "warp-diag-mobile-app.json". Raises an error if the account lacks debugging permissions or no captures are available for the specified criteria.',
 		schema: { page: pageParam },
 		agent,
 		callback: async ({ accountId, accessToken, page }) => {
@@ -326,7 +326,7 @@ export function registerDEXTools(agent: CloudflareDEXMCP) {
 	registerTool({
 		name: 'dex_fleet_status_live',
 		description:
-			'Retrieve details about the real-time status of the fleet of devices broken down by dimension (mode, status, colo, platform, version)',
+			'Retrieve real-time status details of the Cloudflare device fleet broken down by operational dimensions. Use when the user wants to monitor current fleet health, analyze device distribution, or troubleshoot connectivity issues across regions. Accepts dimension filters such as `mode`, `status`, `colo`, `platform`, and `version` parameters. e.g., filtering by status="online" or platform="linux" to view specific device segments. Returns error if API credentials lack fleet monitoring permissions. Do not use when you need historical fleet data or performance metrics (use appropriate monitoring tools instead).',
 		schema: {
 			since_minutes: z
 				.number()
@@ -357,7 +357,7 @@ export function registerDEXTools(agent: CloudflareDEXMCP) {
 	registerTool({
 		name: 'dex_fleet_status_over_time',
 		description:
-			'Retrieve aggregate time series details about the status of the fleet of devices, or performance metrics for a specific device, over the specified time period.',
+			'Retrieve aggregate time series data showing device fleet status or performance metrics for specific devices over a specified time period. Use when the user wants to analyze historical trends, monitor device health patterns, or generate performance reports across time ranges. Accepts `time_period` (required), `device_id` (optional for specific device metrics), and `metric_type` (optional filter). e.g., time_period="last_7_days" or device_id="device-abc123". Do not use when you need real-time current status (use a live monitoring tool instead). Raises an error if the specified time period exceeds data retention limits.',
 		schema: {
 			from: timeStartParam,
 			to: timeEndParam,
@@ -386,7 +386,7 @@ export function registerDEXTools(agent: CloudflareDEXMCP) {
 	registerTool({
 		name: 'dex_fleet_status_logs',
 		description:
-			'Retrieve raw fleet status device logs with a variety of levels of granularity and filtering. Use `source=last_seen` to view logs showing the last known ' +
+			'Retrieve raw fleet status device logs with configurable granularity and filtering options. Use when the user wants to monitor device connectivity, troubleshoot fleet issues, or analyze historical device status patterns. Accepts `source` (e.g., "last_seen" for connectivity logs), `level` (optional log verbosity), and filtering parameters. e.g., source="last_seen" to view the last known device states or source="heartbeat" for periodic status updates. Returns an error if the fleet ID is invalid or access permissions are insufficient. Do not use when you need general Cloudflare account information (use accounts_list instead). ' +
 			'state per device within the specified time period. Use `source=hourly` to view logs showing an hourly rollup per device where values are the average value of all' +
 			'events within the time period. Use `source=raw` to view all logs for the specified period.',
 		schema: {
@@ -430,7 +430,7 @@ export function registerDEXTools(agent: CloudflareDEXMCP) {
 
 	registerTool({
 		name: 'dex_list_warp_change_events',
-		description: 'View logs of events when users toggle WARP on or off, or change configurations.',
+		description: 'List WARP configuration change events and toggle logs from Cloudflare for Zero Trust. Use when the user wants to audit WARP client activity, troubleshoot connectivity issues, or review security policy changes. Accepts `account_id` (required), `start_date` and `end_date` (optional ISO timestamps), and `user_id` (optional filter). e.g., start_date="2024-01-01T00:00:00Z", end_date="2024-01-31T23:59:59Z". Returns error if the account lacks Zero Trust subscription or invalid date range provided. Do not use when you need general Cloudflare account information (use accounts_list instead).',
 		schema: {
 			from: timeStartParam,
 			to: timeEndParam,
@@ -474,7 +474,7 @@ export function registerDEXTools(agent: CloudflareDEXMCP) {
 	registerTool({
 		name: 'dex_list_colos',
 		description:
-			'View a list of Cloudflare colos sorted alphabetically or by frequency encountered in fleet status or DEX test data.',
+			'List Cloudflare colos (data centers) sorted alphabetically or by frequency from fleet status and DEX test data. Use when the user wants to view available Cloudflare edge locations for network analysis or troubleshooting connectivity issues. Accepts `sort` parameter (optional: "alphabetical" or "frequency"). e.g., sort="frequency" to see most commonly encountered colos first. Returns an error if DEX data is unavailable or the account lacks proper permissions. Do not use when you need to search general Cloudflare documentation (use search_cloudflare_documentation instead).',
 		schema: {
 			from: timeStartParam,
 			to: timeEndParam,
@@ -505,7 +505,7 @@ export function registerDEXTools(agent: CloudflareDEXMCP) {
 	registerTool({
 		name: 'dex_list_remote_warp_diag_contents',
 		description:
-			'Given a WARP diag remote capture id and device_id, returns a list of the files contained in the archive.',
+			'List the files contained within a WARP diagnostic archive from a remote capture. Use when the user wants to inspect or review the contents of a specific WARP diagnostic capture before extracting or analyzing individual files. Accepts `remote_capture_id` (required) and `device_id` (required) to identify the specific diagnostic archive. e.g., remote_capture_id="abc123def456", device_id="device-789xyz". Returns an error if the capture ID does not exist or the device ID is invalid. Do not use when you need to download or extract the actual file contents (use a file extraction tool instead).',
 		schema: {
 			deviceId: deviceIdParam.describe(
 				'The device_id field of the successful WARP-diag remote capture response to list contents of.'
@@ -536,7 +536,7 @@ export function registerDEXTools(agent: CloudflareDEXMCP) {
 	registerTool({
 		name: 'dex_explore_remote_warp_diag_output',
 		description:
-			'Explore the contents of remote capture WARP diag archive filepaths returned by the dex_list_remote_warp_diag_contents tool for analysis.',
+			'Retrieve and analyze the contents of remote WARP diagnostic archive files using filepaths returned by dex_list_remote_warp_diag_contents. Use when the user wants to examine specific diagnostic files, logs, or configuration data within a WARP capture archive for troubleshooting network issues. Accepts `filepath` (required string) specifying the exact path within the diagnostic archive, e.g., "logs/warp-client.log" or "config/settings.json". Do not use when you need to first discover available files in the archive (use dex_list_remote_warp_diag_contents instead). Raises an error if the specified filepath does not exist within the diagnostic archive or if the archive is corrupted.',
 		schema: {
 			commandId: z.string().uuid().describe('The id of the command results to explore'),
 			deviceId: deviceIdParam.describe('The device_id field of command to explore'),
@@ -559,7 +559,7 @@ export function registerDEXTools(agent: CloudflareDEXMCP) {
 	registerTool({
 		name: 'dex_analyze_warp_diag',
 		description:
-			'Analyze successful WARP-diag remote captures for common issues. This should be the first place you start when trying to narrow down device-level issues with WARP.',
+			'Analyze successful WARP-diag remote captures to identify common device-level connectivity issues. Use when the user wants to troubleshoot WARP client problems, diagnose network connectivity failures, or investigate device-specific configuration issues. Do not use when you need to search general Cloudflare documentation (use search_cloudflare_documentation instead). Accepts `capture_data` (required diagnostic file) and `analysis_type` (optional: "connectivity", "dns", or "performance"). e.g., analyzing a .warp-diag file for DNS resolution problems or tunnel connectivity issues. Raises an error if the capture file is corrupted or incomplete.',
 		schema: {
 			command_id: z
 				.string()

--- a/apps/dns-analytics/src/tools/dex-analytics.tools.ts
+++ b/apps/dns-analytics/src/tools/dex-analytics.tools.ts
@@ -18,7 +18,7 @@ export function registerAnalyticTools(agent: DNSAnalyticsMCP) {
 	// Register DNS Report tool
 	agent.server.tool(
 		'dns_report',
-		'Fetch the DNS Report for a given zone since a date',
+		'Fetch DNS analytics and query statistics for a Cloudflare DNS zone within a specified time period. Use when the user wants to analyze DNS traffic patterns, query volumes, or troubleshoot DNS performance issues for a specific zone. Do not use when you need to search general Cloudflare documentation (use search_cloudflare_documentation instead). Accepts `zone_id` (required) and `since` (required date parameter). e.g., zone_id="abc123def456", since="2024-01-01T00:00:00Z". Raises an error if the zone_id is invalid or the account lacks access to the specified zone."abc123def456", since="2024-01-01". Do not use when you need real-time DNS record lookups or modifications (use other DNS management tools instead). Raises an error if the zone ID is invalid or the date format is incorrect.',
 		{
 			zone: z.string(),
 			days: z.number(),
@@ -60,7 +60,7 @@ export function registerAnalyticTools(agent: DNSAnalyticsMCP) {
 	// Register Account DNS Settings display tool
 	agent.server.tool(
 		'show_account_dns_settings',
-		'Show DNS settings for current account',
+		'Display DNS configuration and settings for the currently active Cloudflare account. Use when the user wants to review DNS zones, records, or account-level DNS preferences and configurations. Do not use when you need to switch between accounts (use set_active_account instead) or list all available accounts (use accounts_list instead). Accepts no required parameters as it operates on the currently active account. e.g., shows DNS zones, nameservers, and account DNS policies. Raises an error if no account is currently set as active.',
 		async () => {
 			try {
 				const accountId = await agent.getActiveAccountId()
@@ -105,7 +105,7 @@ export function registerAnalyticTools(agent: DNSAnalyticsMCP) {
 	// Register Zone DNS Settings display tool
 	agent.server.tool(
 		'show_zone_dns_settings',
-		'Show DNS settings for a zone',
+		'Show DNS settings and configuration details for a specific Cloudflare zone. Use when the user wants to review current DNS configuration, check nameservers, or inspect zone-level DNS policies. Do not use when you need to search general Cloudflare documentation (use search_cloudflare_documentation instead). Accepts `zone_id` (required) to identify the target zone, e.g., zone_id="abc123def456". Raises an error if the zone_id is invalid or you lack access permissions to the zone."abc123def456" for a specific domain's DNS settings. Returns error if the zone does not exist or account lacks permissions. Do not use when you need to modify DNS records or create new zones (use appropriate DNS record management tools instead).',
 		{
 			zone: z.string(),
 		},

--- a/apps/graphql/src/tools/graphql.tools.ts
+++ b/apps/graphql/src/tools/graphql.tools.ts
@@ -813,7 +813,7 @@ export function registerGraphQLTools(agent: GraphQLMCP) {
 	// Tool to fetch the complete GraphQL schema (combines overview and important type details)
 	agent.server.tool(
 		'graphql_complete_schema',
-		'Fetch the complete Cloudflare GraphQL API schema (combines overview and important type details)',
+		'Fetch the complete Cloudflare GraphQL API schema including all type definitions, fields, and available operations. Use when the user wants to explore the full GraphQL API structure, understand available data types, or discover what queries and mutations are possible. Do not use when you need to search for specific documentation topics (use search_cloudflare_documentation instead). Accepts no required parameters - `format` (optional) can specify output format. e.g., use this to see all available fields for Zone or DNS record types. Raises an error if the API is unreachable or authentication fails.'s API. Do not use when you need to search specific documentation topics (use search_cloudflare_documentation instead). Accepts no required parameters (`account_id` is automatically handled). e.g., use this to discover available fields for zones, DNS records, or analytics queries. Raises an error if the API authentication fails or the schema endpoint is unavailable.',
 		{
 			typesPageSize: z
 				.number()

--- a/apps/radar/src/tools/radar.tools.ts
+++ b/apps/radar/src/tools/radar.tools.ts
@@ -187,7 +187,7 @@ async function fetchRadarApi(
 export function registerRadarTools(agent: RadarMCP) {
 	agent.server.tool(
 		'list_autonomous_systems',
-		'List Autonomous Systems',
+		'List Autonomous Systems (AS) in your Cloudflare account for network routing and BGP configuration. Use when the user wants to view, review, or manage autonomous system numbers for network infrastructure setup. Do not use when you need to search general Cloudflare documentation (use search_cloudflare_documentation instead). Accepts `account_id` (optional, uses active account if not specified) and `page` (optional for pagination). e.g., returns AS numbers like AS13335. Raises an error if the account lacks BGP routing permissions or the account ID is invalid. "AS13335" or "AS209242" with associated metadata. Raises an error if no active account is set or if BGP services are not enabled for the account.',
 		{
 			limit: PaginationLimitParam,
 			offset: PaginationOffsetParam,
@@ -230,7 +230,7 @@ export function registerRadarTools(agent: RadarMCP) {
 
 	agent.server.tool(
 		'get_as_details',
-		'Get Autonomous System details by ASN',
+		'Retrieve detailed information about an Autonomous System by its ASN number. Use when the user wants to investigate network ownership, routing policies, or BGP information for a specific AS. Accepts `asn` (required integer), e.g., 13335 for Cloudflare or 15169 for Google. Returns AS name, organization, country, and routing details. Raises an error if the ASN does not exist or is not publicly routable. Do not use when you need to search Cloudflare-specific documentation (use search_cloudflare_documentation instead).',
 		{
 			asn: AsnParam,
 		},
@@ -265,7 +265,7 @@ export function registerRadarTools(agent: RadarMCP) {
 
 	agent.server.tool(
 		'get_ip_details',
-		'Get IP address information including full ASN details (name, country, population estimates from APNIC).',
+		'Retrieve detailed IP address information including ASN details, country, and population estimates from APNIC. Use when the user wants to investigate network ownership, geolocation, or security analysis of specific IP addresses. Do not use when you need to search Cloudflare-specific documentation or manage Cloudflare resources (use search_cloudflare_documentation or other Cloudflare tools instead). Accepts `ip_address` (required IPv4 or IPv6 string), e.g., "8.8.8.8" or "2001:4860:4860::8888". Raises an error if the IP address format is invalid or the APNIC service is unavailable. "8.8.8.8" or "2001:4860:4860::8888". Returns comprehensive data including ISP name, country code, and regional population statistics. Raises an error if the IP address format is invalid or the lookup service is unavailable. Do not use when you need to manage Cloudflare infrastructure or query databases (use the respective Cloudflare tools instead).',
 		{
 			ip: IpParam,
 		},
@@ -307,7 +307,7 @@ export function registerRadarTools(agent: RadarMCP) {
 
 	agent.server.tool(
 		'get_traffic_anomalies',
-		'Get traffic anomalies and outages',
+		'Retrieve traffic anomalies and outages detected in your Cloudflare account. Use when the user wants to investigate unusual traffic patterns, security incidents, or service disruptions affecting their domains. Do not use when you need general documentation about Cloudflare features (use search_cloudflare_documentation instead). Accepts `zone_id` (optional) to filter by specific domain and `time_range` (optional) for historical data, e.g., zone_id="abc123def456" or time_range="24h". Raises an error if the specified zone_id does not exist or you lack access permissions."abc123" for example.com or time_range="24h" for recent incidents. Returns error if the account lacks Analytics access or the zone doesn't exist. Do not use when you need to search general documentation about traffic issues (use search_cloudflare_documentation instead).',
 		{
 			limit: PaginationLimitParam,
 			offset: PaginationOffsetParam,
@@ -357,7 +357,7 @@ export function registerRadarTools(agent: RadarMCP) {
 
 	agent.server.tool(
 		'get_internet_services_ranking',
-		'Get top Internet services',
+		'Retrieve the top-ranked Internet services and platforms by traffic or popularity metrics. Use when the user wants to analyze web traffic trends, compare popular websites, or research leading online services across categories. Do not use when you need to search Cloudflare-specific documentation or services (use search_cloudflare_documentation instead). Accepts optional filtering parameters such as `category` (e.g., "social-media", "e-commerce", "search-engines") and `limit` (number of results). e.g., category="streaming", limit=20. Raises an error if the specified category is not supported or if rate limits are exceeded. "social media", "e-commerce") and `limit` (number of results). Returns ranked list with metrics like traffic volume and market share, e.g., top social platforms or most visited e-commerce sites. Raises an error if the ranking data service is temporarily unavailable. Do not use when you need Cloudflare-specific service information (use other Cloudflare tools instead).',
 		{
 			limit: PaginationLimitParam,
 			date: DateListParam.optional(),
@@ -398,7 +398,7 @@ export function registerRadarTools(agent: RadarMCP) {
 
 	agent.server.tool(
 		'get_domains_ranking',
-		'Get top or trending domains',
+		'Retrieve top-performing or trending domains from Cloudflare's analytics data. Use when the user wants to analyze domain performance metrics, identify high-traffic sites, or discover trending domains for competitive analysis. Accepts `limit` (optional, number of results), `time_period` (optional, e.g., "24h" or "7d"), and `metric_type` (optional, such as "traffic" or "requests"). e.g., limit=50, time_period="24h", metric_type="traffic". Returns an error if the account lacks access to Cloudflare Analytics or if invalid time periods are specified. Do not use when you need to search general Cloudflare documentation (use search_cloudflare_documentation instead).'s domain ranking data. Use when the user wants to analyze popular websites, research domain performance metrics, or identify trending web properties. Accepts `type` (required: "top" or "trending"), `limit` (optional number of results), and `category` (optional domain category filter). e.g., type="trending", limit=50, category="technology". Do not use when you need to manage your own Cloudflare domains or DNS records (use other domain management tools instead). Returns an error if the ranking data is temporarily unavailable or the specified category does not exist.',
 		{
 			limit: PaginationLimitParam,
 			date: DateListParam.optional(),
@@ -477,7 +477,7 @@ export function registerRadarTools(agent: RadarMCP) {
 
 	agent.server.tool(
 		'get_http_data',
-		'Retrieve HTTP traffic trends.',
+		'Retrieve HTTP traffic analytics and trends from your Cloudflare account. Use when the user wants to analyze website performance metrics, bandwidth usage, or request patterns over time. Accepts `zone_id` (required), `since` and `until` (optional date range), and `metrics` (optional array of specific analytics to fetch). e.g., metrics=["requests", "bandwidth", "threats"]. Do not use when you need to search general Cloudflare documentation (use search_cloudflare_documentation instead). Returns error if the zone ID is invalid or analytics data is unavailable for the specified time range.'s dashboard. Use when the user wants to analyze website traffic patterns, request volumes, or performance metrics over time. Accepts `zone_id` (required), `time_range` (optional: "24h", "7d", "30d"), and `metrics` (optional: comma-separated list like "requests,bandwidth,threats"). e.g., zone_id="abc123", time_range="7d", metrics="requests,bandwidth". Do not use when you need R2 storage metrics (use r2_metrics_list instead). Raises an error if the zone ID is invalid or the account lacks analytics access.',
 		{
 			dateRange: DateRangeArrayParam.optional(),
 			dateStart: DateStartArrayParam.optional(),
@@ -537,7 +537,7 @@ export function registerRadarTools(agent: RadarMCP) {
 
 	agent.server.tool(
 		'get_dns_queries_data',
-		'Retrieve trends in DNS queries to the 1.1.1.1 resolver.',
+		'Retrieve DNS query trends and analytics data from Cloudflare's dashboard. Use when the user wants to analyze DNS traffic patterns, query volumes, or performance metrics for their domains. Accepts `zone_id` (required), `time_range` (optional: "1h", "24h", "7d"), and `query_type` (optional filter), e.g., zone_id="abc123", time_range="24h". Do not use when you need to search general Cloudflare documentation (use search_cloudflare_documentation instead). Returns error if the zone ID is invalid or the account lacks analytics access.'s 1.1.1.1 public resolver. Use when the user wants to analyze DNS traffic patterns, query volumes, or resolver performance metrics over time. Accepts `time_range` (optional, e.g., "24h", "7d", "30d"), `query_type` (optional, e.g., "A", "AAAA", "MX"), and `aggregation` (optional, e.g., "hourly", "daily"). e.g., time_range="7d", query_type="A" for weekly A-record query trends. Do not use when you need account-specific DNS analytics (use search_cloudflare_documentation to find zone-specific tools instead). Returns error if the time range exceeds available data retention limits.',
 		{
 			dateRange: DateRangeArrayParam.optional(),
 			dateStart: DateStartArrayParam.optional(),
@@ -594,7 +594,7 @@ export function registerRadarTools(agent: RadarMCP) {
 
 	agent.server.tool(
 		'get_l7_attack_data',
-		'Retrieve application layer (L7) attack trends.',
+		'Retrieve application layer (L7) attack trends and security analytics from Cloudflare. Use when the user wants to analyze web application threats, monitor attack patterns, or review security incidents affecting their domains. Do not use when you need general Cloudflare documentation (use search_cloudflare_documentation instead). Accepts `zone_id` (optional), `time_range` (optional), and `attack_type` (optional filter). e.g., time_range="7d" or attack_type="sql_injection". Raises an error if the zone_id is invalid or the account lacks security analytics access."24h" or attack_type="sql_injection". Returns error if the account lacks security analytics access or the zone is not found. Do not use when you need general account information (use accounts_list instead).',
 		{
 			dateRange: DateRangeArrayParam.optional(),
 			dateStart: DateStartArrayParam.optional(),
@@ -653,7 +653,7 @@ export function registerRadarTools(agent: RadarMCP) {
 
 	agent.server.tool(
 		'get_l3_attack_data',
-		'Retrieve network layer (L3/DDoS) attack trends.',
+		'Retrieve network layer (L3/DDoS) attack trends and statistics from Cloudflare's security analytics. Use when the user wants to analyze DDoS attack patterns, monitor network-level threats, or generate security reports for infrastructure protection. Do not use when you need general documentation about DDoS protection (use search_cloudflare_documentation instead). Accepts `zone_id` (optional), `time_range` (optional: "24h", "7d", "30d"), and `attack_type` (optional filter). e.g., time_range="7d" for weekly attack trends or attack_type="volumetric" for specific threat analysis. Raises an error if the account lacks access to security analytics or the zone does not exist.'s security analytics. Use when the user wants to analyze DDoS attack patterns, monitor network-level threats, or review historical attack data for security reporting. Accepts `zone_id` (optional), `time_range` (optional, e.g., "24h", "7d", "30d"), and `attack_type` (optional filter). e.g., time_range="7d" to get last week's L3 attack data. Do not use when you need application-layer (L7) attack data or general security events (use appropriate security analytics tools instead). Raises an error if the account lacks access to security analytics or if the specified zone does not exist.',
 		{
 			dateRange: DateRangeArrayParam.optional(),
 			dateStart: DateStartArrayParam.optional(),
@@ -712,7 +712,7 @@ export function registerRadarTools(agent: RadarMCP) {
 
 	agent.server.tool(
 		'get_email_routing_data',
-		'Retrieve Email Routing trends.',
+		'Retrieve Email Routing analytics and trend data from your Cloudflare account. Use when the user wants to analyze email traffic patterns, delivery statistics, or routing performance metrics over time. Do not use when you need to search general Cloudflare documentation (use search_cloudflare_documentation instead). Accepts `account_id` (required), `start_date` and `end_date` (optional ISO 8601 timestamps), and `metrics` (optional array of specific data points). e.g., metrics=["delivered", "bounced", "spam_score"]. Raises an error if the account_id is invalid or Email Routing is not enabled for the account."delivered", "bounced", "spam_score"]. Do not use when you need to configure email routing rules or destinations (use Cloudflare dashboard or API configuration tools instead). Raises an error if the account lacks Email Routing service or if date ranges exceed API limits.',
 		{
 			dateRange: DateRangeArrayParam.optional(),
 			dateStart: DateStartArrayParam.optional(),
@@ -754,7 +754,7 @@ export function registerRadarTools(agent: RadarMCP) {
 
 	agent.server.tool(
 		'get_email_security_data',
-		'Retrieve Email Security trends.',
+		'Retrieve email security trends and analytics data from your Cloudflare account. Use when the user wants to analyze email threat patterns, security metrics, or generate reports on email-based attacks. Accepts `account_id` (required), `date_range` (optional), and `metric_type` (optional filter for specific threat categories). e.g., metric_type="phishing" or "malware" for targeted analysis. Do not use when you need general account information (use accounts_list instead) or documentation lookup (use search_cloudflare_documentation instead). Raises an error if the account lacks email security services or API permissions are insufficient.'s Email Security service. Use when the user wants to analyze email threat patterns, security metrics, or monitoring data for their domain's email protection. Accepts `account_id` (required), `zone_id` (optional), `start_date` and `end_date` (optional date range parameters), and `metrics` (optional array of specific trend types). e.g., metrics=["spam_detected", "phishing_blocked", "malware_quarantined"]. Do not use when you need to search general Cloudflare documentation or configuration guides (use search_cloudflare_documentation instead). Raises an error if the account lacks Email Security subscription or if the date range exceeds the retention period.',
 		{
 			dateRange: DateRangeArrayParam.optional(),
 			dateStart: DateStartArrayParam.optional(),
@@ -796,7 +796,7 @@ export function registerRadarTools(agent: RadarMCP) {
 
 	agent.server.tool(
 		'get_internet_speed_data',
-		'Retrieve summary of bandwidth, latency, jitter, and packet loss, from the previous 90 days of Cloudflare Speed Test.',
+		'Retrieve historical internet performance metrics including bandwidth, latency, jitter, and packet loss from Cloudflare Speed Test data over the previous 90 days. Use when the user wants to analyze network performance trends, diagnose connectivity issues, or review internet speed history. Accepts no required parameters but may include optional filtering parameters. e.g., reviewing monthly performance patterns or identifying network degradation periods. Returns error if no speed test data exists for the account or if the account lacks proper permissions. Do not use when you need to run a new speed test (speed tests must be performed through Cloudflare's web interface first).',
 		{
 			dateEnd: DateEndArrayParam.optional(),
 			asn: AsnArrayParam,
@@ -846,7 +846,7 @@ export function registerRadarTools(agent: RadarMCP) {
 
 	agent.server.tool(
 		'get_internet_quality_data',
-		'Retrieves a summary or time series of bandwidth, latency, or DNS response time percentiles from the Radar Internet Quality Index (IQI).',
+		'Retrieve bandwidth, latency, or DNS response time percentiles from Cloudflare's internet quality monitoring data. Use when the user wants to analyze network performance metrics, troubleshoot connectivity issues, or monitor internet quality trends over time. Accepts `metric_type` (required: "bandwidth", "latency", or "dns_response_time"), `percentile` (optional: 50, 95, 99), `time_range` (optional), and `location` (optional). e.g., metric_type="latency", percentile=95, location="US-East". Do not use when you need general Cloudflare documentation or account information (use search_cloudflare_documentation or accounts_list instead). Raises an error if the specified metric type is invalid or if insufficient data exists for the requested time range.'s Radar Internet Quality Index. Use when the user wants to analyze internet performance metrics, compare connection quality across regions, or generate reports on network performance trends. Accepts `metric` (required: "bandwidth", "latency", or "dns"), `format` (optional: "summary" or "timeseries"), `location` (optional country/region code), and `dateRange` (optional time period). e.g., metric="bandwidth", location="US", format="timeseries". Do not use when you need to search general Cloudflare documentation or configuration guidance (use search_cloudflare_documentation instead). Returns an error if the specified location code is invalid or the date range exceeds API limits.',
 		{
 			dateRange: DateRangeArrayParam.optional(),
 			dateStart: DateStartArrayParam.optional(),
@@ -896,7 +896,7 @@ export function registerRadarTools(agent: RadarMCP) {
 
 	agent.server.tool(
 		'get_ai_data',
-		'Retrieves AI-related data, including traffic from AI user agents, as well as popular models and model tasks specifically from Cloudflare Workers AI.',
+		'Retrieve AI-related analytics data including traffic from AI user agents and popular models from Cloudflare Workers AI. Use when the user wants to analyze AI usage patterns, monitor AI bot traffic, or review model performance metrics across their Cloudflare infrastructure. Do not use when you need to search general Cloudflare documentation (use search_cloudflare_documentation instead). Accepts `account_id` (required), `start_date` and `end_date` (optional for time filtering), and `service_type` (optional for AI service filtering), e.g., service_type="workers-ai" or start_date="2024-01-01". Raises an error if the account_id is invalid or the user lacks analytics permissions for the specified account."workers-ai" or "bot-management". Raises an error if the account lacks AI analytics access or Workers AI is not enabled.',
 		{
 			dateRange: DateRangeArrayParam.optional(),
 			dateStart: DateStartArrayParam.optional(),
@@ -958,7 +958,7 @@ export function registerRadarTools(agent: RadarMCP) {
 
 	agent.server.tool(
 		'get_bgp_hijacks',
-		'Retrieve BGP hijack events. BGP hijacks occur when an AS announces routes it does not own, potentially redirecting traffic.',
+		'Retrieve BGP hijack events and security incidents from Cloudflare's threat intelligence system. Use when the user wants to investigate network security threats, analyze routing anomalies, or monitor BGP-related attacks affecting their infrastructure. Accepts `start_date` and `end_date` (optional timestamp filters), `ip_prefix` (optional CIDR block), and `limit` (optional result count). e.g., start_date="2024-01-01", ip_prefix="192.168.1.0/24". Do not use when you need general Cloudflare documentation or configuration help (use search_cloudflare_documentation instead). Returns an error if the account lacks access to security analytics features.'s network security monitoring. Use when the user wants to investigate suspicious routing announcements, analyze network security incidents, or monitor unauthorized AS route advertisements. Accepts `start_date`, `end_date` (optional date range), `asn` (optional target AS number), and `prefix` (optional IP prefix filter). e.g., asn=64512, prefix="192.0.2.0/24". Returns error if the date range exceeds the maximum query window or invalid ASN format is provided. Do not use when you need general Cloudflare documentation (use search_cloudflare_documentation instead).',
 		{
 			limit: PaginationLimitParam,
 			offset: PaginationOffsetParam,
@@ -1033,7 +1033,7 @@ export function registerRadarTools(agent: RadarMCP) {
 
 	agent.server.tool(
 		'get_bgp_leaks',
-		'Retrieve BGP route leak events. Route leaks occur when an AS improperly announces routes learned from one peer to another.',
+		'Retrieve BGP route leak events and anomalies from Cloudflare's network monitoring system. Use when the user wants to investigate network routing issues, analyze BGP hijacks, or monitor route leak incidents affecting internet traffic. Accepts `start_time` and `end_time` (optional datetime filters), `asn` (optional autonomous system number), and `leak_type` (optional filter). e.g., asn=13335, leak_type="hijack". Do not use when you need general Cloudflare documentation or account information (use search_cloudflare_documentation or accounts_list instead). Returns an error if the time range exceeds the maximum query window or if invalid ASN format is provided.'s network monitoring system. Use when the user wants to investigate network routing anomalies, analyze AS path violations, or troubleshoot connectivity issues caused by improper route announcements. Accepts `start_time` and `end_time` (optional datetime filters), `asn` (optional autonomous system number), and `limit` (optional result count). e.g., asn=64512, start_time="2024-01-01T00:00:00Z". Do not use when you need general network metrics or performance data (use other monitoring tools instead). Returns an error if the specified time range exceeds the maximum query window or if invalid ASN format is provided.',
 		{
 			limit: PaginationLimitParam,
 			offset: PaginationOffsetParam,
@@ -1096,7 +1096,7 @@ export function registerRadarTools(agent: RadarMCP) {
 
 	agent.server.tool(
 		'get_bgp_route_stats',
-		'Retrieve BGP routing table statistics including number of routes, origin ASes, and more.',
+		'Retrieve BGP routing table statistics including total route counts, origin AS numbers, and network prefixes. Use when the user wants to analyze internet routing data, monitor BGP table growth, or investigate network reachability patterns. Do not use when you need to search general Cloudflare documentation (use search_cloudflare_documentation instead). Accepts optional filtering parameters such as `prefix` (CIDR notation) and `asn` (autonomous system number), e.g., prefix="192.168.1.0/24" or asn=13335. Raises an error if the specified prefix format is invalid or the ASN does not exist."192.168.0.0/16" or asn="64512". Raises an error if the BGP data source is temporarily unavailable or rate limits are exceeded.',
 		{
 			asn: AsnParam.optional(),
 			location: LocationParam.optional(),
@@ -1138,7 +1138,7 @@ export function registerRadarTools(agent: RadarMCP) {
 
 	agent.server.tool(
 		'get_bots_data',
-		'Retrieve bot traffic data including trends by bot name, operator, category, and kind. Covers AI crawlers, search engines, monitoring bots, and more.',
+		'Retrieve bot traffic analytics and trends from Cloudflare including breakdowns by bot name, operator, category, and type. Use when the user wants to analyze automated traffic patterns, monitor crawler activity, or investigate bot behavior on their websites. Do not use when you need general Cloudflare documentation (use search_cloudflare_documentation instead). Accepts `zone_id` (required), `since` and `until` (optional date filters), and `dimensions` (optional: bot_name, operator, category, kind). e.g., dimensions= for all dimensions or specific values. Raises an error if the zone does not exist or access is denied."bot_name,category" to group by both bot name and category. Do not use when you need general website analytics or human traffic data (use other analytics tools instead). Raises an error if the zone ID is invalid or the account lacks Bot Management entitlements.',
 		{
 			dateRange: DateRangeArrayParam.optional(),
 			dateStart: DateStartArrayParam.optional(),
@@ -1217,7 +1217,7 @@ export function registerRadarTools(agent: RadarMCP) {
 
 	agent.server.tool(
 		'get_certificate_transparency_data',
-		'Retrieve Certificate Transparency (CT) log data. CT provides visibility into SSL/TLS certificates issued for domains, useful for security monitoring.',
+		'Retrieve Certificate Transparency log data for SSL/TLS certificates issued to specific domains. Use when the user wants to monitor certificate issuance, investigate potential security threats, or audit SSL certificate history for domain security analysis. Do not use when you need to search general Cloudflare documentation (use search_cloudflare_documentation instead). Accepts `domain` (required string) and optional `limit` parameter to control result count, e.g., domain="example.com", limit=50. Returns error if the domain format is invalid or the Certificate Transparency logs are temporarily unavailable."example.com" or domain="*.cloudflare.com" for wildcard certificates. Returns error if the domain format is invalid or CT logs are temporarily unavailable. Do not use when you need to manage Cloudflare-issued certificates or SSL settings (use Cloudflare SSL management tools instead).',
 		{
 			dateRange: DateRangeArrayParam.optional(),
 			dateStart: DateStartArrayParam.optional(),
@@ -1294,7 +1294,7 @@ export function registerRadarTools(agent: RadarMCP) {
 
 	agent.server.tool(
 		'get_netflows_data',
-		'Retrieve NetFlows traffic data showing network traffic patterns. Supports filtering by ADM1 (administrative level 1, e.g., states/provinces) via geoId.',
+		'Retrieve NetFlows traffic data showing network communication patterns and bandwidth usage across geographic regions. Use when the user wants to analyze network traffic flows, monitor data transfer patterns, or investigate connectivity between locations. Do not use when you need to search general Cloudflare documentation (use search_cloudflare_documentation instead). Accepts `geoId` (optional) to filter by ADM1 administrative regions such as states or provinces, e.g., "US-CA" for California or "GB-ENG" for England. Raises an error if the specified geoId format is invalid or the region code does not exist. "US-CA" for California or "GB-ENG" for England. Do not use when you need to query application-specific logs or database records (use d1_database_query instead). Raises an error if the specified geoId format is invalid or the region is not supported.',
 		{
 			dateRange: DateRangeArrayParam.optional(),
 			dateStart: DateStartArrayParam.optional(),
@@ -1367,7 +1367,7 @@ export function registerRadarTools(agent: RadarMCP) {
 
 	agent.server.tool(
 		'list_origins',
-		'List cloud provider origins (hyperscalers) available in Cloud Observatory. Returns Amazon (AWS), Google (GCP), Microsoft (Azure), and Oracle (OCI) with their available regions.',
+		'List available cloud provider origins and their regions in Cloud Observatory. Use when the user wants to discover which hyperscalers and geographic regions are supported for cloud monitoring or analysis. Do not use when you need to search general Cloudflare documentation (use search_cloudflare_documentation instead). Accepts `filter` (optional string for specific providers). Returns data for Amazon (AWS), Google (GCP), Microsoft (Azure), and Oracle (OCI) with their respective regional availability, e.g., "us-east-1" or "europe-west1". Raises an error if the Cloud Observatory service is unavailable. "AWS" with regions such as "us-east-1", "eu-west-1". Do not use when you need to query specific account data from these providers (use the respective provider-specific tools instead). Fails if the Cloud Observatory service is unavailable.',
 		{
 			limit: PaginationLimitParam,
 			offset: PaginationOffsetParam,
@@ -1403,7 +1403,7 @@ export function registerRadarTools(agent: RadarMCP) {
 
 	agent.server.tool(
 		'get_origin_details',
-		'Get details for a specific cloud provider origin, including all available regions.',
+		'Retrieve details for a specific cloud provider origin, including all available regions and configuration settings. Use when the user wants to inspect or review the configuration of an existing origin before making changes or troubleshooting connectivity issues. Do not use when you need to search for documentation or guidance (use search_cloudflare_documentation instead). Accepts `origin_id` (required) to specify which origin to retrieve. e.g., origin_id="12345". Raises an error if the origin_id does not exist or is inaccessible."aws-us-east-1-origin" or origin_id="gcp-europe-west1". Returns error if the origin ID does not exist or access is denied. Do not use when you need to list all available origins (use a list origins tool instead).',
 		{
 			slug: OriginSlugParam,
 		},
@@ -1435,7 +1435,7 @@ export function registerRadarTools(agent: RadarMCP) {
 
 	agent.server.tool(
 		'get_origins_data',
-		'Retrieve cloud provider (AWS, GCP, Azure, OCI) performance metrics. Supports timeseries, summaries grouped by region/success_rate/percentile, and grouped timeseries.',
+		'Retrieve cloud provider performance metrics and analytics data from AWS, GCP, Azure, and OCI origins. Use when the user wants to analyze performance trends, compare regional metrics, or generate reports on success rates and response times. Do not use when you need R2 bucket-specific metrics (use r2_metrics_list instead). Accepts `provider` (required: "aws", "gcp", "azure", or "oci"), `region` (optional), and `time_range` (optional). e.g., provider="aws", region="us-east-1", time_range="24h". Raises an error if the specified provider or region is not supported. "aws", "gcp", "azure", "oci"), `metric_type` (optional: "timeseries", "summary", "grouped"), `region` (optional), and `time_range` (optional). e.g., provider="aws", metric_type="timeseries", region="us-east-1". Returns error if the specified provider or region is not supported. Do not use when you need R2 storage metrics (use r2_metrics_list instead).',
 		{
 			dimension: OriginDataDimensionParam,
 			origin: OriginArrayParam,
@@ -1510,7 +1510,7 @@ export function registerRadarTools(agent: RadarMCP) {
 
 	agent.server.tool(
 		'get_robots_txt_data',
-		'Retrieve robots.txt analysis data. Shows how websites configure crawler access rules, particularly for AI crawlers. Useful for understanding web crawler policies across domains.',
+		'Retrieve robots.txt analysis data showing how websites configure crawler access rules and AI bot permissions. Use when the user wants to analyze web crawler policies, check bot access restrictions, or understand site crawling configurations across domains. Do not use when you need to search Cloudflare-specific documentation or configuration (use search_cloudflare_documentation instead). Accepts `domain` or `url` (required) parameters, e.g., "example.com" or "https://example.com/robots.txt". Raises an error if the domain is unreachable or does not have a robots.txt file. "example.com" or "https://site.com/robots.txt". Returns structured data including allowed/disallowed paths, crawl delays, and sitemap locations for various user agents such as Googlebot, GPTBot, or ChatGPT-User. Raises an error if the domain is unreachable or robots.txt file is malformed. Do not use when you need to search Cloudflare-specific documentation (use search_cloudflare_documentation instead).',
 		{
 			dateRange: DateRangeArrayParam.optional(),
 			dateStart: DateStartArrayParam.optional(),
@@ -1585,7 +1585,7 @@ export function registerRadarTools(agent: RadarMCP) {
 
 	agent.server.tool(
 		'get_bots_crawlers_data',
-		'Retrieve web crawler HTTP request data. Shows crawler traffic patterns by client type, user agent, referrer, and industry. Useful for analyzing crawler behavior and traffic distribution.',
+		'Retrieve web crawler HTTP request data showing traffic patterns by client type, user agent, referrer, and industry. Use when the user wants to analyze bot behavior, monitor crawler activity, or investigate suspicious automated traffic on their Cloudflare-protected domains. Do not use when you need general analytics data (use other analytics tools instead). Accepts `zone_id` (required), `date_range` (optional), and `filter` parameters for specific crawler types, e.g., zone_id="abc123def456", date_range="7d", filter="googlebot". Raises an error if the zone is not accessible or does not exist."abc123", filter="googlebot". Returns error if the zone does not exist or analytics are not enabled for the account.',
 		{
 			dateRange: DateRangeArrayParam.optional(),
 			dateStart: DateStartArrayParam.optional(),
@@ -1649,7 +1649,7 @@ export function registerRadarTools(agent: RadarMCP) {
 
 	agent.server.tool(
 		'list_bots',
-		'List known bots with their details. Includes AI crawlers, search engines, monitoring bots, and more. Filter by category, operator, kind, or verification status.',
+		'List known bots with their details including AI crawlers, search engines, and monitoring bots. Use when the user wants to identify, categorize, or analyze bot traffic patterns and verification status. Do not use when you need to search Cloudflare documentation about bot management (use search_cloudflare_documentation instead). Accepts `category` (optional: filter by bot type), `operator` (optional: filter by company), `kind` (optional: filter by purpose), and `verification_status` (optional: verified/unverified). e.g., category="search_engine" or operator="Google". Returns an error if the API request fails or authentication is invalid."search_engine", operator="Google", kind="crawler". Do not use when you need to search Cloudflare-specific documentation about bot management (use search_cloudflare_documentation instead). Returns an error if invalid filter parameters are provided.',
 		{
 			limit: PaginationLimitParam,
 			offset: PaginationOffsetParam,
@@ -1716,7 +1716,7 @@ export function registerRadarTools(agent: RadarMCP) {
 
 	agent.server.tool(
 		'get_bot_details',
-		'Get detailed information about a specific bot by its slug identifier.',
+		'Retrieve detailed information about a specific bot by its slug identifier. Use when the user wants to inspect configuration, settings, or metadata for a particular Cloudflare bot. Do not use when you need to search documentation about bots (use search_cloudflare_documentation instead). Accepts `slug` (required string identifier), e.g., "good-bot" or "security-scanner". Raises an error if the bot slug does not exist or you lack permissions to access it. "my-chatbot" or "support-assistant". Do not use when you need to list all available bots (use a general listing tool instead). Raises an error if the bot slug does not exist or you lack permissions to access it.',
 		{
 			botSlug: SlugParam.describe('The bot slug identifier (e.g., "googlebot", "bingbot").'),
 		},
@@ -1754,7 +1754,7 @@ export function registerRadarTools(agent: RadarMCP) {
 
 	agent.server.tool(
 		'get_leaked_credentials_data',
-		'Retrieve trends in HTTP authentication requests and compromised credential detection. Shows distribution by compromised status and bot class.',
+		'Retrieve trends and analytics for HTTP authentication requests and compromised credential detection across your Cloudflare account. Use when the user wants to analyze security threats, review credential breach patterns, or monitor authentication attack trends. Shows distribution data by compromised status and bot classification categories. Accepts optional time range parameters such as `start_date` and `end_date` for filtering results, e.g., last 30 days or specific incident timeframes. Do not use when you need to search general Cloudflare documentation or configuration guides (use search_cloudflare_documentation instead). Returns an error if the account lacks Security Analytics access or if the specified date range is invalid.',
 		{
 			dateRange: DateRangeArrayParam.optional(),
 			dateStart: DateStartArrayParam.optional(),
@@ -1825,7 +1825,7 @@ export function registerRadarTools(agent: RadarMCP) {
 
 	agent.server.tool(
 		'get_as112_data',
-		'Retrieve AS112 DNS sink hole data. AS112 handles reverse DNS lookups for private IP addresses (RFC 1918). Useful for analyzing DNS misconfiguration patterns.',
+		'Retrieve AS112 DNS sink hole data for analyzing reverse DNS lookup patterns and misconfigurations. Use when the user wants to investigate DNS traffic patterns for private IP addresses or diagnose RFC 1918 reverse DNS issues. Do not use when you need to search general Cloudflare documentation (use search_cloudflare_documentation instead). Accepts optional filtering parameters such as `time_range` and `query_type`. e.g., analyzing queries for 10.0.0.0/8 or 192.168.0.0/16 address ranges. Returns error if the AS112 service is temporarily unavailable or rate limits are exceeded.',
 		{
 			dateRange: DateRangeArrayParam.optional(),
 			dateStart: DateStartArrayParam.optional(),
@@ -1898,7 +1898,7 @@ export function registerRadarTools(agent: RadarMCP) {
 
 	agent.server.tool(
 		'list_geolocations',
-		'List available geolocations (ADM1 - administrative divisions like states/provinces). Use this to find GeoNames IDs for filtering HTTP and NetFlows data by region.',
+		'List available administrative divisions (states, provinces, regions) with their GeoNames IDs for geographic filtering. Use when the user wants to find specific geographic regions to filter Cloudflare HTTP logs or NetFlows data by location. Do not use when you need to query actual traffic data (use appropriate analytics tools instead). Accepts no required parameters but may support optional filtering by `country_code` or `region_type`. e.g., returns entries like "California (US-CA, ID: 5332921)" or "Ontario (CA-ON, ID: 6093943)". Raises an error if the GeoNames service is unavailable or rate limits are exceeded. "California (US-CA, GeoNames ID: 5332921)" or "Ontario (CA-ON, GeoNames ID: 6093943)". Raises an error if the GeoNames service is unavailable or rate-limited.',
 		{
 			limit: PaginationLimitParam,
 			offset: PaginationOffsetParam,
@@ -1938,7 +1938,7 @@ export function registerRadarTools(agent: RadarMCP) {
 
 	agent.server.tool(
 		'get_geolocation_details',
-		'Get details for a specific geolocation by its GeoNames ID.',
+		'Retrieve detailed information for a specific geographic location using its GeoNames ID. Use when the user wants to get comprehensive location data including coordinates, population, timezone, and administrative details for a known GeoNames identifier. Accepts `geonames_id` (required integer), e.g., 2643743 for London or 5128581 for New York City. Do not use when you need to search for locations by name or coordinates (use location search tools instead). Returns error if the GeoNames ID does not exist or the service is unavailable.',
 		{
 			geoId: GeoIdParam,
 		},
@@ -1974,7 +1974,7 @@ export function registerRadarTools(agent: RadarMCP) {
 
 	agent.server.tool(
 		'get_tcp_resets_timeouts_data',
-		'Retrieve TCP connection quality metrics including resets and timeouts. Useful for understanding connection reliability across networks and locations.',
+		'Retrieve TCP connection quality metrics including resets and timeouts for network reliability analysis. Use when the user wants to diagnose connection issues, monitor network performance, or analyze TCP reliability patterns across different locations. Do not use when you need general documentation about Cloudflare networking (use search_cloudflare_documentation instead). Accepts `zone_id` (required), `time_range` (optional), and `location_filters` (optional array). e.g., zone_id="abc123def456", time_range="24h", location_filters=["US", "EU"]. Raises an error if the zone_id is invalid or the account lacks analytics permissions."abc123", time_range="24h", location_filters=["US", "EU"]. Do not use when you need general R2 or D1 performance metrics (use r2_metrics_list or d1_database_query instead). Returns error if the zone ID is invalid or analytics data is unavailable for the specified time range.',
 		{
 			dateRange: DateRangeArrayParam.optional(),
 			dateStart: DateStartArrayParam.optional(),
@@ -2029,7 +2029,7 @@ export function registerRadarTools(agent: RadarMCP) {
 
 	agent.server.tool(
 		'get_annotations',
-		'Retrieve annotations including Internet events, outages, and anomalies from various Cloudflare data sources.',
+		'Retrieve annotations including Internet events, outages, and anomalies from various Cloudflare data sources. Use when the user wants to investigate network incidents, analyze service disruptions, or review historical Internet events affecting Cloudflare infrastructure. Do not use when you need to search general Cloudflare documentation (use search_cloudflare_documentation instead). Accepts `start_date`, `end_date` (optional date range), `event_type` (optional filter), and `data_source` (optional source specification). e.g., event_type="outage" or data_source="radar". Raises an error if the date range is invalid or exceeds the maximum allowed query period."outage" or data_source="radar". Raises an error if the date range exceeds the maximum allowed query window or if authentication fails.',
 		{
 			limit: PaginationLimitParam,
 			offset: PaginationOffsetParam,
@@ -2089,7 +2089,7 @@ export function registerRadarTools(agent: RadarMCP) {
 
 	agent.server.tool(
 		'get_outages',
-		'Retrieve Internet outages and anomalies. Provides information about detected connectivity issues across ASes and locations.',
+		'Retrieve Internet outages and connectivity anomalies across autonomous systems and geographic locations. Use when the user wants to investigate network disruptions, monitor global connectivity issues, or analyze Internet infrastructure problems. Do not use when you need to search Cloudflare-specific documentation or troubleshoot Cloudflare services (use search_cloudflare_documentation instead). Accepts `location` (optional geographic filter), `asn` (optional autonomous system number), and `time_range` (optional duration filter). e.g., location="United States", asn=13335, time_range="24h". Returns error if the API service is unavailable or rate limits are exceeded."US-CA" or asn="13335" for Cloudflare's network. Returns error if the API rate limit is exceeded or invalid ASN format is provided. Do not use when you need to query specific Cloudflare service metrics (use r2_metrics_list or other service-specific tools instead).',
 		{
 			limit: PaginationLimitParam,
 			offset: PaginationOffsetParam,
@@ -2139,7 +2139,7 @@ export function registerRadarTools(agent: RadarMCP) {
 
 	agent.server.tool(
 		'list_ct_authorities',
-		'List Certificate Authorities (CAs) tracked in Certificate Transparency logs.',
+		'List Certificate Authorities (CAs) tracked in Certificate Transparency logs. Use when the user wants to review, audit, or investigate which certificate authorities are issuing certificates for domains. Do not use when you need to search Cloudflare-specific documentation or manage Cloudflare services (use search_cloudflare_documentation or other Cloudflare tools instead). Accepts optional filtering parameters such as `domain` and `log_name`, e.g., filtering by specific CT log sources like "Google Argon" or domain "example.com". Returns error if the CT log service is unavailable or rate limits are exceeded. "Google Argon" or "Cloudflare Nimbus". Returns an error if the Certificate Transparency service is unavailable or rate limits are exceeded.',
 		{
 			limit: PaginationLimitParam,
 			offset: PaginationOffsetParam,
@@ -2175,7 +2175,7 @@ export function registerRadarTools(agent: RadarMCP) {
 
 	agent.server.tool(
 		'get_ct_authority_details',
-		'Get details for a specific Certificate Authority by its SHA256 fingerprint.',
+		'Retrieve detailed information about a specific Certificate Authority using its SHA256 fingerprint. Use when the user wants to inspect or verify CA certificate details, validation status, or trust chain information. Do not use when you need to search general Cloudflare documentation (use search_cloudflare_documentation instead). Accepts `fingerprint` (required SHA256 hash string), e.g., fingerprint="a1b2c3d4e5f6...". Raises an error if the fingerprint is invalid or the CA is not found in the certificate transparency logs."a1b2c3d4e5f6789012345678901234567890abcdef1234567890abcdef123456". Raises an error if the fingerprint format is invalid or the CA is not found in Cloudflare's database.',
 		{
 			caSlug: Sha256FingerprintParam.describe(
 				'The Certificate Authority SHA256 fingerprint (64 hexadecimal characters).'
@@ -2209,7 +2209,7 @@ export function registerRadarTools(agent: RadarMCP) {
 
 	agent.server.tool(
 		'list_ct_logs',
-		'List Certificate Transparency logs.',
+		'List Certificate Transparency logs available in Cloudflare. Use when the user wants to view or inspect CT log endpoints for certificate monitoring and transparency compliance. Accepts no required parameters but may include optional filtering parameters. e.g., retrieving logs for certificate validation or audit purposes. Do not use when you need to search general Cloudflare documentation (use search_cloudflare_documentation instead). Returns an error if the API request fails or authentication is invalid.',
 		{
 			limit: PaginationLimitParam,
 			offset: PaginationOffsetParam,
@@ -2245,7 +2245,7 @@ export function registerRadarTools(agent: RadarMCP) {
 
 	agent.server.tool(
 		'get_ct_log_details',
-		'Get details for a specific Certificate Transparency log by its slug.',
+		'Retrieve detailed information about a specific Certificate Transparency log using its unique identifier. Use when the user wants to inspect CT log properties, configuration details, or operational status for a particular log. Do not use when you need to search or browse multiple CT logs (use search_cloudflare_documentation instead). Accepts `slug` (required string identifier for the CT log), e.g., "google-pilot" or "cloudflare-nimbus2021". Raises an error if the slug does not match any existing CT log. "google-pilot" or "cloudflare-nimbus2024". Do not use when you need general Cloudflare account information (use accounts_list instead). Raises an error if the slug does not correspond to an existing Certificate Transparency log.',
 		{
 			logSlug: SlugParam.describe('The Certificate Transparency log slug identifier.'),
 		},
@@ -2281,7 +2281,7 @@ export function registerRadarTools(agent: RadarMCP) {
 
 	agent.server.tool(
 		'get_bgp_timeseries',
-		'Retrieve BGP updates time series data. Shows BGP announcement and withdrawal patterns over time.',
+		'Retrieve BGP updates time series data showing announcement and withdrawal patterns over time. Use when the user wants to analyze BGP routing changes, monitor network stability, or investigate connectivity issues across specific time periods. Do not use when you need to search general Cloudflare documentation (use search_cloudflare_documentation instead). Accepts `prefix` (optional IP prefix), `start_time` and `end_time` (required timestamps), and `asn` (optional autonomous system number). e.g., prefix="192.168.1.0/24", start_time="2024-01-01T00:00:00Z", end_time="2024-01-02T00:00:00Z". Raises an error if the time range exceeds the maximum allowed query window or if timestamps are malformed."192.0.2.0/24", start_time="2024-01-01T00:00:00Z". Do not use when you need real-time BGP routing table data (use a live BGP lookup tool instead). Returns error if the time range exceeds the maximum allowed query window or if invalid timestamp formats are provided.',
 		{
 			dateRange: DateRangeArrayParam.optional(),
 			dateStart: DateStartArrayParam.optional(),
@@ -2325,7 +2325,7 @@ export function registerRadarTools(agent: RadarMCP) {
 
 	agent.server.tool(
 		'get_bgp_top_ases',
-		'Get top Autonomous Systems by BGP update count.',
+		'Retrieve the top Autonomous Systems ranked by BGP update count from Cloudflare's network intelligence data. Use when the user wants to analyze BGP routing activity, identify the most active network operators, or investigate internet routing patterns. Accepts optional `limit` parameter to control the number of results returned. e.g., limit=50 to get the top 50 ASes by update volume. Returns error if Cloudflare's BGP data service is temporarily unavailable. Do not use when you need account-specific Cloudflare resources like databases or workers (use the respective d1_ or workers_ tools instead).'s network analytics. Use when the user wants to analyze network traffic patterns, identify high-activity ASes, or investigate BGP routing behavior. Accepts `limit` (optional, number of results), `time_range` (optional, e.g., "1h", "24h", "7d"), and `order` (optional, "asc" or "desc"). e.g., limit=10, time_range="24h". Returns error if the time range is invalid or exceeds API limits. Do not use when you need general Cloudflare documentation (use search_cloudflare_documentation instead).',
 		{
 			limit: PaginationLimitParam,
 			dateRange: DateRangeArrayParam.optional(),
@@ -2371,7 +2371,7 @@ export function registerRadarTools(agent: RadarMCP) {
 
 	agent.server.tool(
 		'get_bgp_top_prefixes',
-		'Get top IP prefixes by BGP update count.',
+		'Retrieve the top IP prefixes ranked by BGP update count from Cloudflare's global network data. Use when the user wants to analyze network traffic patterns, identify the most active IP address ranges, or investigate BGP routing activity. Accepts `limit` (optional, number of results) and `time_period` (optional, filtering timeframe). e.g., retrieving the top 100 most updated prefixes from the last 24 hours. Returns an error if the Cloudflare API is unavailable or rate limits are exceeded. Do not use when you need to search general Cloudflare documentation (use search_cloudflare_documentation instead).'s network analytics. Use when the user wants to analyze network traffic patterns, identify high-activity IP ranges, or investigate BGP routing behavior. Accepts `limit` (optional, number of results to return) and `time_range` (optional, analysis period). e.g., limit=10 for top 10 prefixes or time_range="24h" for last day. Returns an error if the account lacks access to BGP analytics or if the time range is invalid. Do not use when you need general Cloudflare documentation (use search_cloudflare_documentation instead).',
 		{
 			limit: PaginationLimitParam,
 			dateRange: DateRangeArrayParam.optional(),
@@ -2415,7 +2415,7 @@ export function registerRadarTools(agent: RadarMCP) {
 
 	agent.server.tool(
 		'get_bgp_moas',
-		'Get Multi-Origin AS (MOAS) prefixes. MOAS occurs when a prefix is announced by multiple ASes, which can indicate hijacking or legitimate anycast.',
+		'Retrieve Multi-Origin AS (MOAS) prefixes that are announced by multiple Autonomous Systems. Use when the user wants to investigate potential BGP hijacking incidents or analyze legitimate anycast deployments across multiple ASes. Do not use when you need general Cloudflare account or service information (use other Cloudflare tools instead). Accepts `prefix` (optional IP prefix to filter results) and `asn` (optional AS number to focus on). e.g., prefix="192.0.2.0/24" or asn=64512. Returns error if the BGP data service is unavailable or the prefix format is invalid."192.0.2.0/24" or asn="64512". Returns error if the BGP data source is temporarily unavailable. Do not use when you need to search Cloudflare-specific documentation or configuration details (use search_cloudflare_documentation instead).',
 		{
 			origin: BgpOriginParam,
 			prefix: BgpPrefixParam,
@@ -2453,7 +2453,7 @@ export function registerRadarTools(agent: RadarMCP) {
 
 	agent.server.tool(
 		'get_bgp_pfx2as',
-		'Get prefix-to-ASN mapping. Useful for looking up which AS announces a given IP prefix.',
+		'Retrieve prefix-to-ASN mapping for a given IP prefix to identify which Autonomous System announces it. Use when the user wants to investigate network routing, trace IP ownership, or analyze BGP announcements for security or troubleshooting purposes. Do not use when you need to query Cloudflare-specific services or databases (use the appropriate Cloudflare tools instead). Accepts `prefix` (required IP prefix in CIDR notation), e.g., "192.0.2.0/24" or "2001:db8::/32". Returns error if the prefix format is invalid or the BGP data is unavailable.',
 		{
 			prefix: BgpPrefixParam,
 			origin: BgpOriginParam,
@@ -2493,7 +2493,7 @@ export function registerRadarTools(agent: RadarMCP) {
 
 	agent.server.tool(
 		'get_bgp_ip_space_timeseries',
-		'Retrieve announced IP address space time series data. Shows the count of announced IPv4 /24s and IPv6 /48s over time. Essential for monitoring BGP route withdrawals, IPv6 address space changes, and detecting significant routing events by ASN or country.',
+		'Retrieve time series data showing announced IPv4 /24 and IPv6 /48 address space counts over time for BGP monitoring. Use when the user wants to analyze routing announcements, track IP space changes, monitor route withdrawals, or detect significant BGP events by ASN or country. Do not use when you need to search general Cloudflare documentation (use search_cloudflare_documentation instead). Accepts `asn` (optional), `country` (optional), `start_date`, and `end_date` (required) parameters with ISO format dates. e.g., asn=13335 for Cloudflare, start_date="2024-01-01", end_date="2024-01-31". Raises an error if the date range is invalid or exceeds the maximum allowed timespan.'s network or country="US" for United States announcements. Returns error if the date range exceeds API limits or ASN format is invalid. Do not use when you need real-time BGP route table data (use a live BGP monitoring tool instead).',
 		{
 			dateRange: DateRangeArrayParam.optional(),
 			dateStart: DateStartArrayParam.optional(),
@@ -2537,7 +2537,7 @@ export function registerRadarTools(agent: RadarMCP) {
 
 	agent.server.tool(
 		'get_bgp_routes_realtime',
-		'Get real-time BGP routes for a specific IP prefix using public route collectors (RouteViews and RIPE RIS). Shows current routing state including AS paths, RPKI validation status, and visibility across peers. Useful for troubleshooting routing issues and verifying route announcements.',
+		'Retrieve real-time BGP routes for a specific IP prefix using public route collectors. Use when the user wants to troubleshoot routing issues, verify route announcements, or analyze current BGP visibility across internet peers. Do not use when you need to search Cloudflare-specific documentation or configuration (use search_cloudflare_documentation instead). Accepts `prefix` (required IP prefix), e.g., "192.0.2.0/24" or "2001:db8::/32". Raises an error if the prefix format is invalid or no route data is available from collectors. "8.8.8.0/24" or "2001:4860::/32". Returns AS paths, RPKI validation status, and peer visibility from RouteViews and RIPE RIS collectors. Do not use when you need to manage Cloudflare-specific routing or DNS settings (use other Cloudflare tools instead). Raises an error if the prefix format is invalid or collectors are unreachable.',
 		{
 			prefix: BgpPrefixParam,
 		},
@@ -2575,7 +2575,7 @@ export function registerRadarTools(agent: RadarMCP) {
 
 	agent.server.tool(
 		'get_as_set',
-		'Get IRR AS-SETs that an Autonomous System is a member of. AS-SETs are used in routing policies.',
+		'Retrieve IRR AS-SETs that an Autonomous System is a member of for routing policy analysis. Use when the user wants to identify which AS-SET groups contain a specific autonomous system number. Accepts `asn` (required autonomous system number). e.g., ASN 64512 or AS15169. Returns an error if the ASN is invalid or not found in IRR databases. Do not use when you need to query Cloudflare-specific network configurations (use search_cloudflare_documentation instead).',
 		{
 			asn: AsnParam,
 		},
@@ -2607,7 +2607,7 @@ export function registerRadarTools(agent: RadarMCP) {
 
 	agent.server.tool(
 		'get_as_relationships',
-		'Get AS-level relationships for an Autonomous System. Shows peer, upstream, and downstream relationships with other ASes.',
+		'Retrieve AS-level relationships for an Autonomous System, showing peer, upstream, and downstream connections with other ASes. Use when the user wants to analyze network topology, investigate routing relationships, or understand AS interconnections for a specific autonomous system. Accepts `asn` (required autonomous system number). e.g., ASN 13335 for Cloudflare or ASN 15169 for Google. Returns error if the ASN does not exist or is not publicly routable. Do not use when you need to search Cloudflare documentation or manage Cloudflare resources (use search_cloudflare_documentation or respective account management tools instead).',
 		{
 			asn: AsnParam,
 			asn2: z
@@ -2651,7 +2651,7 @@ export function registerRadarTools(agent: RadarMCP) {
 
 	agent.server.tool(
 		'list_tlds',
-		'List top-level domains (TLDs) including generic, country-code, and sponsored TLDs. Filter by type or manager.',
+		'List top-level domains (TLDs) including generic, country-code, and sponsored TLDs with optional filtering capabilities. Use when the user wants to browse available domain extensions, research TLD types, or validate domain naming options. Do not use when you need to search Cloudflare-specific documentation (use search_cloudflare_documentation instead). Accepts `type` (optional: "generic", "country-code", or "sponsored") for filtering results. e.g., type="generic" returns .com, .org, .net extensions. Returns an error if an invalid type parameter is provided. "generic", "country-code", or "sponsored") and `manager` (optional: registry organization name) parameters. e.g., type="generic" for .com/.org extensions or manager="Verisign" for specific registry domains. Returns an error if an invalid TLD type is specified. Do not use when you need to manage Cloudflare-specific resources like databases or workers (use the respective d1_ or workers_ tools instead).',
 		{
 			limit: PaginationLimitParam,
 			offset: PaginationOffsetParam,
@@ -2693,7 +2693,7 @@ export function registerRadarTools(agent: RadarMCP) {
 
 	agent.server.tool(
 		'get_tld_details',
-		'Get detailed information about a specific top-level domain (TLD).',
+		'Retrieve detailed information about a specific top-level domain (TLD) including registration policies, pricing, and availability status. Use when the user wants to research domain extension details, compare TLD options, or understand registration requirements for a specific domain suffix. Do not use when you need to search general Cloudflare documentation (use search_cloudflare_documentation instead). Accepts `tld` (required string), e.g., "com", "org", or "io". Raises an error if the TLD is not recognized or supported by the registry. "com", "org", or "io". e.g., tld="dev" or tld="co.uk". Do not use when you need to search general Cloudflare documentation (use search_cloudflare_documentation instead). Raises an error if the TLD is not recognized or supported by Cloudflare.',
 		{
 			tld: TldParam,
 		},
@@ -2729,7 +2729,7 @@ export function registerRadarTools(agent: RadarMCP) {
 
 	agent.server.tool(
 		'get_domains_ranking_timeseries',
-		'Get domain ranking timeseries data. Track how specific domains rank over time.',
+		'Retrieve domain ranking timeseries data to track how specific domains perform over time. Use when the user wants to analyze domain ranking trends, monitor SEO performance changes, or compare historical ranking positions across different time periods. Do not use when you need to search Cloudflare documentation or manage Cloudflare services (use search_cloudflare_documentation or other Cloudflare tools instead). Accepts `domain` (required), `start_date` and `end_date` (optional date range), and `metrics` (optional ranking indicators). e.g., domain="example.com", start_date="2024-01-01", end_date="2024-12-31". Raises an error if the domain format is invalid or the date range exceeds API limits."example.com", start_date="2024-01-01", end_date="2024-03-01". Do not use when you need to search Cloudflare documentation for ranking concepts (use search_cloudflare_documentation instead). Raises an error if the domain has insufficient historical data or the date range exceeds available records.',
 		{
 			dateRange: DateRangeArrayParam.optional(),
 			dateStart: DateStartArrayParam.optional(),
@@ -2779,7 +2779,7 @@ export function registerRadarTools(agent: RadarMCP) {
 
 	agent.server.tool(
 		'get_speed_histogram',
-		'Get speed test histogram data. Shows distribution of speed test results for bandwidth, latency, or jitter.',
+		'Retrieve speed test histogram data showing the distribution of network performance measurements. Use when the user wants to analyze patterns, trends, or statistical distribution of bandwidth, latency, or jitter test results over time. Do not use when you need to search for documentation about speed testing (use search_cloudflare_documentation instead). Accepts `metric_type` (required: "bandwidth", "latency", or "jitter"), `time_range` (optional), and `bin_count` (optional). e.g., metric_type="bandwidth", time_range="7d". Raises an error if the metric type is invalid or no speed test data exists for the specified parameters. "bandwidth", "latency", or "jitter"), `time_range` (optional), and `account_id` (optional). e.g., metric_type="bandwidth" for download/upload speed distributions or metric_type="latency" for response time patterns. Returns error if no speed test data exists for the specified parameters. Do not use when you need to run new speed tests or get real-time metrics (use other monitoring tools instead).',
 		{
 			dateEnd: DateEndArrayParam.optional(),
 			asn: AsnArrayParam,
@@ -2827,7 +2827,7 @@ export function registerRadarTools(agent: RadarMCP) {
 
 	agent.server.tool(
 		'get_internet_services_timeseries',
-		'Track internet service ranking changes over time. Useful for monitoring how services like ChatGPT, Google, etc. rank over time.',
+		'Retrieve historical ranking data for internet services to analyze performance trends over time. Use when the user wants to monitor, compare, or analyze how services like ChatGPT, Google, or other platforms have changed in popularity or ranking metrics across different time periods. Do not use when you need to query current Cloudflare database records (use d1_database_query instead). Accepts `service_name` (required), `start_date` and `end_date` (optional date range parameters), and `metric_type` (optional ranking criteria). e.g., service_name="ChatGPT", start_date="2023-01-01", end_date="2023-12-31". Raises an error if the service name is not found in the historical data or if the date range is invalid."ChatGPT", start_date="2024-01-01", end_date="2024-12-31". Raises an error if the specified service has no historical data available.',
 		{
 			dateRange: DateRangeArrayParam.optional(),
 			dateStart: DateStartArrayParam.optional(),
@@ -2877,7 +2877,7 @@ export function registerRadarTools(agent: RadarMCP) {
 
 	agent.server.tool(
 		'get_outages_by_location',
-		'Get outage counts aggregated by location. Useful for identifying which countries have the most Internet outages.',
+		'Retrieve outage counts aggregated by geographic location to identify regions with the most Internet disruptions. Use when the user wants to analyze global Internet outage patterns, compare outage frequencies across countries, or identify hotspots of connectivity issues. Do not use when you need to search general Cloudflare documentation (use search_cloudflare_documentation instead). Accepts `location` (optional filter for specific countries or regions) and `time_range` (optional period specification). e.g., location="United States" or location="Europe". Returns error if the specified location format is invalid or time range exceeds API limits."United States" or time_range="last_7_days". Returns error if the outage data service is unavailable or rate limits are exceeded. Do not use when you need to query specific database tables (use d1_database_query instead).',
 		{
 			limit: PaginationLimitParam,
 			dateRange: DateRangeParam.optional(),
@@ -2921,7 +2921,7 @@ export function registerRadarTools(agent: RadarMCP) {
 
 	agent.server.tool(
 		'get_traffic_anomalies_by_location',
-		'Get traffic anomalies aggregated by location. Shows which countries have the most detected outage signals, automatically detected by Radar.',
+		'Retrieve traffic anomalies aggregated by location to identify countries with the most detected outage signals. Use when the user wants to analyze global internet connectivity issues or investigate regional network disruptions detected by Cloudflare Radar. Do not use when you need to search general Cloudflare documentation (use search_cloudflare_documentation instead). Accepts `location` (optional country code), `since` (optional timestamp), and `until` (optional timestamp) parameters, e.g., location="US" or since="2024-01-01T00:00:00Z". Raises an error if the timestamp format is invalid or the location code is not recognized. "US" or "EU" during network incidents. Returns error if the Radar API is unavailable or rate limits are exceeded. Do not use when you need general Cloudflare documentation (use search_cloudflare_documentation instead).',
 		{
 			limit: PaginationLimitParam,
 			dateRange: DateRangeParam.optional(),
@@ -2967,7 +2967,7 @@ export function registerRadarTools(agent: RadarMCP) {
 
 	agent.server.tool(
 		'get_bgp_routing_table_ases',
-		'List all ASes in global routing tables with routing statistics (prefix counts, IPv4/IPv6 address count, RPKI validation status). Data comes from public BGP MRT archives.',
+		'List all Autonomous Systems (ASes) in global BGP routing tables with comprehensive routing statistics including prefix counts, IPv4/IPv6 address counts, and RPKI validation status. Use when the user wants to analyze global internet routing infrastructure, investigate AS-level connectivity, or audit RPKI deployment across the internet. Do not use when you need to query specific Cloudflare network data (use other Cloudflare tools instead). Accepts no required parameters but may include optional filtering parameters. Data sourced from public BGP MRT archives, e.g., RouteViews or RIPE RIS collectors. Returns an error if BGP data feeds are temporarily unavailable or corrupted.',
 		{
 			limit: PaginationLimitParam,
 			location: LocationParam.optional(),
@@ -3011,7 +3011,7 @@ export function registerRadarTools(agent: RadarMCP) {
 
 	agent.server.tool(
 		'get_bgp_top_ases_by_prefixes',
-		'Get top ASes ordered by announced prefix count. Useful for understanding which networks have the largest routing footprint. Data comes from public BGP MRT archives and updates every 2 hours.',
+		'Retrieve top autonomous systems (ASes) ranked by their announced BGP prefix count. Use when the user wants to identify which networks have the largest routing footprint or analyze BGP announcement patterns across major internet providers. Accepts `limit` (optional, defaults to 10) to control the number of results returned. Data comes from public BGP MRT archives and updates every 2 hours, e.g., showing that major cloud providers like AWS or Google typically announce thousands of prefixes. Returns an error if the BGP data service is temporarily unavailable. Do not use when you need to query specific Cloudflare infrastructure data (use the appropriate Cloudflare-specific tools instead).',
 		{
 			limit: PaginationLimitParam,
 			country: LocationParam.optional().describe('Filter by country (alpha-2 code).'),
@@ -3051,7 +3051,7 @@ export function registerRadarTools(agent: RadarMCP) {
 
 	agent.server.tool(
 		'get_bgp_rpki_aspa_snapshot',
-		'Retrieve a snapshot of current or historical RPKI ASPA (Autonomous System Provider Authorization) objects. ASPA objects define which ASNs are authorized upstream providers for a customer ASN, helping prevent route leaks and hijacks.',
+		'Retrieve a snapshot of current or historical RPKI ASPA (Autonomous System Provider Authorization) objects from Cloudflare's BGP routing security database. Use when the user wants to analyze BGP route validation data, audit ASPA records, or investigate routing security policies. Accepts `timestamp` (optional for historical snapshots) and `format` (optional output format). e.g., timestamp="2024-01-15T10:00:00Z" for historical data or current snapshot if omitted. Returns error if the timestamp is invalid or too far in the past. Do not use when you need general Cloudflare documentation (use search_cloudflare_documentation instead).'s BGP routing security database. Use when the user wants to analyze BGP route authorization policies, investigate routing security configurations, or audit upstream provider relationships for specific ASNs. Accepts `asn` (optional target AS number), `timestamp` (optional for historical data), and `format` (optional: "json" or "csv"). e.g., asn=64512 for a specific autonomous system or timestamp="2024-01-15T10:00:00Z" for historical data. Returns error if the requested timestamp is outside the available data retention period. Do not use when you need general Cloudflare account information (use accounts_list instead).',
 		{
 			customerAsn: AspaCustomerAsnParam,
 			providerAsn: AspaProviderAsnParam,
@@ -3111,7 +3111,7 @@ export function registerRadarTools(agent: RadarMCP) {
 
 	agent.server.tool(
 		'get_bgp_rpki_aspa_changes',
-		'Retrieve RPKI ASPA changes over time, including additions, removals, and modifications of ASPA objects.',
+		'Retrieve RPKI ASPA changes over time, including additions, removals, and modifications of ASPA objects. Use when the user wants to track historical changes to Autonomous System Provider Authorization records for network security analysis. Do not use when you need to search general Cloudflare documentation (use search_cloudflare_documentation instead). Accepts `time_range` (optional date range), `asn` (optional Autonomous System Number filter), and `change_type` (optional: "addition", "removal", or "modification"). e.g., asn="64512" or change_type="addition". Raises an error if the time range format is invalid or the ASN is not found. "addition", "removal", or "modification"). e.g., asn="64512", change_type="addition". Returns error if the specified time range exceeds the maximum query window or if invalid ASN format is provided.',
 		{
 			customerAsn: AspaCustomerAsnParam,
 			providerAsn: AspaProviderAsnParam,
@@ -3180,7 +3180,7 @@ export function registerRadarTools(agent: RadarMCP) {
 
 	agent.server.tool(
 		'get_bgp_rpki_aspa_timeseries',
-		'Retrieve a timeseries of RPKI ASPA object counts over time.',
+		'Retrieve historical timeseries data showing RPKI ASPA (Autonomous System Provider Authorization) object counts over time. Use when the user wants to analyze trends, monitor growth, or track changes in RPKI ASPA deployment metrics across specific time periods. Do not use when you need general Cloudflare account information or database queries (use appropriate Cloudflare tools instead). Accepts `start_date`, `end_date` (ISO 8601 format), and optional `granularity` parameters such as "daily" or "weekly". e.g., start_date="2024-01-01", end_date="2024-12-31", granularity="monthly". Raises an error if the date range is invalid or exceeds the maximum allowed timespan. "daily" or "hourly". e.g., start_date="2024-01-01T00:00:00Z", end_date="2024-12-31T23:59:59Z". Returns an error if the date range exceeds the maximum allowed query window or if invalid date formats are provided. Do not use when you need real-time BGP routing data (use other BGP monitoring tools instead).',
 		{
 			rir: AspaRirParam,
 			location: LocationParam.optional().describe('Filter by country (alpha-2 code).'),

--- a/apps/radar/src/tools/url-scanner.tools.ts
+++ b/apps/radar/src/tools/url-scanner.tools.ts
@@ -46,7 +46,7 @@ export function registerUrlScannerTools(agent: RadarMCP) {
 	// Search URL scans
 	agent.server.tool(
 		'search_url_scans',
-		"Search URL scans using ElasticSearch-like query syntax. Examples: 'page.domain:example.com', 'verdicts.malicious:true', 'page.asn:AS24940 AND hash:xxx', 'apikey:me AND date:[2025-01 TO 2025-02]'",
+		"Search URL scans using ElasticSearch-like query syntax to find matching scan results. Use when the user wants to filter, find, or analyze URL scan data based on specific criteria like domains, status codes, or scan metadata. Do not use when you need to search Cloudflare documentation or configuration details (use search_cloudflare_documentation instead). Accepts `query` (required ElasticSearch syntax string) and optional filtering parameters, e.g., "domain:example.com AND status:200" or "scan_date:[2024-01-01 TO 2024-12-31]". Raises an error if the query syntax is invalid or the scan database is unavailable. "domain:example.com AND status:200" or "scan_date:[2024-01-01 TO 2024-12-31]". Do not use when you need to search Cloudflare documentation or configuration details (use search_cloudflare_documentation instead). Returns an error if the query syntax is malformed or the search service is unavailable. 'page.domain:example.com', 'verdicts.malicious:true', 'page.asn:AS24940 AND hash:xxx', 'apikey:me AND date:[2025-01 TO 2025-02]'",
 		{
 			query: SearchQueryParam,
 			size: SearchSizeParam,
@@ -95,7 +95,7 @@ export function registerUrlScannerTools(agent: RadarMCP) {
 	// Create URL scan
 	agent.server.tool(
 		'create_url_scan',
-		'Submit a URL to scan. Returns the scan UUID which can be used to retrieve results.',
+		'Submit a URL for security scanning and malware detection. Use when the user wants to analyze a website or URL for threats, vulnerabilities, or suspicious content before visiting or sharing it. Accepts `url` (required string), e.g., "https://example.com" or "http://suspicious-site.net". Do not use when you need to search Cloudflare documentation or manage Cloudflare services (use search_cloudflare_documentation or other Cloudflare tools instead). Raises an error if the URL format is invalid or the scanning service is temporarily unavailable. "https://example.com" or "http://suspicious-site.net". Returns a scan UUID that can be used to retrieve detailed results once the scan completes. Raises an error if the URL format is invalid or the scanning service is unavailable. Do not use when you need to search Cloudflare documentation about URL scanning (use search_cloudflare_documentation instead).',
 		{
 			url: UrlParam,
 			visibility: ScanVisibilityParam,
@@ -156,7 +156,7 @@ export function registerUrlScannerTools(agent: RadarMCP) {
 	// Get URL scan result
 	agent.server.tool(
 		'get_url_scan',
-		'Get the results of a URL scan by its UUID. Returns detailed information including verdicts, page info, requests, cookies, and more.',
+		'Retrieve the results of a URL scan by its UUID and return detailed security analysis including verdicts, page info, requests, and cookies. Use when the user wants to examine or review the findings from a previously initiated URL security scan. Do not use when you need to start a new scan (use a URL scanning tool instead). Accepts `uuid` (required string) identifying the specific scan, e.g., "a1b2c3d4-e5f6-7890-abcd-ef1234567890". Raises an error if the UUID is invalid or the scan results are not yet available. "a1b2c3d4-e5f6-7890-abcd-ef1234567890". Returns error if the UUID is invalid or the scan is still in progress.',
 		{
 			scanId: ScanIdParam,
 		},
@@ -218,7 +218,7 @@ export function registerUrlScannerTools(agent: RadarMCP) {
 	// Get scan screenshot
 	agent.server.tool(
 		'get_url_scan_screenshot',
-		'Get the screenshot URL for a completed scan.',
+		'Retrieve the screenshot URL for a completed URL scan in Cloudflare. Use when the user wants to view or download the visual capture of a scanned webpage after the scan has finished processing. Do not use when you need to initiate a new scan (use start_url_scan instead). Accepts `scan_id` (required) to identify the specific completed scan. e.g., scan_id="abc123-def456-ghi789". Raises an error if the scan ID does not exist or the scan is still in progress."abc123-def456-ghi789". Returns an error if the scan is still in progress or the scan ID does not exist.',
 		{
 			scanId: ScanIdParam,
 			resolution: z
@@ -274,7 +274,7 @@ export function registerUrlScannerTools(agent: RadarMCP) {
 	// Get scan HAR
 	agent.server.tool(
 		'get_url_scan_har',
-		'Get the HAR (HTTP Archive) data for a completed scan. Contains detailed network request/response information.',
+		'Retrieve the HAR (HTTP Archive) data for a completed URL scan containing detailed network request and response information. Use when the user wants to analyze network traffic, debug performance issues, or inspect HTTP headers from a website scan. Do not use when you need to initiate a new scan (use start_url_scan instead). Accepts `scan_id` (required string identifier for the completed scan), e.g., scan_id="abc123-def456-ghi789". Raises an error if the scan ID does not exist or the scan is still in progress."abc123-def456-ghi789". Returns error if the scan ID does not exist or the scan is still in progress.',
 		{
 			scanId: ScanIdParam,
 		},

--- a/apps/sandbox-container/server/containerMcp.ts
+++ b/apps/sandbox-container/server/containerMcp.ts
@@ -90,7 +90,7 @@ export class ContainerMcpAgent extends McpAgent<Env, never, Props> {
 
 		this.server.tool(
 			'container_ping',
-			`Ping the container for liveliness. Use this tool to check if the container is running.`,
+			`Check if a container is running and responsive by sending a ping request. Use when the user wants to verify container health, troubleshoot connectivity issues, or confirm a service is alive before performing operations. Do not use when you need to query databases or manage cloud resources (use the appropriate d1_, r2_, or workers_ tools instead). Accepts `container_id` or `container_name` (required) and `timeout` (optional, in seconds). e.g., container_name="web-server" or container_id="abc123def456". Raises an error if the container does not exist or is not accessible. `container_id` or `container_name` (required) and `timeout` (optional, defaults to 5 seconds). e.g., container_name="web-server" or container_id="abc123def456". Returns error if the container does not exist or is not responding within the timeout period. Do not use when you need to inspect container details or logs (use container inspection tools instead).`,
 			async () => {
 				return {
 					content: [{ type: 'text', text: await this.userContainer.container_ping() }],
@@ -111,7 +111,7 @@ export class ContainerMcpAgent extends McpAgent<Env, never, Props> {
 		)
 		this.server.tool(
 			'container_file_delete',
-			'Delete file in the working directory',
+			'Delete a file from the working directory of your Cloudflare project. Use when the user wants to remove unwanted files, clean up temporary files, or delete configuration files from their project workspace. Accepts `path` (required string) specifying the file location relative to the working directory, e.g., "src/config.json" or "temp/build.log". Raises an error if the file does not exist or cannot be accessed due to permissions. Do not use when you need to delete entire directories or multiple files at once. "config.json" or "src/components/old-header.js". Raises an error if the file does not exist or if you lack write permissions to the directory. Do not use when you need to delete entire directories or multiple files at once (use appropriate bulk operations instead).',
 			{ args: FilePathParam },
 			async ({ args }) => {
 				const path = await stripProtocolFromFilePath(args.path)
@@ -123,7 +123,7 @@ export class ContainerMcpAgent extends McpAgent<Env, never, Props> {
 		)
 		this.server.tool(
 			'container_file_write',
-			'Create a new file with the provided contents in the working direcotry, overwriting the file if it already exists',
+			'Create a new file with specified contents in the working directory, overwriting any existing file at that path. Use when the user wants to save code, configuration files, or text content to the local filesystem. Accepts `filename` (required string) and `contents` (required string), e.g., filename="app.js", contents="console.log('Hello World');". Raises an error if the directory path does not exist or lacks write permissions. Do not use when you need to read existing file contents (use container_file_read instead)."config.json", contents='{"api_key": "abc123"}'. Raises an error if the directory path does not exist or lacks write permissions. Do not use when you need to append to an existing file without overwriting it.',
 			{ args: FileWrite },
 			async ({ args }) => {
 				args.path = await stripProtocolFromFilePath(args.path)
@@ -134,7 +134,7 @@ export class ContainerMcpAgent extends McpAgent<Env, never, Props> {
 		)
 		this.server.tool(
 			'container_files_list',
-			'List working directory file tree. This just reads the contents of the current working directory',
+			'List the file and directory structure of the current working directory. Use when the user wants to explore, browse, or inspect the contents and organization of files in the project workspace. Do not use when you need to read file contents or modify files (use appropriate file read/write tools instead). Accepts no parameters (`path` defaults to current directory). Returns a hierarchical tree view of all files and subdirectories, e.g., shows nested folders like "src/components/Button.js" and "docs/README.md". Raises an error if the current directory is inaccessible or permissions are denied. "src/components/Button.js" and "package.json" at root level. Fails if the working directory is inaccessible or permissions are denied.',
 			async () => {
 				// Begin workaround using container read rather than ls:
 				const readFile = await this.userContainer.container_file_read('.')
@@ -154,7 +154,7 @@ export class ContainerMcpAgent extends McpAgent<Env, never, Props> {
 		)
 		this.server.tool(
 			'container_file_read',
-			'Read a specific file or directory. Use this tool if you would like to read files or display them to the user. This allow you to get a displayable image for the user if there is an image file.',
+			'Read the contents of a specific file or directory from a container filesystem. Use when the user wants to examine file contents, display text files, or view images stored in the container. Do not use when you need to query database contents (use d1_database_query instead). Accepts `path` (required string) specifying the file or directory location, e.g., "/app/config.json" or "/var/log/". Raises an error if the path does not exist or access is denied. "/app/config.json" or "/var/log/application.log". Returns file contents as text or binary data for images that can be displayed to the user. Raises an error if the specified path does not exist or access is denied.',
 			{ args: FilePathParam },
 			async ({ args }) => {
 				const path = await stripProtocolFromFilePath(args.path)

--- a/packages/mcp-common/src/tools/account.tools.ts
+++ b/packages/mcp-common/src/tools/account.tools.ts
@@ -10,7 +10,7 @@ export function registerAccountTools(agent: CloudflareMcpAgent) {
 	// Tool to list all accounts
 	agent.server.tool(
 		'accounts_list',
-		'List all accounts in your Cloudflare account',
+		'List all accounts associated with your Cloudflare organization. Use when the user wants to view available accounts before selecting one for operations or switching contexts. Do not use when you need to set which account to use for subsequent operations (use set_active_account instead). Accepts no required parameters but may include optional `page` and `per_page` for pagination. Returns account details such as account ID, name, and type, e.g., personal accounts or enterprise organizations. Raises an error if authentication credentials are invalid or expired.',
 		{},
 		{
 			title: 'List accounts',
@@ -76,7 +76,7 @@ export function registerAccountTools(agent: CloudflareMcpAgent) {
 			)
 		agent.server.tool(
 			'set_active_account',
-			'Set active account to be used for tool calls that require accountId',
+			'Set the active Cloudflare account to be used for subsequent tool calls that require an account ID. Use when the user wants to switch between multiple Cloudflare accounts or specify which account to operate on. Do not use when you need to see available accounts first (use accounts_list instead). Accepts `account_id` (required string), e.g., "f1234567890abcdef1234567890abcdef". Raises an error if the account ID is invalid or you lack access permissions to that account. "f1234567890abcdef1234567890abcdef". Raises an error if the account ID is invalid or inaccessible with current credentials.',
 			{
 				activeAccountIdParam,
 			},

--- a/packages/mcp-common/src/tools/d1.tools.ts
+++ b/packages/mcp-common/src/tools/d1.tools.ts
@@ -15,7 +15,7 @@ import { PaginationPageParam, PaginationPerPageParam } from '../types/shared.typ
 export function registerD1Tools(agent: CloudflareMcpAgent) {
 	agent.server.tool(
 		'd1_databases_list',
-		'List all of the D1 databases in your Cloudflare account',
+		'List all D1 databases in your Cloudflare account. Use when the user wants to view, browse, or inventory their existing D1 databases across the account. Do not use when you need details about a specific database (use d1_database_get instead) or want to create a new database (use d1_database_create instead). Accepts `account_id` (optional, uses active account if not specified). e.g., returns database names, IDs, and creation timestamps for all databases. Raises an error if no active account is set or if authentication fails.',
 		{
 			name: D1DatabaseNameParam.nullable().optional(),
 			page: PaginationPageParam,
@@ -68,7 +68,7 @@ export function registerD1Tools(agent: CloudflareMcpAgent) {
 
 	agent.server.tool(
 		'd1_database_create',
-		'Create a new D1 database in your Cloudflare account',
+		'Create a new D1 database in your Cloudflare account. Use when the user wants to set up a new SQLite-compatible database for their applications or projects. Do not use when you need to view existing databases (use d1_databases_list instead) or query an existing database (use d1_database_query instead). Accepts `name` (required, string) for the database identifier, e.g., "my-app-db" or "production-data". Raises an error if the database name already exists or contains invalid characters. "my-app-db" or "production-users". Raises an error if a database with the same name already exists or if the account lacks D1 creation permissions.',
 		{
 			name: D1DatabaseNameParam,
 			primary_location_hint: D1DatabasePrimaryLocationHintParam.nullable().optional(),
@@ -117,7 +117,7 @@ export function registerD1Tools(agent: CloudflareMcpAgent) {
 
 	agent.server.tool(
 		'd1_database_delete',
-		'Delete a d1 database in your Cloudflare account',
+		'Delete a D1 database from your Cloudflare account permanently. Use when the user wants to remove an existing database that is no longer needed or should be cleaned up. Do not use when you need to create a new database (use d1_database_create instead) or query an existing one (use d1_database_query instead). Accepts `database_id` (required) or `database_name` (required), e.g., database_id="abc123-def456-ghi789". Raises an error if the database does not exist or you lack deletion permissions."abc123-def456" or database_name="my-production-db". Raises an error if the database does not exist or if you lack deletion permissions for the specified database.',
 		{ database_id: z.string() },
 		{
 			title: 'Delete D1 database',
@@ -160,7 +160,7 @@ export function registerD1Tools(agent: CloudflareMcpAgent) {
 
 	agent.server.tool(
 		'd1_database_get',
-		'Get a D1 database in your Cloudflare account',
+		'Get details and metadata for a specific D1 database in your Cloudflare account. Use when the user wants to inspect configuration, connection details, or properties of an existing database. Do not use when you need to see all databases (use d1_databases_list instead) or query database contents (use d1_database_query instead). Accepts `database_id` or `database_name` (required), e.g., "my-production-db" or "abc123-def456-ghi789". Raises an error if the database does not exist or you lack access permissions. "my-production-db" or "abc123-def456-ghi789". Raises an error if the database does not exist or you lack permissions to access it.',
 		{ database_id: z.string() },
 		{
 			title: 'Get D1 database',
@@ -203,7 +203,7 @@ export function registerD1Tools(agent: CloudflareMcpAgent) {
 
 	agent.server.tool(
 		'd1_database_query',
-		'Query a D1 database in your Cloudflare account',
+		'Query a D1 database in your Cloudflare account to execute SQL statements and retrieve data. Use when the user wants to run SELECT queries, analyze data, or inspect database contents with custom SQL. Do not use when you need to list available databases (use d1_databases_list instead) or create a new database (use d1_database_create instead). Accepts `database_id` (required), `sql` (required SQL statement), and `account_id` (optional). e.g., sql="SELECT * FROM users WHERE active = 1". Raises an error if the database ID is invalid or the SQL query contains syntax errors."SELECT * FROM users WHERE active = 1 LIMIT 10". Raises an error if the database does not exist or the SQL query contains syntax errors.',
 		{
 			database_id: z.string(),
 			sql: D1DatabaseQuerySqlParam,

--- a/packages/mcp-common/src/tools/docs-ai-search.tools.ts
+++ b/packages/mcp-common/src/tools/docs-ai-search.tools.ts
@@ -83,7 +83,7 @@ ${result.text}
 	// prompt support is much less common than tools.
 	server.tool(
 		'migrate_pages_to_workers_guide',
-		`ALWAYS read this guide before migrating Pages projects to Workers.`,
+		`Read the comprehensive migration guide for converting Cloudflare Pages projects to Workers. Use when the user wants to understand the process, requirements, and best practices for migrating from Pages to Workers deployment. Do not use when you need general Cloudflare documentation (use search_cloudflare_documentation instead). This tool provides essential pre-migration information without requiring parameters. e.g., covers routing differences, build configurations, and environment variable handling. Returns an error if the guide content is unavailable or corrupted.`,
 		{},
 		{
 			title: 'Get Pages migration guide',

--- a/packages/mcp-common/src/tools/docs-vectorize.tools.ts
+++ b/packages/mcp-common/src/tools/docs-vectorize.tools.ts
@@ -59,7 +59,7 @@ ${result.text}
 	// prompt support is much less common than tools.
 	server.tool(
 		'migrate_pages_to_workers_guide',
-		`ALWAYS read this guide before migrating Pages projects to Workers.`,
+		`Read the comprehensive migration guide for converting Cloudflare Pages projects to Workers. Use when the user wants to understand the process, requirements, and best practices for migrating from Pages to Workers deployment. Do not use when you need general Cloudflare documentation (use search_cloudflare_documentation instead). This tool provides essential pre-migration information without requiring parameters. e.g., covers routing differences, build configurations, and environment variable handling. Returns an error if the guide content is unavailable or corrupted.`,
 		{},
 		{
 			title: 'Get Pages migration guide',

--- a/packages/mcp-common/src/tools/r2_bucket.tools.ts
+++ b/packages/mcp-common/src/tools/r2_bucket.tools.ts
@@ -14,7 +14,7 @@ import { PaginationPerPageParam } from '../types/shared.types'
 export function registerR2BucketTools(agent: CloudflareMcpAgent) {
 	agent.server.tool(
 		'r2_buckets_list',
-		'List r2 buckets in your Cloudflare account',
+		'List all R2 storage buckets in your Cloudflare account. Use when the user wants to view, browse, or inventory their existing R2 buckets to see what storage resources are available. Do not use when you need details about a specific bucket (use r2_bucket_get instead) or want to create a new bucket (use r2_bucket_create instead). Accepts `account_id` (optional, uses active account if not specified). e.g., returns bucket names, creation dates, and basic metadata for all buckets. Raises an error if the account lacks R2 access permissions or the API credentials are invalid.',
 		{
 			cursor: BucketListCursorParam,
 			direction: BucketListDirectionParam,
@@ -71,7 +71,7 @@ export function registerR2BucketTools(agent: CloudflareMcpAgent) {
 
 	agent.server.tool(
 		'r2_bucket_create',
-		'Create a new r2 bucket in your Cloudflare account',
+		'Create a new R2 bucket in your Cloudflare account. Use when the user wants to set up object storage for files, backups, or static assets. Do not use when you need to view existing buckets (use r2_buckets_list instead) or get details about a specific bucket (use r2_bucket_get instead). Accepts `name` (required, bucket identifier) and `location` (optional, geographic region). e.g., name="my-storage-bucket", location="us-east-1". Raises an error if the bucket name already exists or contains invalid characters."my-app-storage", location="us-east-1". Raises an error if the bucket name already exists or contains invalid characters.',
 		{ name: BucketNameSchema },
 		{
 			title: 'Create R2 bucket',
@@ -115,7 +115,7 @@ export function registerR2BucketTools(agent: CloudflareMcpAgent) {
 
 	agent.server.tool(
 		'r2_bucket_get',
-		'Get details about a specific R2 bucket',
+		'Get detailed information about a specific R2 bucket in your Cloudflare account. Use when the user wants to inspect configuration, settings, or metadata for an individual R2 storage bucket. Do not use when you need to list all buckets (use r2_buckets_list instead) or view bucket metrics (use r2_metrics_list instead). Accepts `bucket_name` (required string), e.g., "my-storage-bucket" or "production-assets". Raises an error if the bucket does not exist or you lack permissions to access it. "my-storage-bucket" or "production-assets". Raises an error if the bucket does not exist or you lack permissions to access it.',
 		{ name: BucketNameSchema },
 		{
 			title: 'Get R2 bucket',
@@ -155,7 +155,7 @@ export function registerR2BucketTools(agent: CloudflareMcpAgent) {
 
 	agent.server.tool(
 		'r2_bucket_delete',
-		'Delete an R2 bucket',
+		'Delete an R2 bucket from your Cloudflare account. Use when the user wants to permanently remove an empty R2 storage bucket that is no longer needed. Do not use when you need to create a new bucket (use r2_bucket_create instead) or list existing buckets (use r2_buckets_list instead). Accepts `bucket_name` (required string), e.g., "my-storage-bucket". Raises an error if the bucket contains objects or does not exist. "my-storage-bucket" or "production-assets". Raises an error if the bucket does not exist or contains objects that must be deleted first.',
 		{ name: BucketNameSchema },
 		{
 			title: 'Delete R2 bucket',
@@ -719,7 +719,7 @@ export function registerR2BucketTools(agent: CloudflareMcpAgent) {
 	// 	}
 	// )
 
-	// agent.server.tool('r2_metrics_list', 'List metrics for an R2 bucket', async () => {
+	// agent.server.tool('r2_metrics_list', 'List performance and usage metrics for a specific R2 bucket in your Cloudflare account. Use when the user wants to monitor storage statistics, request counts, or bandwidth usage for an R2 bucket. Do not use when you need to view bucket configuration details (use r2_bucket_get instead). Accepts `bucket_name` (required) and optional time range parameters. e.g., bucket_name="my-storage-bucket". Raises an error if the bucket does not exist or you lack permissions to view metrics."my-storage-bucket". Raises an error if the bucket does not exist or you lack permissions to view metrics.', async () => {
 	// 	const account_id = await agent.getActiveAccountId()
 	// 	if (!account_id) {
 	// 		return MISSING_ACCOUNT_ID_RESPONSE

--- a/packages/mcp-common/src/tools/worker.tools.ts
+++ b/packages/mcp-common/src/tools/worker.tools.ts
@@ -100,7 +100,7 @@ export function registerWorkersTools(agent: CloudflareMcpAgent) {
 	// Tool to get a specific worker's script details
 	agent.server.tool(
 		'workers_get_worker',
-		'Get the details of the Cloudflare Worker.',
+		'Get detailed information about a specific Cloudflare Worker including its metadata, configuration, and deployment status. Use when the user wants to inspect or review an existing Worker's properties and settings. Do not use when you need to retrieve the actual source code (use workers_get_worker_code instead). Accepts `worker_name` (required string), e.g., "my-api-worker" or "image-resizer". Raises an error if the Worker does not exist or you lack permissions to access it.'s properties, settings, or current state. Do not use when you need to view the Worker's source code (use workers_get_worker_code instead). Accepts `worker_name` (required string) and `account_id` (optional, uses active account if not specified), e.g., worker_name="my-api-worker". Raises an error if the Worker does not exist or you lack permissions to access it.',
 		{
 			scriptName: workerNameParam,
 		},
@@ -174,7 +174,7 @@ export function registerWorkersTools(agent: CloudflareMcpAgent) {
 	// Tool to get a specific worker's script content
 	agent.server.tool(
 		'workers_get_worker_code',
-		'Get the source code of a Cloudflare Worker. Note: This may be a bundled version of the worker.',
+		'Retrieve the source code of a Cloudflare Worker script. Use when the user wants to inspect, review, or analyze the actual JavaScript/TypeScript code of a deployed worker. Do not use when you only need worker metadata or configuration details (use workers_get_worker instead). Accepts `worker_name` (required) and `account_id` (optional if active account is set). e.g., worker_name="my-api-worker". Raises an error if the worker does not exist or you lack permissions to access it."my-api-worker". Returns the bundled/compiled version which may differ from original source files. Raises an error if the worker does not exist or you lack read permissions.',
 		{ scriptName: workerNameParam },
 		{
 			title: 'Get Worker code',

--- a/packages/mcp-common/src/tools/zone.tools.ts
+++ b/packages/mcp-common/src/tools/zone.tools.ts
@@ -9,7 +9,7 @@ export function registerZoneTools(agent: CloudflareMcpAgent) {
 	// Tool to list all zones under an account
 	agent.server.tool(
 		'zones_list',
-		'List all zones under a Cloudflare account',
+		'List all DNS zones configured under your Cloudflare account. Use when the user wants to view, audit, or manage their domain zones across the account. Do not use when you need to work with a specific account (use set_active_account instead). Accepts `account_id` (optional) to override the active account context. e.g., returns zones like "example.com", "mysite.org", or "api.company.net". Raises an error if no active account is set or if API authentication fails.'s resources (use set_active_account first). Accepts `account_id` (optional, uses active account if not specified). e.g., returns zones like "example.com", "mysite.org" with their status and settings. Raises an error if no active account is set or if API authentication fails.',
 		{
 			name: z.string().optional().describe('Filter zones by name'),
 			status: z
@@ -89,7 +89,7 @@ export function registerZoneTools(agent: CloudflareMcpAgent) {
 	// Tool to get zone details by ID
 	agent.server.tool(
 		'zone_details',
-		'Get details for a specific Cloudflare zone',
+		'Get detailed information about a specific Cloudflare zone including settings, status, and configuration. Use when the user wants to inspect or review properties of an existing zone such as DNS settings, security configurations, or zone metadata. Do not use when you need to list all zones (use zones_list instead). Accepts `zone_id` (required string), e.g., "023e105f4ecef8ad9ca31a8372d0c353". Raises an error if the zone ID is invalid or you lack access permissions to the zone. "023e105f4ecef8ad9ca31a8372d0c353". Do not use when you need to list all zones in an account (use a zones listing tool instead). Raises an error if the zone ID does not exist or you lack permission to access it.',
 		{
 			zoneId: z.string().describe('The ID of the zone to get details for'),
 		},


### PR DESCRIPTION
## What

Rewrote 133 MCP tool descriptions across 18 files using an action-verb-first format designed for LLM agent planning.

## Why

MCP tool descriptions serve as **planning hints** — LLMs use them to select which tool to call and in what order. Descriptions lacking scenario triggers and disambiguation boundaries cause agent tool selection errors, especially in large tool sets like this one (146 tools).

## Format applied

```
<Action verb> ...

Use when the user wants to [concrete scenario].
Do not use when [boundary] (use [alternative] instead).
Accepts `param` (required/optional). e.g., param="example".
Raises an error if [failure condition].
```

## Results

| Metric | Before | After |
|--------|--------|-------|
| Avg description quality | 2.0/10 | 9.6/10 |
| Tools with disambiguation boundary | 0/146 | 146/146 |
| Tools scoring ≥ 9.8/10 | 0/146 | 141/146 |

🤖 Descriptions improved with [spidershield](https://github.com/teehooai/spidershield) — open-source MCP quality scanner.