### PR TITLE
fix(graphql): prevent GraphQL injection in fetchTypeDetails

### DIFF
--- a/apps/graphql/src/tools/graphql.tools.ts
+++ b/apps/graphql/src/tools/graphql.tools.ts
@@ -115,8 +115,8 @@ async function fetchSchemaOverview(apiToken: string): Promise<SchemaOverviewResp
  */
 async function fetchTypeDetails(typeName: string, apiToken: string): Promise<TypeDetailsResponse> {
 	const typeDetailsQuery = `
-		query TypeDetails {
-			__type(name: "${typeName}") {
+		query TypeDetails($typeName: String!) {
+			__type(name: $typeName) {
 				name
 				kind
 				description
@@ -174,8 +174,30 @@ async function fetchTypeDetails(typeName: string, apiToken: string): Promise<Typ
 		}
 	`
 
-	const response = await executeGraphQLRequest<TypeDetailsResponse>(typeDetailsQuery, apiToken)
-	return response
+	const response = await fetch(CLOUDFLARE_GRAPHQL_ENDPOINT, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			Authorization: `Bearer ${apiToken}`,
+		},
+		body: JSON.stringify({
+			query: typeDetailsQuery,
+			variables: { typeName },
+		}),
+	})
+
+	if (!response.ok) {
+		throw new Error(`Failed to execute GraphQL request: ${response.statusText}`)
+	}
+
+	const data = graphQLResponseSchema.parse(await response.json())
+
+	if (data && data.errors && Array.isArray(data.errors) && data.errors.length > 0) {
+		const errorMessages = data.errors.map((e: { message: string }) => e.message).join(', ')
+		console.warn(`GraphQL errors: ${errorMessages}`)
+	}
+
+	return data as unknown as TypeDetailsResponse
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #320

Uses a GraphQL variable (`$typeName`) instead of string interpolation to pass the type name to `__type()` in `fetchTypeDetails()`. This prevents injection of arbitrary GraphQL syntax through crafted type names.

## Changes

| File | Change |
|------|--------|
| `apps/graphql/src/tools/graphql.tools.ts` | Replace `"${typeName}"` interpolation with `$typeName` variable; pass variable via request body |

## Before / After

**Before** (vulnerable):
```graphql
query TypeDetails {
    __type(name: "${typeName}") {
```

**After** (safe):
```graphql
query TypeDetails($typeName: String!) {
    __type(name: $typeName) {
```

## Test Plan

- [x] `npx tsc --noEmit -p apps/graphql/tsconfig.json` — zero errors
- [ ] Verify type detail queries still return correct results for valid type names
---
*Found by [SpiderShield](https://github.com/teehooai/spidershield) security scanner*