### PR TITLE
chore: bump @cloudflare/workers-oauth-provider to 0.3.2

### DIFF
--- a/apps/ai-gateway/package.json
+++ b/apps/ai-gateway/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.3.0",
+		"@cloudflare/workers-oauth-provider": "0.3.2",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/auditlogs/package.json
+++ b/apps/auditlogs/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.3.0",
+		"@cloudflare/workers-oauth-provider": "0.3.2",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/autorag/package.json
+++ b/apps/autorag/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.3.0",
+		"@cloudflare/workers-oauth-provider": "0.3.2",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/browser-rendering/package.json
+++ b/apps/browser-rendering/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.3.0",
+		"@cloudflare/workers-oauth-provider": "0.3.2",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/cloudflare-one-casb/package.json
+++ b/apps/cloudflare-one-casb/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.3.0",
+		"@cloudflare/workers-oauth-provider": "0.3.2",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/dex-analysis/package.json
+++ b/apps/dex-analysis/package.json
@@ -13,7 +13,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.3.0",
+		"@cloudflare/workers-oauth-provider": "0.3.2",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/dns-analytics/package.json
+++ b/apps/dns-analytics/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.3.0",
+		"@cloudflare/workers-oauth-provider": "0.3.2",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/docs-ai-search/package.json
+++ b/apps/docs-ai-search/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.3.0",
+		"@cloudflare/workers-oauth-provider": "0.3.2",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/docs-autorag/package.json
+++ b/apps/docs-autorag/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.3.0",
+		"@cloudflare/workers-oauth-provider": "0.3.2",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/docs-vectorize/package.json
+++ b/apps/docs-vectorize/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.3.0",
+		"@cloudflare/workers-oauth-provider": "0.3.2",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/graphql/package.json
+++ b/apps/graphql/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.3.0",
+		"@cloudflare/workers-oauth-provider": "0.3.2",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/logpush/package.json
+++ b/apps/logpush/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.3.0",
+		"@cloudflare/workers-oauth-provider": "0.3.2",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/radar/package.json
+++ b/apps/radar/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.3.0",
+		"@cloudflare/workers-oauth-provider": "0.3.2",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/sandbox-container/package.json
+++ b/apps/sandbox-container/package.json
@@ -19,7 +19,7 @@
 		"eval:ci": "start-server-and-test --expect 404 eval:server http://localhost:8976 'vitest run --testTimeout=60000 --config vitest.config.evals.ts'"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.3.0",
+		"@cloudflare/workers-oauth-provider": "0.3.2",
 		"@hono/node-server": "1.13.8",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",

--- a/apps/workers-bindings/package.json
+++ b/apps/workers-bindings/package.json
@@ -25,7 +25,7 @@
 		"wrangler": "4.10.0"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.3.0",
+		"@cloudflare/workers-oauth-provider": "0.3.2",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@n8n/json-schema-to-zod": "1.1.0",
 		"@repo/eval-tools": "workspace:*",

--- a/apps/workers-builds/package.json
+++ b/apps/workers-builds/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.3.0",
+		"@cloudflare/workers-oauth-provider": "0.3.2",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/workers-observability/package.json
+++ b/apps/workers-observability/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.3.0",
+		"@cloudflare/workers-oauth-provider": "0.3.2",
 		"@fast-csv/format": "5.0.2",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",

--- a/packages/mcp-common/package.json
+++ b/packages/mcp-common/package.json
@@ -11,7 +11,7 @@
 		"test:coverage": "run-vitest-coverage"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.3.0",
+		"@cloudflare/workers-oauth-provider": "0.3.2",
 		"@fast-csv/format": "5.0.2",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,8 +51,8 @@ importers:
   apps/ai-gateway:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.3.0
-        version: 0.3.0
+        specifier: 0.3.2
+        version: 0.3.2
       '@hono/zod-validator':
         specifier: 0.4.3
         version: 0.4.3(hono@4.7.6)(zod@3.24.2)
@@ -100,8 +100,8 @@ importers:
   apps/auditlogs:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.3.0
-        version: 0.3.0
+        specifier: 0.3.2
+        version: 0.3.2
       '@hono/zod-validator':
         specifier: 0.4.3
         version: 0.4.3(hono@4.7.6)(zod@3.24.2)
@@ -149,8 +149,8 @@ importers:
   apps/autorag:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.3.0
-        version: 0.3.0
+        specifier: 0.3.2
+        version: 0.3.2
       '@hono/zod-validator':
         specifier: 0.4.3
         version: 0.4.3(hono@4.7.6)(zod@3.24.2)
@@ -198,8 +198,8 @@ importers:
   apps/browser-rendering:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.3.0
-        version: 0.3.0
+        specifier: 0.3.2
+        version: 0.3.2
       '@hono/zod-validator':
         specifier: 0.4.3
         version: 0.4.3(hono@4.7.6)(zod@3.24.2)
@@ -247,8 +247,8 @@ importers:
   apps/cloudflare-one-casb:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.3.0
-        version: 0.3.0
+        specifier: 0.3.2
+        version: 0.3.2
       '@hono/zod-validator':
         specifier: 0.4.3
         version: 0.4.3(hono@4.7.6)(zod@3.24.2)
@@ -333,8 +333,8 @@ importers:
   apps/dex-analysis:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.3.0
-        version: 0.3.0
+        specifier: 0.3.2
+        version: 0.3.2
       '@hono/zod-validator':
         specifier: 0.4.3
         version: 0.4.3(hono@4.7.6)(zod@3.24.2)
@@ -388,8 +388,8 @@ importers:
   apps/dns-analytics:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.3.0
-        version: 0.3.0
+        specifier: 0.3.2
+        version: 0.3.2
       '@hono/zod-validator':
         specifier: 0.4.3
         version: 0.4.3(hono@4.7.6)(zod@3.24.2)
@@ -437,8 +437,8 @@ importers:
   apps/docs-ai-search:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.3.0
-        version: 0.3.0
+        specifier: 0.3.2
+        version: 0.3.2
       '@hono/zod-validator':
         specifier: 0.4.3
         version: 0.4.3(hono@4.7.6)(zod@3.24.2)
@@ -489,8 +489,8 @@ importers:
   apps/docs-autorag:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.3.0
-        version: 0.3.0
+        specifier: 0.3.2
+        version: 0.3.2
       '@hono/zod-validator':
         specifier: 0.4.3
         version: 0.4.3(hono@4.7.6)(zod@3.24.2)
@@ -541,8 +541,8 @@ importers:
   apps/docs-vectorize:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.3.0
-        version: 0.3.0
+        specifier: 0.3.2
+        version: 0.3.2
       '@hono/zod-validator':
         specifier: 0.4.3
         version: 0.4.3(hono@4.7.6)(zod@3.24.2)
@@ -593,8 +593,8 @@ importers:
   apps/graphql:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.3.0
-        version: 0.3.0
+        specifier: 0.3.2
+        version: 0.3.2
       '@hono/zod-validator':
         specifier: 0.4.3
         version: 0.4.3(hono@4.7.6)(zod@3.24.2)
@@ -645,8 +645,8 @@ importers:
   apps/logpush:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.3.0
-        version: 0.3.0
+        specifier: 0.3.2
+        version: 0.3.2
       '@hono/zod-validator':
         specifier: 0.4.3
         version: 0.4.3(hono@4.7.6)(zod@3.24.2)
@@ -694,8 +694,8 @@ importers:
   apps/radar:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.3.0
-        version: 0.3.0
+        specifier: 0.3.2
+        version: 0.3.2
       '@hono/zod-validator':
         specifier: 0.4.3
         version: 0.4.3(hono@4.7.6)(zod@3.24.2)
@@ -743,8 +743,8 @@ importers:
   apps/sandbox-container:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.3.0
-        version: 0.3.0
+        specifier: 0.3.2
+        version: 0.3.2
       '@hono/node-server':
         specifier: 1.13.8
         version: 1.13.8(hono@4.7.6)
@@ -822,8 +822,8 @@ importers:
   apps/workers-bindings:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.3.0
-        version: 0.3.0
+        specifier: 0.3.2
+        version: 0.3.2
       '@modelcontextprotocol/sdk':
         specifier: 1.20.2
         version: 1.20.2
@@ -883,8 +883,8 @@ importers:
   apps/workers-builds:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.3.0
-        version: 0.3.0
+        specifier: 0.3.2
+        version: 0.3.2
       '@hono/zod-validator':
         specifier: 0.4.3
         version: 0.4.3(hono@4.7.6)(zod@3.24.2)
@@ -938,8 +938,8 @@ importers:
   apps/workers-observability:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.3.0
-        version: 0.3.0
+        specifier: 0.3.2
+        version: 0.3.2
       '@fast-csv/format':
         specifier: 5.0.2
         version: 5.0.2
@@ -1078,8 +1078,8 @@ importers:
   packages/mcp-common:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.3.0
-        version: 0.3.0
+        specifier: 0.3.2
+        version: 0.3.2
       '@fast-csv/format':
         specifier: 5.0.2
         version: 5.0.2
@@ -1541,8 +1541,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@cloudflare/workers-oauth-provider@0.3.0':
-    resolution: {integrity: sha512-I39kyUzNQWxVTIQs56xbnnHSrOY5UjiGKVeYI2zY5h+LjUxqeiuOBTTlKEDUirRvnMmBg3yppA6pR8bYKBrTAA==}
+  '@cloudflare/workers-oauth-provider@0.3.2':
+    resolution: {integrity: sha512-WFK95ThKutKDiTCPPbfzya1Fo7YMmEISQ0OlmJ+mGQJdb2dwOPS+YUY9Lk9pF/huOB0PS0V2cdb6BESqBlx3cQ==}
 
   '@cloudflare/workers-types@4.20250410.0':
     resolution: {integrity: sha512-Yx9VUi6QpmXtUIhOL+em+V02gue12kmVBVL6RGH5mhFh50M0x9JyOmm6wKwKZUny2uQd+22nuouE2q3z1OrsIQ==}
@@ -6626,7 +6626,7 @@ snapshots:
   '@cloudflare/workerd-windows-64@1.20250507.0':
     optional: true
 
-  '@cloudflare/workers-oauth-provider@0.3.0': {}
+  '@cloudflare/workers-oauth-provider@0.3.2': {}
 
   '@cloudflare/workers-types@4.20250410.0': {}
 


### PR DESCRIPTION
## Summary

Bumps `@cloudflare/workers-oauth-provider` from 0.3.0 to 0.3.2 across all 18 apps and packages.

v0.3.2 includes two RFC 9728 compliance fixes for OAuth Protected Resource Metadata:

- **cloudflare/workers-oauth-provider#173**: Support path-suffixed well-known URLs. MCP servers at subpaths (e.g. `/mcp`) now correctly serve metadata at `/.well-known/oauth-protected-resource/mcp` and return the correct `resource` identifier per [RFC 9728 §3.1](https://www.rfc-editor.org/rfc/rfc9728#section-3.1) and [§3.3](https://www.rfc-editor.org/rfc/rfc9728#section-3.3).
- **cloudflare/workers-oauth-provider#174**: Include the request path in `WWW-Authenticate` `resource_metadata` URL per [RFC 9728 §5.1](https://www.rfc-editor.org/rfc/rfc9728#section-5.1), so MCP clients discover the correct path-specific metadata endpoint.

These fixes are required by the [MCP Authorization Spec (draft 2025-03-26)](https://modelcontextprotocol.io/specification/draft/basic/authorization) which mandates RFC 9728 compliance.

## Test plan

- [ ] Verify `pnpm install` resolves cleanly
- [ ] Spot-check a deployed MCP server's `/.well-known/oauth-protected-resource/mcp` returns correct `resource` value