### PR TITLE
[DO NOT MERGE] chore: add changeset for workers-oauth-provider 0.3.2 bump

### DIFF
--- a/.changeset/oauth-provider-bump-032.md
+++ b/.changeset/oauth-provider-bump-032.md
@@ -1,0 +1,22 @@
+---
+'cloudflare-ai-gateway-mcp-server': patch
+'auditlogs': patch
+'cloudflare-autorag-mcp-server': patch
+'cloudflare-browser-mcp-server': patch
+'cloudflare-casb-mcp-server': patch
+'dex-analysis': patch
+'dns-analytics': patch
+'docs-ai-search': patch
+'docs-autorag': patch
+'docs-vectorize': patch
+'graphql-mcp-server': patch
+'logpush': patch
+'cloudflare-radar-mcp-server': patch
+'containers-mcp': patch
+'workers-bindings': patch
+'workers-builds': patch
+'workers-observability': patch
+'@repo/mcp-common': patch
+---
+
+Bump @cloudflare/workers-oauth-provider from 0.3.0 to 0.3.2


### PR DESCRIPTION
## Summary
- Adds patch changeset for all 17 MCP servers and `@repo/mcp-common` to trigger a production release
- This covers the `@cloudflare/workers-oauth-provider` 0.3.0 → 0.3.2 bump merged in #335

## Release plan
Once merged, the release workflow will:
1. Create a "Version Packages" PR with bumped versions
2. Merging that PR will publish and deploy all MCP servers to production