### PR TITLE
chore: bump @cloudflare/workers-oauth-provider to ^0.4.0

### DIFF
--- a/.changeset/upgrade-oauth-auditlogs.md
+++ b/.changeset/upgrade-oauth-auditlogs.md
@@ -1,0 +1,5 @@
+---
+"auditlogs": patch
+---
+
+Bump @cloudflare/workers-oauth-provider from 0.3.2 to 0.3.3

--- a/.changeset/upgrade-oauth-auditlogs.md
+++ b/.changeset/upgrade-oauth-auditlogs.md
@@ -2,4 +2,4 @@
 "auditlogs": patch
 ---
 
-Bump @cloudflare/workers-oauth-provider from 0.3.2 to 0.3.3
+Bump @cloudflare/workers-oauth-provider to ^0.4.0, add resourceMatchOriginOnly migration flag and 30-day refresh token TTL

--- a/.changeset/upgrade-oauth-cloudflare-ai-gateway-mcp-server.md
+++ b/.changeset/upgrade-oauth-cloudflare-ai-gateway-mcp-server.md
@@ -1,0 +1,5 @@
+---
+"cloudflare-ai-gateway-mcp-server": patch
+---
+
+Bump @cloudflare/workers-oauth-provider from 0.3.2 to 0.3.3

--- a/.changeset/upgrade-oauth-cloudflare-ai-gateway-mcp-server.md
+++ b/.changeset/upgrade-oauth-cloudflare-ai-gateway-mcp-server.md
@@ -2,4 +2,4 @@
 "cloudflare-ai-gateway-mcp-server": patch
 ---
 
-Bump @cloudflare/workers-oauth-provider from 0.3.2 to 0.3.3
+Bump @cloudflare/workers-oauth-provider to ^0.4.0, add resourceMatchOriginOnly migration flag and 30-day refresh token TTL

--- a/.changeset/upgrade-oauth-cloudflare-autorag-mcp-server.md
+++ b/.changeset/upgrade-oauth-cloudflare-autorag-mcp-server.md
@@ -2,4 +2,4 @@
 "cloudflare-autorag-mcp-server": patch
 ---
 
-Bump @cloudflare/workers-oauth-provider from 0.3.2 to 0.3.3
+Bump @cloudflare/workers-oauth-provider to ^0.4.0, add resourceMatchOriginOnly migration flag and 30-day refresh token TTL

--- a/.changeset/upgrade-oauth-cloudflare-autorag-mcp-server.md
+++ b/.changeset/upgrade-oauth-cloudflare-autorag-mcp-server.md
@@ -1,0 +1,5 @@
+---
+"cloudflare-autorag-mcp-server": patch
+---
+
+Bump @cloudflare/workers-oauth-provider from 0.3.2 to 0.3.3

--- a/.changeset/upgrade-oauth-cloudflare-browser-mcp-server.md
+++ b/.changeset/upgrade-oauth-cloudflare-browser-mcp-server.md
@@ -2,4 +2,4 @@
 "cloudflare-browser-mcp-server": patch
 ---
 
-Bump @cloudflare/workers-oauth-provider from 0.3.2 to 0.3.3
+Bump @cloudflare/workers-oauth-provider to ^0.4.0, add resourceMatchOriginOnly migration flag and 30-day refresh token TTL

--- a/.changeset/upgrade-oauth-cloudflare-browser-mcp-server.md
+++ b/.changeset/upgrade-oauth-cloudflare-browser-mcp-server.md
@@ -1,0 +1,5 @@
+---
+"cloudflare-browser-mcp-server": patch
+---
+
+Bump @cloudflare/workers-oauth-provider from 0.3.2 to 0.3.3

--- a/.changeset/upgrade-oauth-cloudflare-casb-mcp-server.md
+++ b/.changeset/upgrade-oauth-cloudflare-casb-mcp-server.md
@@ -2,4 +2,4 @@
 "cloudflare-casb-mcp-server": patch
 ---
 
-Bump @cloudflare/workers-oauth-provider from 0.3.2 to 0.3.3
+Bump @cloudflare/workers-oauth-provider to ^0.4.0, add resourceMatchOriginOnly migration flag and 30-day refresh token TTL

--- a/.changeset/upgrade-oauth-cloudflare-casb-mcp-server.md
+++ b/.changeset/upgrade-oauth-cloudflare-casb-mcp-server.md
@@ -1,0 +1,5 @@
+---
+"cloudflare-casb-mcp-server": patch
+---
+
+Bump @cloudflare/workers-oauth-provider from 0.3.2 to 0.3.3

--- a/.changeset/upgrade-oauth-cloudflare-radar-mcp-server.md
+++ b/.changeset/upgrade-oauth-cloudflare-radar-mcp-server.md
@@ -1,0 +1,5 @@
+---
+"cloudflare-radar-mcp-server": patch
+---
+
+Bump @cloudflare/workers-oauth-provider from 0.3.2 to 0.3.3

--- a/.changeset/upgrade-oauth-cloudflare-radar-mcp-server.md
+++ b/.changeset/upgrade-oauth-cloudflare-radar-mcp-server.md
@@ -2,4 +2,4 @@
 "cloudflare-radar-mcp-server": patch
 ---
 
-Bump @cloudflare/workers-oauth-provider from 0.3.2 to 0.3.3
+Bump @cloudflare/workers-oauth-provider to ^0.4.0, add resourceMatchOriginOnly migration flag and 30-day refresh token TTL

--- a/.changeset/upgrade-oauth-containers-mcp.md
+++ b/.changeset/upgrade-oauth-containers-mcp.md
@@ -1,0 +1,5 @@
+---
+"containers-mcp": patch
+---
+
+Bump @cloudflare/workers-oauth-provider from 0.3.2 to 0.3.3

--- a/.changeset/upgrade-oauth-containers-mcp.md
+++ b/.changeset/upgrade-oauth-containers-mcp.md
@@ -2,4 +2,4 @@
 "containers-mcp": patch
 ---
 
-Bump @cloudflare/workers-oauth-provider from 0.3.2 to 0.3.3
+Bump @cloudflare/workers-oauth-provider to ^0.4.0, add resourceMatchOriginOnly migration flag and 30-day refresh token TTL

--- a/.changeset/upgrade-oauth-dex-analysis.md
+++ b/.changeset/upgrade-oauth-dex-analysis.md
@@ -2,4 +2,4 @@
 "dex-analysis": patch
 ---
 
-Bump @cloudflare/workers-oauth-provider from 0.3.2 to 0.3.3
+Bump @cloudflare/workers-oauth-provider to ^0.4.0, add resourceMatchOriginOnly migration flag and 30-day refresh token TTL

--- a/.changeset/upgrade-oauth-dex-analysis.md
+++ b/.changeset/upgrade-oauth-dex-analysis.md
@@ -1,0 +1,5 @@
+---
+"dex-analysis": patch
+---
+
+Bump @cloudflare/workers-oauth-provider from 0.3.2 to 0.3.3

--- a/.changeset/upgrade-oauth-dns-analytics.md
+++ b/.changeset/upgrade-oauth-dns-analytics.md
@@ -1,0 +1,5 @@
+---
+"dns-analytics": patch
+---
+
+Bump @cloudflare/workers-oauth-provider from 0.3.2 to 0.3.3

--- a/.changeset/upgrade-oauth-dns-analytics.md
+++ b/.changeset/upgrade-oauth-dns-analytics.md
@@ -2,4 +2,4 @@
 "dns-analytics": patch
 ---
 
-Bump @cloudflare/workers-oauth-provider from 0.3.2 to 0.3.3
+Bump @cloudflare/workers-oauth-provider to ^0.4.0, add resourceMatchOriginOnly migration flag and 30-day refresh token TTL

--- a/.changeset/upgrade-oauth-docs-ai-search.md
+++ b/.changeset/upgrade-oauth-docs-ai-search.md
@@ -2,4 +2,4 @@
 "docs-ai-search": patch
 ---
 
-Bump @cloudflare/workers-oauth-provider from 0.3.2 to 0.3.3
+Bump @cloudflare/workers-oauth-provider to ^0.4.0, add resourceMatchOriginOnly migration flag and 30-day refresh token TTL

--- a/.changeset/upgrade-oauth-docs-ai-search.md
+++ b/.changeset/upgrade-oauth-docs-ai-search.md
@@ -1,0 +1,5 @@
+---
+"docs-ai-search": patch
+---
+
+Bump @cloudflare/workers-oauth-provider from 0.3.2 to 0.3.3

--- a/.changeset/upgrade-oauth-docs-autorag.md
+++ b/.changeset/upgrade-oauth-docs-autorag.md
@@ -1,0 +1,5 @@
+---
+"docs-autorag": patch
+---
+
+Bump @cloudflare/workers-oauth-provider from 0.3.2 to 0.3.3

--- a/.changeset/upgrade-oauth-docs-autorag.md
+++ b/.changeset/upgrade-oauth-docs-autorag.md
@@ -2,4 +2,4 @@
 "docs-autorag": patch
 ---
 
-Bump @cloudflare/workers-oauth-provider from 0.3.2 to 0.3.3
+Bump @cloudflare/workers-oauth-provider to ^0.4.0, add resourceMatchOriginOnly migration flag and 30-day refresh token TTL

--- a/.changeset/upgrade-oauth-docs-vectorize.md
+++ b/.changeset/upgrade-oauth-docs-vectorize.md
@@ -2,4 +2,4 @@
 "docs-vectorize": patch
 ---
 
-Bump @cloudflare/workers-oauth-provider from 0.3.2 to 0.3.3
+Bump @cloudflare/workers-oauth-provider to ^0.4.0, add resourceMatchOriginOnly migration flag and 30-day refresh token TTL

--- a/.changeset/upgrade-oauth-docs-vectorize.md
+++ b/.changeset/upgrade-oauth-docs-vectorize.md
@@ -1,0 +1,5 @@
+---
+"docs-vectorize": patch
+---
+
+Bump @cloudflare/workers-oauth-provider from 0.3.2 to 0.3.3

--- a/.changeset/upgrade-oauth-graphql-mcp-server.md
+++ b/.changeset/upgrade-oauth-graphql-mcp-server.md
@@ -2,4 +2,4 @@
 "graphql-mcp-server": patch
 ---
 
-Bump @cloudflare/workers-oauth-provider from 0.3.2 to 0.3.3
+Bump @cloudflare/workers-oauth-provider to ^0.4.0, add resourceMatchOriginOnly migration flag and 30-day refresh token TTL

--- a/.changeset/upgrade-oauth-graphql-mcp-server.md
+++ b/.changeset/upgrade-oauth-graphql-mcp-server.md
@@ -1,0 +1,5 @@
+---
+"graphql-mcp-server": patch
+---
+
+Bump @cloudflare/workers-oauth-provider from 0.3.2 to 0.3.3

--- a/.changeset/upgrade-oauth-logpush.md
+++ b/.changeset/upgrade-oauth-logpush.md
@@ -2,4 +2,4 @@
 "logpush": patch
 ---
 
-Bump @cloudflare/workers-oauth-provider from 0.3.2 to 0.3.3
+Bump @cloudflare/workers-oauth-provider to ^0.4.0, add resourceMatchOriginOnly migration flag and 30-day refresh token TTL

--- a/.changeset/upgrade-oauth-logpush.md
+++ b/.changeset/upgrade-oauth-logpush.md
@@ -1,0 +1,5 @@
+---
+"logpush": patch
+---
+
+Bump @cloudflare/workers-oauth-provider from 0.3.2 to 0.3.3

--- a/.changeset/upgrade-oauth-mcp-common.md
+++ b/.changeset/upgrade-oauth-mcp-common.md
@@ -2,4 +2,4 @@
 "@repo/mcp-common": patch
 ---
 
-Bump @cloudflare/workers-oauth-provider from 0.3.2 to 0.3.3
+Bump @cloudflare/workers-oauth-provider to ^0.4.0, add resourceMatchOriginOnly migration flag and 30-day refresh token TTL

--- a/.changeset/upgrade-oauth-mcp-common.md
+++ b/.changeset/upgrade-oauth-mcp-common.md
@@ -1,0 +1,5 @@
+---
+"@repo/mcp-common": patch
+---
+
+Bump @cloudflare/workers-oauth-provider from 0.3.2 to 0.3.3

--- a/.changeset/upgrade-oauth-workers-bindings.md
+++ b/.changeset/upgrade-oauth-workers-bindings.md
@@ -1,0 +1,5 @@
+---
+"workers-bindings": patch
+---
+
+Bump @cloudflare/workers-oauth-provider from 0.3.2 to 0.3.3

--- a/.changeset/upgrade-oauth-workers-bindings.md
+++ b/.changeset/upgrade-oauth-workers-bindings.md
@@ -2,4 +2,4 @@
 "workers-bindings": patch
 ---
 
-Bump @cloudflare/workers-oauth-provider from 0.3.2 to 0.3.3
+Bump @cloudflare/workers-oauth-provider to ^0.4.0, add resourceMatchOriginOnly migration flag and 30-day refresh token TTL

--- a/.changeset/upgrade-oauth-workers-builds.md
+++ b/.changeset/upgrade-oauth-workers-builds.md
@@ -1,0 +1,5 @@
+---
+"workers-builds": patch
+---
+
+Bump @cloudflare/workers-oauth-provider from 0.3.2 to 0.3.3

--- a/.changeset/upgrade-oauth-workers-builds.md
+++ b/.changeset/upgrade-oauth-workers-builds.md
@@ -2,4 +2,4 @@
 "workers-builds": patch
 ---
 
-Bump @cloudflare/workers-oauth-provider from 0.3.2 to 0.3.3
+Bump @cloudflare/workers-oauth-provider to ^0.4.0, add resourceMatchOriginOnly migration flag and 30-day refresh token TTL

--- a/.changeset/upgrade-oauth-workers-observability.md
+++ b/.changeset/upgrade-oauth-workers-observability.md
@@ -1,0 +1,5 @@
+---
+"workers-observability": patch
+---
+
+Bump @cloudflare/workers-oauth-provider from 0.3.2 to 0.3.3

--- a/.changeset/upgrade-oauth-workers-observability.md
+++ b/.changeset/upgrade-oauth-workers-observability.md
@@ -2,4 +2,4 @@
 "workers-observability": patch
 ---
 
-Bump @cloudflare/workers-oauth-provider from 0.3.2 to 0.3.3
+Bump @cloudflare/workers-oauth-provider to ^0.4.0, add resourceMatchOriginOnly migration flag and 30-day refresh token TTL

--- a/apps/ai-gateway/package.json
+++ b/apps/ai-gateway/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "^0.3.3",
+		"@cloudflare/workers-oauth-provider": "^0.4.0",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/ai-gateway/package.json
+++ b/apps/ai-gateway/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.3.2",
+		"@cloudflare/workers-oauth-provider": "0.3.3",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/ai-gateway/package.json
+++ b/apps/ai-gateway/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "^0.4.0",
+		"@cloudflare/workers-oauth-provider": "0.4.0",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/ai-gateway/package.json
+++ b/apps/ai-gateway/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.3.3",
+		"@cloudflare/workers-oauth-provider": "^0.3.3",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/ai-gateway/src/ai-gateway.app.ts
+++ b/apps/ai-gateway/src/ai-gateway.app.ts
@@ -130,6 +130,9 @@ export default {
 				),
 			// Cloudflare access token TTL
 			accessTokenTTL: 3600,
+			refreshTokenTTL: 2592000, // 30 days
+			// TODO: Remove after 2026-05-01 — all pre-0.4.0 grants will have expired by then
+			resourceMatchOriginOnly: true,
 			clientRegistrationEndpoint: '/register',
 		}).fetch(req, env, ctx)
 	},

--- a/apps/auditlogs/package.json
+++ b/apps/auditlogs/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "^0.3.3",
+		"@cloudflare/workers-oauth-provider": "^0.4.0",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/auditlogs/package.json
+++ b/apps/auditlogs/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.3.2",
+		"@cloudflare/workers-oauth-provider": "0.3.3",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/auditlogs/package.json
+++ b/apps/auditlogs/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "^0.4.0",
+		"@cloudflare/workers-oauth-provider": "0.4.0",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/auditlogs/package.json
+++ b/apps/auditlogs/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.3.3",
+		"@cloudflare/workers-oauth-provider": "^0.3.3",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/auditlogs/src/auditlogs.app.ts
+++ b/apps/auditlogs/src/auditlogs.app.ts
@@ -130,6 +130,9 @@ export default {
 				),
 			// Cloudflare access token TTL
 			accessTokenTTL: 3600,
+			refreshTokenTTL: 2592000, // 30 days
+			// TODO: Remove after 2026-05-01 — all pre-0.4.0 grants will have expired by then
+			resourceMatchOriginOnly: true,
 			clientRegistrationEndpoint: '/register',
 		}).fetch(req, env, ctx)
 	},

--- a/apps/autorag/package.json
+++ b/apps/autorag/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "^0.3.3",
+		"@cloudflare/workers-oauth-provider": "^0.4.0",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/autorag/package.json
+++ b/apps/autorag/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.3.2",
+		"@cloudflare/workers-oauth-provider": "0.3.3",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/autorag/package.json
+++ b/apps/autorag/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "^0.4.0",
+		"@cloudflare/workers-oauth-provider": "0.4.0",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/autorag/package.json
+++ b/apps/autorag/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.3.3",
+		"@cloudflare/workers-oauth-provider": "^0.3.3",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/autorag/src/autorag.app.ts
+++ b/apps/autorag/src/autorag.app.ts
@@ -130,6 +130,9 @@ export default {
 				),
 			// Cloudflare access token TTL
 			accessTokenTTL: 3600,
+			refreshTokenTTL: 2592000, // 30 days
+			// TODO: Remove after 2026-05-01 — all pre-0.4.0 grants will have expired by then
+			resourceMatchOriginOnly: true,
 			clientRegistrationEndpoint: '/register',
 		}).fetch(req, env, ctx)
 	},

--- a/apps/browser-rendering/package.json
+++ b/apps/browser-rendering/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "^0.3.3",
+		"@cloudflare/workers-oauth-provider": "^0.4.0",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/browser-rendering/package.json
+++ b/apps/browser-rendering/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.3.2",
+		"@cloudflare/workers-oauth-provider": "0.3.3",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/browser-rendering/package.json
+++ b/apps/browser-rendering/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "^0.4.0",
+		"@cloudflare/workers-oauth-provider": "0.4.0",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/browser-rendering/package.json
+++ b/apps/browser-rendering/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.3.3",
+		"@cloudflare/workers-oauth-provider": "^0.3.3",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/browser-rendering/src/browser.app.ts
+++ b/apps/browser-rendering/src/browser.app.ts
@@ -130,6 +130,9 @@ export default {
 				),
 			// Cloudflare access token TTL
 			accessTokenTTL: 3600,
+			refreshTokenTTL: 2592000, // 30 days
+			// TODO: Remove after 2026-05-01 — all pre-0.4.0 grants will have expired by then
+			resourceMatchOriginOnly: true,
 			clientRegistrationEndpoint: '/register',
 		}).fetch(req, env, ctx)
 	},

--- a/apps/cloudflare-one-casb/package.json
+++ b/apps/cloudflare-one-casb/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "^0.3.3",
+		"@cloudflare/workers-oauth-provider": "^0.4.0",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/cloudflare-one-casb/package.json
+++ b/apps/cloudflare-one-casb/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.3.2",
+		"@cloudflare/workers-oauth-provider": "0.3.3",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/cloudflare-one-casb/package.json
+++ b/apps/cloudflare-one-casb/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "^0.4.0",
+		"@cloudflare/workers-oauth-provider": "0.4.0",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/cloudflare-one-casb/package.json
+++ b/apps/cloudflare-one-casb/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.3.3",
+		"@cloudflare/workers-oauth-provider": "^0.3.3",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/cloudflare-one-casb/src/cf1-casb.app.ts
+++ b/apps/cloudflare-one-casb/src/cf1-casb.app.ts
@@ -128,6 +128,9 @@ export default {
 				),
 			// Cloudflare access token TTL
 			accessTokenTTL: 3600,
+			refreshTokenTTL: 2592000, // 30 days
+			// TODO: Remove after 2026-05-01 — all pre-0.4.0 grants will have expired by then
+			resourceMatchOriginOnly: true,
 			clientRegistrationEndpoint: '/register',
 		}).fetch(req, env, ctx)
 	},

--- a/apps/dex-analysis/package.json
+++ b/apps/dex-analysis/package.json
@@ -13,7 +13,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "^0.3.3",
+		"@cloudflare/workers-oauth-provider": "^0.4.0",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/dex-analysis/package.json
+++ b/apps/dex-analysis/package.json
@@ -13,7 +13,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "^0.4.0",
+		"@cloudflare/workers-oauth-provider": "0.4.0",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/dex-analysis/package.json
+++ b/apps/dex-analysis/package.json
@@ -13,7 +13,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.3.3",
+		"@cloudflare/workers-oauth-provider": "^0.3.3",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/dex-analysis/package.json
+++ b/apps/dex-analysis/package.json
@@ -13,7 +13,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.3.2",
+		"@cloudflare/workers-oauth-provider": "0.3.3",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/dex-analysis/src/dex-analysis.app.ts
+++ b/apps/dex-analysis/src/dex-analysis.app.ts
@@ -132,6 +132,9 @@ export default {
 				),
 			// Cloudflare access token TTL
 			accessTokenTTL: 3600,
+			refreshTokenTTL: 2592000, // 30 days
+			// TODO: Remove after 2026-05-01 — all pre-0.4.0 grants will have expired by then
+			resourceMatchOriginOnly: true,
 			clientRegistrationEndpoint: '/register',
 		}).fetch(req, env, ctx)
 	},

--- a/apps/dns-analytics/package.json
+++ b/apps/dns-analytics/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "^0.3.3",
+		"@cloudflare/workers-oauth-provider": "^0.4.0",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/dns-analytics/package.json
+++ b/apps/dns-analytics/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.3.2",
+		"@cloudflare/workers-oauth-provider": "0.3.3",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/dns-analytics/package.json
+++ b/apps/dns-analytics/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "^0.4.0",
+		"@cloudflare/workers-oauth-provider": "0.4.0",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/dns-analytics/package.json
+++ b/apps/dns-analytics/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.3.3",
+		"@cloudflare/workers-oauth-provider": "^0.3.3",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/dns-analytics/src/dns-analytics.app.ts
+++ b/apps/dns-analytics/src/dns-analytics.app.ts
@@ -137,6 +137,9 @@ export default {
 				),
 			// Cloudflare access token TTL
 			accessTokenTTL: 3600,
+			refreshTokenTTL: 2592000, // 30 days
+			// TODO: Remove after 2026-05-01 — all pre-0.4.0 grants will have expired by then
+			resourceMatchOriginOnly: true,
 			clientRegistrationEndpoint: '/register',
 		}).fetch(req, env, ctx)
 	},

--- a/apps/docs-ai-search/package.json
+++ b/apps/docs-ai-search/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "^0.3.3",
+		"@cloudflare/workers-oauth-provider": "^0.4.0",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/docs-ai-search/package.json
+++ b/apps/docs-ai-search/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.3.2",
+		"@cloudflare/workers-oauth-provider": "0.3.3",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/docs-ai-search/package.json
+++ b/apps/docs-ai-search/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "^0.4.0",
+		"@cloudflare/workers-oauth-provider": "0.4.0",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/docs-ai-search/package.json
+++ b/apps/docs-ai-search/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.3.3",
+		"@cloudflare/workers-oauth-provider": "^0.3.3",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/docs-autorag/package.json
+++ b/apps/docs-autorag/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "^0.3.3",
+		"@cloudflare/workers-oauth-provider": "^0.4.0",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/docs-autorag/package.json
+++ b/apps/docs-autorag/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.3.2",
+		"@cloudflare/workers-oauth-provider": "0.3.3",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/docs-autorag/package.json
+++ b/apps/docs-autorag/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "^0.4.0",
+		"@cloudflare/workers-oauth-provider": "0.4.0",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/docs-autorag/package.json
+++ b/apps/docs-autorag/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.3.3",
+		"@cloudflare/workers-oauth-provider": "^0.3.3",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/docs-vectorize/package.json
+++ b/apps/docs-vectorize/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "^0.3.3",
+		"@cloudflare/workers-oauth-provider": "^0.4.0",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/docs-vectorize/package.json
+++ b/apps/docs-vectorize/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.3.2",
+		"@cloudflare/workers-oauth-provider": "0.3.3",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/docs-vectorize/package.json
+++ b/apps/docs-vectorize/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "^0.4.0",
+		"@cloudflare/workers-oauth-provider": "0.4.0",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/docs-vectorize/package.json
+++ b/apps/docs-vectorize/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.3.3",
+		"@cloudflare/workers-oauth-provider": "^0.3.3",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/graphql/package.json
+++ b/apps/graphql/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "^0.3.3",
+		"@cloudflare/workers-oauth-provider": "^0.4.0",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/graphql/package.json
+++ b/apps/graphql/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.3.2",
+		"@cloudflare/workers-oauth-provider": "0.3.3",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/graphql/package.json
+++ b/apps/graphql/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "^0.4.0",
+		"@cloudflare/workers-oauth-provider": "0.4.0",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/graphql/package.json
+++ b/apps/graphql/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.3.3",
+		"@cloudflare/workers-oauth-provider": "^0.3.3",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/graphql/src/graphql.app.ts
+++ b/apps/graphql/src/graphql.app.ts
@@ -140,6 +140,9 @@ export default {
 				),
 			// Cloudflare access token TTL
 			accessTokenTTL: 3600,
+			refreshTokenTTL: 2592000, // 30 days
+			// TODO: Remove after 2026-05-01 — all pre-0.4.0 grants will have expired by then
+			resourceMatchOriginOnly: true,
 			clientRegistrationEndpoint: '/register',
 		}).fetch(req, env, ctx)
 	},

--- a/apps/logpush/package.json
+++ b/apps/logpush/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "^0.3.3",
+		"@cloudflare/workers-oauth-provider": "^0.4.0",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/logpush/package.json
+++ b/apps/logpush/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.3.2",
+		"@cloudflare/workers-oauth-provider": "0.3.3",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/logpush/package.json
+++ b/apps/logpush/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "^0.4.0",
+		"@cloudflare/workers-oauth-provider": "0.4.0",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/logpush/package.json
+++ b/apps/logpush/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.3.3",
+		"@cloudflare/workers-oauth-provider": "^0.3.3",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/logpush/src/logpush.app.ts
+++ b/apps/logpush/src/logpush.app.ts
@@ -131,6 +131,9 @@ export default {
 				),
 			// Cloudflare access token TTL
 			accessTokenTTL: 3600,
+			refreshTokenTTL: 2592000, // 30 days
+			// TODO: Remove after 2026-05-01 — all pre-0.4.0 grants will have expired by then
+			resourceMatchOriginOnly: true,
 			clientRegistrationEndpoint: '/register',
 		}).fetch(req, env, ctx)
 	},

--- a/apps/radar/package.json
+++ b/apps/radar/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "^0.3.3",
+		"@cloudflare/workers-oauth-provider": "^0.4.0",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/radar/package.json
+++ b/apps/radar/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.3.2",
+		"@cloudflare/workers-oauth-provider": "0.3.3",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/radar/package.json
+++ b/apps/radar/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "^0.4.0",
+		"@cloudflare/workers-oauth-provider": "0.4.0",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/radar/package.json
+++ b/apps/radar/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.3.3",
+		"@cloudflare/workers-oauth-provider": "^0.3.3",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/radar/src/radar.app.ts
+++ b/apps/radar/src/radar.app.ts
@@ -133,6 +133,9 @@ export default {
 				),
 			// Cloudflare access token TTL
 			accessTokenTTL: 3600,
+			refreshTokenTTL: 2592000, // 30 days
+			// TODO: Remove after 2026-05-01 — all pre-0.4.0 grants will have expired by then
+			resourceMatchOriginOnly: true,
 			clientRegistrationEndpoint: '/register',
 		}).fetch(req, env, ctx)
 	},

--- a/apps/sandbox-container/package.json
+++ b/apps/sandbox-container/package.json
@@ -19,7 +19,7 @@
 		"eval:ci": "start-server-and-test --expect 404 eval:server http://localhost:8976 'vitest run --testTimeout=60000 --config vitest.config.evals.ts'"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.3.2",
+		"@cloudflare/workers-oauth-provider": "0.3.3",
 		"@hono/node-server": "1.13.8",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",

--- a/apps/sandbox-container/package.json
+++ b/apps/sandbox-container/package.json
@@ -19,7 +19,7 @@
 		"eval:ci": "start-server-and-test --expect 404 eval:server http://localhost:8976 'vitest run --testTimeout=60000 --config vitest.config.evals.ts'"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.3.3",
+		"@cloudflare/workers-oauth-provider": "^0.3.3",
 		"@hono/node-server": "1.13.8",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",

--- a/apps/sandbox-container/package.json
+++ b/apps/sandbox-container/package.json
@@ -19,7 +19,7 @@
 		"eval:ci": "start-server-and-test --expect 404 eval:server http://localhost:8976 'vitest run --testTimeout=60000 --config vitest.config.evals.ts'"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "^0.4.0",
+		"@cloudflare/workers-oauth-provider": "0.4.0",
 		"@hono/node-server": "1.13.8",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",

--- a/apps/sandbox-container/package.json
+++ b/apps/sandbox-container/package.json
@@ -19,7 +19,7 @@
 		"eval:ci": "start-server-and-test --expect 404 eval:server http://localhost:8976 'vitest run --testTimeout=60000 --config vitest.config.evals.ts'"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "^0.3.3",
+		"@cloudflare/workers-oauth-provider": "^0.4.0",
 		"@hono/node-server": "1.13.8",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",

--- a/apps/sandbox-container/server/sandbox.server.app.ts
+++ b/apps/sandbox-container/server/sandbox.server.app.ts
@@ -55,6 +55,9 @@ export default {
 				),
 			// Cloudflare access token TTL
 			accessTokenTTL: 3600,
+			refreshTokenTTL: 2592000, // 30 days
+			// TODO: Remove after 2026-05-01 — all pre-0.4.0 grants will have expired by then
+			resourceMatchOriginOnly: true,
 			clientRegistrationEndpoint: '/register',
 		}).fetch(req, env, ctx)
 	},

--- a/apps/workers-bindings/package.json
+++ b/apps/workers-bindings/package.json
@@ -25,7 +25,7 @@
 		"wrangler": "4.10.0"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "^0.4.0",
+		"@cloudflare/workers-oauth-provider": "0.4.0",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@n8n/json-schema-to-zod": "1.1.0",
 		"@repo/eval-tools": "workspace:*",

--- a/apps/workers-bindings/package.json
+++ b/apps/workers-bindings/package.json
@@ -25,7 +25,7 @@
 		"wrangler": "4.10.0"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.3.3",
+		"@cloudflare/workers-oauth-provider": "^0.3.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@n8n/json-schema-to-zod": "1.1.0",
 		"@repo/eval-tools": "workspace:*",

--- a/apps/workers-bindings/package.json
+++ b/apps/workers-bindings/package.json
@@ -25,7 +25,7 @@
 		"wrangler": "4.10.0"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.3.2",
+		"@cloudflare/workers-oauth-provider": "0.3.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@n8n/json-schema-to-zod": "1.1.0",
 		"@repo/eval-tools": "workspace:*",

--- a/apps/workers-bindings/package.json
+++ b/apps/workers-bindings/package.json
@@ -25,7 +25,7 @@
 		"wrangler": "4.10.0"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "^0.3.3",
+		"@cloudflare/workers-oauth-provider": "^0.4.0",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@n8n/json-schema-to-zod": "1.1.0",
 		"@repo/eval-tools": "workspace:*",

--- a/apps/workers-bindings/src/bindings.app.ts
+++ b/apps/workers-bindings/src/bindings.app.ts
@@ -150,6 +150,9 @@ export default {
 				),
 			// Cloudflare access token TTL
 			accessTokenTTL: 3600,
+			refreshTokenTTL: 2592000, // 30 days
+			// TODO: Remove after 2026-05-01 — all pre-0.4.0 grants will have expired by then
+			resourceMatchOriginOnly: true,
 			clientRegistrationEndpoint: '/register',
 		}).fetch(req, env, ctx)
 	},

--- a/apps/workers-builds/package.json
+++ b/apps/workers-builds/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "^0.3.3",
+		"@cloudflare/workers-oauth-provider": "^0.4.0",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/workers-builds/package.json
+++ b/apps/workers-builds/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.3.2",
+		"@cloudflare/workers-oauth-provider": "0.3.3",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/workers-builds/package.json
+++ b/apps/workers-builds/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "^0.4.0",
+		"@cloudflare/workers-oauth-provider": "0.4.0",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/workers-builds/package.json
+++ b/apps/workers-builds/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.3.3",
+		"@cloudflare/workers-oauth-provider": "^0.3.3",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/workers-builds/src/workers-builds.app.ts
+++ b/apps/workers-builds/src/workers-builds.app.ts
@@ -196,6 +196,9 @@ export default {
 				),
 			// Cloudflare access token TTL
 			accessTokenTTL: 3600,
+			refreshTokenTTL: 2592000, // 30 days
+			// TODO: Remove after 2026-05-01 — all pre-0.4.0 grants will have expired by then
+			resourceMatchOriginOnly: true,
 			clientRegistrationEndpoint: '/register',
 		}).fetch(req, env, ctx)
 	},

--- a/apps/workers-observability/package.json
+++ b/apps/workers-observability/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "^0.4.0",
+		"@cloudflare/workers-oauth-provider": "0.4.0",
 		"@fast-csv/format": "5.0.2",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",

--- a/apps/workers-observability/package.json
+++ b/apps/workers-observability/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.3.3",
+		"@cloudflare/workers-oauth-provider": "^0.3.3",
 		"@fast-csv/format": "5.0.2",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",

--- a/apps/workers-observability/package.json
+++ b/apps/workers-observability/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "^0.3.3",
+		"@cloudflare/workers-oauth-provider": "^0.4.0",
 		"@fast-csv/format": "5.0.2",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",

--- a/apps/workers-observability/package.json
+++ b/apps/workers-observability/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.3.2",
+		"@cloudflare/workers-oauth-provider": "0.3.3",
 		"@fast-csv/format": "5.0.2",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",

--- a/apps/workers-observability/src/workers-observability.app.ts
+++ b/apps/workers-observability/src/workers-observability.app.ts
@@ -153,6 +153,9 @@ export default {
 				),
 			// Cloudflare access token TTL
 			accessTokenTTL: 3600,
+			refreshTokenTTL: 2592000, // 30 days
+			// TODO: Remove after 2026-05-01 — all pre-0.4.0 grants will have expired by then
+			resourceMatchOriginOnly: true,
 			clientRegistrationEndpoint: '/register',
 		}).fetch(req, env, ctx)
 	},

--- a/packages/mcp-common/package.json
+++ b/packages/mcp-common/package.json
@@ -11,7 +11,7 @@
 		"test:coverage": "run-vitest-coverage"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.3.3",
+		"@cloudflare/workers-oauth-provider": "^0.3.3",
 		"@fast-csv/format": "5.0.2",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",

--- a/packages/mcp-common/package.json
+++ b/packages/mcp-common/package.json
@@ -11,7 +11,7 @@
 		"test:coverage": "run-vitest-coverage"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "^0.3.3",
+		"@cloudflare/workers-oauth-provider": "^0.4.0",
 		"@fast-csv/format": "5.0.2",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",

--- a/packages/mcp-common/package.json
+++ b/packages/mcp-common/package.json
@@ -11,7 +11,7 @@
 		"test:coverage": "run-vitest-coverage"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.3.2",
+		"@cloudflare/workers-oauth-provider": "0.3.3",
 		"@fast-csv/format": "5.0.2",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",

--- a/packages/mcp-common/package.json
+++ b/packages/mcp-common/package.json
@@ -11,7 +11,7 @@
 		"test:coverage": "run-vitest-coverage"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "^0.4.0",
+		"@cloudflare/workers-oauth-provider": "0.4.0",
 		"@fast-csv/format": "5.0.2",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.20.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,7 +51,7 @@ importers:
   apps/ai-gateway:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: ^0.4.0
+        specifier: 0.4.0
         version: 0.4.0
       '@hono/zod-validator':
         specifier: 0.4.3
@@ -100,7 +100,7 @@ importers:
   apps/auditlogs:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: ^0.4.0
+        specifier: 0.4.0
         version: 0.4.0
       '@hono/zod-validator':
         specifier: 0.4.3
@@ -149,7 +149,7 @@ importers:
   apps/autorag:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: ^0.4.0
+        specifier: 0.4.0
         version: 0.4.0
       '@hono/zod-validator':
         specifier: 0.4.3
@@ -198,7 +198,7 @@ importers:
   apps/browser-rendering:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: ^0.4.0
+        specifier: 0.4.0
         version: 0.4.0
       '@hono/zod-validator':
         specifier: 0.4.3
@@ -247,7 +247,7 @@ importers:
   apps/cloudflare-one-casb:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: ^0.4.0
+        specifier: 0.4.0
         version: 0.4.0
       '@hono/zod-validator':
         specifier: 0.4.3
@@ -333,7 +333,7 @@ importers:
   apps/dex-analysis:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: ^0.4.0
+        specifier: 0.4.0
         version: 0.4.0
       '@hono/zod-validator':
         specifier: 0.4.3
@@ -388,7 +388,7 @@ importers:
   apps/dns-analytics:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: ^0.4.0
+        specifier: 0.4.0
         version: 0.4.0
       '@hono/zod-validator':
         specifier: 0.4.3
@@ -437,7 +437,7 @@ importers:
   apps/docs-ai-search:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: ^0.4.0
+        specifier: 0.4.0
         version: 0.4.0
       '@hono/zod-validator':
         specifier: 0.4.3
@@ -489,7 +489,7 @@ importers:
   apps/docs-autorag:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: ^0.4.0
+        specifier: 0.4.0
         version: 0.4.0
       '@hono/zod-validator':
         specifier: 0.4.3
@@ -541,7 +541,7 @@ importers:
   apps/docs-vectorize:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: ^0.4.0
+        specifier: 0.4.0
         version: 0.4.0
       '@hono/zod-validator':
         specifier: 0.4.3
@@ -593,7 +593,7 @@ importers:
   apps/graphql:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: ^0.4.0
+        specifier: 0.4.0
         version: 0.4.0
       '@hono/zod-validator':
         specifier: 0.4.3
@@ -645,7 +645,7 @@ importers:
   apps/logpush:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: ^0.4.0
+        specifier: 0.4.0
         version: 0.4.0
       '@hono/zod-validator':
         specifier: 0.4.3
@@ -694,7 +694,7 @@ importers:
   apps/radar:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: ^0.4.0
+        specifier: 0.4.0
         version: 0.4.0
       '@hono/zod-validator':
         specifier: 0.4.3
@@ -743,7 +743,7 @@ importers:
   apps/sandbox-container:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: ^0.4.0
+        specifier: 0.4.0
         version: 0.4.0
       '@hono/node-server':
         specifier: 1.13.8
@@ -822,7 +822,7 @@ importers:
   apps/workers-bindings:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: ^0.4.0
+        specifier: 0.4.0
         version: 0.4.0
       '@modelcontextprotocol/sdk':
         specifier: 1.20.2
@@ -883,7 +883,7 @@ importers:
   apps/workers-builds:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: ^0.4.0
+        specifier: 0.4.0
         version: 0.4.0
       '@hono/zod-validator':
         specifier: 0.4.3
@@ -938,7 +938,7 @@ importers:
   apps/workers-observability:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: ^0.4.0
+        specifier: 0.4.0
         version: 0.4.0
       '@fast-csv/format':
         specifier: 5.0.2
@@ -1078,7 +1078,7 @@ importers:
   packages/mcp-common:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: ^0.4.0
+        specifier: 0.4.0
         version: 0.4.0
       '@fast-csv/format':
         specifier: 5.0.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,7 +51,7 @@ importers:
   apps/ai-gateway:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.3.3
+        specifier: ^0.3.3
         version: 0.3.3
       '@hono/zod-validator':
         specifier: 0.4.3
@@ -100,7 +100,7 @@ importers:
   apps/auditlogs:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.3.3
+        specifier: ^0.3.3
         version: 0.3.3
       '@hono/zod-validator':
         specifier: 0.4.3
@@ -149,7 +149,7 @@ importers:
   apps/autorag:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.3.3
+        specifier: ^0.3.3
         version: 0.3.3
       '@hono/zod-validator':
         specifier: 0.4.3
@@ -198,7 +198,7 @@ importers:
   apps/browser-rendering:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.3.3
+        specifier: ^0.3.3
         version: 0.3.3
       '@hono/zod-validator':
         specifier: 0.4.3
@@ -247,7 +247,7 @@ importers:
   apps/cloudflare-one-casb:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.3.3
+        specifier: ^0.3.3
         version: 0.3.3
       '@hono/zod-validator':
         specifier: 0.4.3
@@ -333,7 +333,7 @@ importers:
   apps/dex-analysis:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.3.3
+        specifier: ^0.3.3
         version: 0.3.3
       '@hono/zod-validator':
         specifier: 0.4.3
@@ -388,7 +388,7 @@ importers:
   apps/dns-analytics:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.3.3
+        specifier: ^0.3.3
         version: 0.3.3
       '@hono/zod-validator':
         specifier: 0.4.3
@@ -437,7 +437,7 @@ importers:
   apps/docs-ai-search:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.3.3
+        specifier: ^0.3.3
         version: 0.3.3
       '@hono/zod-validator':
         specifier: 0.4.3
@@ -489,7 +489,7 @@ importers:
   apps/docs-autorag:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.3.3
+        specifier: ^0.3.3
         version: 0.3.3
       '@hono/zod-validator':
         specifier: 0.4.3
@@ -541,7 +541,7 @@ importers:
   apps/docs-vectorize:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.3.3
+        specifier: ^0.3.3
         version: 0.3.3
       '@hono/zod-validator':
         specifier: 0.4.3
@@ -593,7 +593,7 @@ importers:
   apps/graphql:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.3.3
+        specifier: ^0.3.3
         version: 0.3.3
       '@hono/zod-validator':
         specifier: 0.4.3
@@ -645,7 +645,7 @@ importers:
   apps/logpush:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.3.3
+        specifier: ^0.3.3
         version: 0.3.3
       '@hono/zod-validator':
         specifier: 0.4.3
@@ -694,7 +694,7 @@ importers:
   apps/radar:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.3.3
+        specifier: ^0.3.3
         version: 0.3.3
       '@hono/zod-validator':
         specifier: 0.4.3
@@ -743,7 +743,7 @@ importers:
   apps/sandbox-container:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.3.3
+        specifier: ^0.3.3
         version: 0.3.3
       '@hono/node-server':
         specifier: 1.13.8
@@ -822,7 +822,7 @@ importers:
   apps/workers-bindings:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.3.3
+        specifier: ^0.3.3
         version: 0.3.3
       '@modelcontextprotocol/sdk':
         specifier: 1.20.2
@@ -883,7 +883,7 @@ importers:
   apps/workers-builds:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.3.3
+        specifier: ^0.3.3
         version: 0.3.3
       '@hono/zod-validator':
         specifier: 0.4.3
@@ -938,7 +938,7 @@ importers:
   apps/workers-observability:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.3.3
+        specifier: ^0.3.3
         version: 0.3.3
       '@fast-csv/format':
         specifier: 5.0.2
@@ -1078,7 +1078,7 @@ importers:
   packages/mcp-common:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.3.3
+        specifier: ^0.3.3
         version: 0.3.3
       '@fast-csv/format':
         specifier: 5.0.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,8 +51,8 @@ importers:
   apps/ai-gateway:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.3.2
-        version: 0.3.2
+        specifier: 0.3.3
+        version: 0.3.3
       '@hono/zod-validator':
         specifier: 0.4.3
         version: 0.4.3(hono@4.7.6)(zod@3.24.2)
@@ -100,8 +100,8 @@ importers:
   apps/auditlogs:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.3.2
-        version: 0.3.2
+        specifier: 0.3.3
+        version: 0.3.3
       '@hono/zod-validator':
         specifier: 0.4.3
         version: 0.4.3(hono@4.7.6)(zod@3.24.2)
@@ -149,8 +149,8 @@ importers:
   apps/autorag:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.3.2
-        version: 0.3.2
+        specifier: 0.3.3
+        version: 0.3.3
       '@hono/zod-validator':
         specifier: 0.4.3
         version: 0.4.3(hono@4.7.6)(zod@3.24.2)
@@ -198,8 +198,8 @@ importers:
   apps/browser-rendering:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.3.2
-        version: 0.3.2
+        specifier: 0.3.3
+        version: 0.3.3
       '@hono/zod-validator':
         specifier: 0.4.3
         version: 0.4.3(hono@4.7.6)(zod@3.24.2)
@@ -247,8 +247,8 @@ importers:
   apps/cloudflare-one-casb:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.3.2
-        version: 0.3.2
+        specifier: 0.3.3
+        version: 0.3.3
       '@hono/zod-validator':
         specifier: 0.4.3
         version: 0.4.3(hono@4.7.6)(zod@3.24.2)
@@ -333,8 +333,8 @@ importers:
   apps/dex-analysis:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.3.2
-        version: 0.3.2
+        specifier: 0.3.3
+        version: 0.3.3
       '@hono/zod-validator':
         specifier: 0.4.3
         version: 0.4.3(hono@4.7.6)(zod@3.24.2)
@@ -388,8 +388,8 @@ importers:
   apps/dns-analytics:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.3.2
-        version: 0.3.2
+        specifier: 0.3.3
+        version: 0.3.3
       '@hono/zod-validator':
         specifier: 0.4.3
         version: 0.4.3(hono@4.7.6)(zod@3.24.2)
@@ -437,8 +437,8 @@ importers:
   apps/docs-ai-search:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.3.2
-        version: 0.3.2
+        specifier: 0.3.3
+        version: 0.3.3
       '@hono/zod-validator':
         specifier: 0.4.3
         version: 0.4.3(hono@4.7.6)(zod@3.24.2)
@@ -489,8 +489,8 @@ importers:
   apps/docs-autorag:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.3.2
-        version: 0.3.2
+        specifier: 0.3.3
+        version: 0.3.3
       '@hono/zod-validator':
         specifier: 0.4.3
         version: 0.4.3(hono@4.7.6)(zod@3.24.2)
@@ -541,8 +541,8 @@ importers:
   apps/docs-vectorize:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.3.2
-        version: 0.3.2
+        specifier: 0.3.3
+        version: 0.3.3
       '@hono/zod-validator':
         specifier: 0.4.3
         version: 0.4.3(hono@4.7.6)(zod@3.24.2)
@@ -593,8 +593,8 @@ importers:
   apps/graphql:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.3.2
-        version: 0.3.2
+        specifier: 0.3.3
+        version: 0.3.3
       '@hono/zod-validator':
         specifier: 0.4.3
         version: 0.4.3(hono@4.7.6)(zod@3.24.2)
@@ -645,8 +645,8 @@ importers:
   apps/logpush:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.3.2
-        version: 0.3.2
+        specifier: 0.3.3
+        version: 0.3.3
       '@hono/zod-validator':
         specifier: 0.4.3
         version: 0.4.3(hono@4.7.6)(zod@3.24.2)
@@ -694,8 +694,8 @@ importers:
   apps/radar:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.3.2
-        version: 0.3.2
+        specifier: 0.3.3
+        version: 0.3.3
       '@hono/zod-validator':
         specifier: 0.4.3
         version: 0.4.3(hono@4.7.6)(zod@3.24.2)
@@ -743,8 +743,8 @@ importers:
   apps/sandbox-container:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.3.2
-        version: 0.3.2
+        specifier: 0.3.3
+        version: 0.3.3
       '@hono/node-server':
         specifier: 1.13.8
         version: 1.13.8(hono@4.7.6)
@@ -822,8 +822,8 @@ importers:
   apps/workers-bindings:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.3.2
-        version: 0.3.2
+        specifier: 0.3.3
+        version: 0.3.3
       '@modelcontextprotocol/sdk':
         specifier: 1.20.2
         version: 1.20.2
@@ -883,8 +883,8 @@ importers:
   apps/workers-builds:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.3.2
-        version: 0.3.2
+        specifier: 0.3.3
+        version: 0.3.3
       '@hono/zod-validator':
         specifier: 0.4.3
         version: 0.4.3(hono@4.7.6)(zod@3.24.2)
@@ -938,8 +938,8 @@ importers:
   apps/workers-observability:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.3.2
-        version: 0.3.2
+        specifier: 0.3.3
+        version: 0.3.3
       '@fast-csv/format':
         specifier: 5.0.2
         version: 5.0.2
@@ -1078,8 +1078,8 @@ importers:
   packages/mcp-common:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.3.2
-        version: 0.3.2
+        specifier: 0.3.3
+        version: 0.3.3
       '@fast-csv/format':
         specifier: 5.0.2
         version: 5.0.2
@@ -1541,8 +1541,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@cloudflare/workers-oauth-provider@0.3.2':
-    resolution: {integrity: sha512-WFK95ThKutKDiTCPPbfzya1Fo7YMmEISQ0OlmJ+mGQJdb2dwOPS+YUY9Lk9pF/huOB0PS0V2cdb6BESqBlx3cQ==}
+  '@cloudflare/workers-oauth-provider@0.3.3':
+    resolution: {integrity: sha512-n0PrX+KZNdyXx2x6EFfIZKWj254LtiWZTCLcrOVHO4MeoFcGtYyG0a1fD/H365XGlpsCScOVCAS/Pc4JymqKJQ==}
 
   '@cloudflare/workers-types@4.20250410.0':
     resolution: {integrity: sha512-Yx9VUi6QpmXtUIhOL+em+V02gue12kmVBVL6RGH5mhFh50M0x9JyOmm6wKwKZUny2uQd+22nuouE2q3z1OrsIQ==}
@@ -6626,7 +6626,7 @@ snapshots:
   '@cloudflare/workerd-windows-64@1.20250507.0':
     optional: true
 
-  '@cloudflare/workers-oauth-provider@0.3.2': {}
+  '@cloudflare/workers-oauth-provider@0.3.3': {}
 
   '@cloudflare/workers-types@4.20250410.0': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,8 +51,8 @@ importers:
   apps/ai-gateway:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: ^0.3.3
-        version: 0.3.3
+        specifier: ^0.4.0
+        version: 0.4.0
       '@hono/zod-validator':
         specifier: 0.4.3
         version: 0.4.3(hono@4.7.6)(zod@3.24.2)
@@ -100,8 +100,8 @@ importers:
   apps/auditlogs:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: ^0.3.3
-        version: 0.3.3
+        specifier: ^0.4.0
+        version: 0.4.0
       '@hono/zod-validator':
         specifier: 0.4.3
         version: 0.4.3(hono@4.7.6)(zod@3.24.2)
@@ -149,8 +149,8 @@ importers:
   apps/autorag:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: ^0.3.3
-        version: 0.3.3
+        specifier: ^0.4.0
+        version: 0.4.0
       '@hono/zod-validator':
         specifier: 0.4.3
         version: 0.4.3(hono@4.7.6)(zod@3.24.2)
@@ -198,8 +198,8 @@ importers:
   apps/browser-rendering:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: ^0.3.3
-        version: 0.3.3
+        specifier: ^0.4.0
+        version: 0.4.0
       '@hono/zod-validator':
         specifier: 0.4.3
         version: 0.4.3(hono@4.7.6)(zod@3.24.2)
@@ -247,8 +247,8 @@ importers:
   apps/cloudflare-one-casb:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: ^0.3.3
-        version: 0.3.3
+        specifier: ^0.4.0
+        version: 0.4.0
       '@hono/zod-validator':
         specifier: 0.4.3
         version: 0.4.3(hono@4.7.6)(zod@3.24.2)
@@ -333,8 +333,8 @@ importers:
   apps/dex-analysis:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: ^0.3.3
-        version: 0.3.3
+        specifier: ^0.4.0
+        version: 0.4.0
       '@hono/zod-validator':
         specifier: 0.4.3
         version: 0.4.3(hono@4.7.6)(zod@3.24.2)
@@ -388,8 +388,8 @@ importers:
   apps/dns-analytics:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: ^0.3.3
-        version: 0.3.3
+        specifier: ^0.4.0
+        version: 0.4.0
       '@hono/zod-validator':
         specifier: 0.4.3
         version: 0.4.3(hono@4.7.6)(zod@3.24.2)
@@ -437,8 +437,8 @@ importers:
   apps/docs-ai-search:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: ^0.3.3
-        version: 0.3.3
+        specifier: ^0.4.0
+        version: 0.4.0
       '@hono/zod-validator':
         specifier: 0.4.3
         version: 0.4.3(hono@4.7.6)(zod@3.24.2)
@@ -489,8 +489,8 @@ importers:
   apps/docs-autorag:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: ^0.3.3
-        version: 0.3.3
+        specifier: ^0.4.0
+        version: 0.4.0
       '@hono/zod-validator':
         specifier: 0.4.3
         version: 0.4.3(hono@4.7.6)(zod@3.24.2)
@@ -541,8 +541,8 @@ importers:
   apps/docs-vectorize:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: ^0.3.3
-        version: 0.3.3
+        specifier: ^0.4.0
+        version: 0.4.0
       '@hono/zod-validator':
         specifier: 0.4.3
         version: 0.4.3(hono@4.7.6)(zod@3.24.2)
@@ -593,8 +593,8 @@ importers:
   apps/graphql:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: ^0.3.3
-        version: 0.3.3
+        specifier: ^0.4.0
+        version: 0.4.0
       '@hono/zod-validator':
         specifier: 0.4.3
         version: 0.4.3(hono@4.7.6)(zod@3.24.2)
@@ -645,8 +645,8 @@ importers:
   apps/logpush:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: ^0.3.3
-        version: 0.3.3
+        specifier: ^0.4.0
+        version: 0.4.0
       '@hono/zod-validator':
         specifier: 0.4.3
         version: 0.4.3(hono@4.7.6)(zod@3.24.2)
@@ -694,8 +694,8 @@ importers:
   apps/radar:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: ^0.3.3
-        version: 0.3.3
+        specifier: ^0.4.0
+        version: 0.4.0
       '@hono/zod-validator':
         specifier: 0.4.3
         version: 0.4.3(hono@4.7.6)(zod@3.24.2)
@@ -743,8 +743,8 @@ importers:
   apps/sandbox-container:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: ^0.3.3
-        version: 0.3.3
+        specifier: ^0.4.0
+        version: 0.4.0
       '@hono/node-server':
         specifier: 1.13.8
         version: 1.13.8(hono@4.7.6)
@@ -822,8 +822,8 @@ importers:
   apps/workers-bindings:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: ^0.3.3
-        version: 0.3.3
+        specifier: ^0.4.0
+        version: 0.4.0
       '@modelcontextprotocol/sdk':
         specifier: 1.20.2
         version: 1.20.2
@@ -883,8 +883,8 @@ importers:
   apps/workers-builds:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: ^0.3.3
-        version: 0.3.3
+        specifier: ^0.4.0
+        version: 0.4.0
       '@hono/zod-validator':
         specifier: 0.4.3
         version: 0.4.3(hono@4.7.6)(zod@3.24.2)
@@ -938,8 +938,8 @@ importers:
   apps/workers-observability:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: ^0.3.3
-        version: 0.3.3
+        specifier: ^0.4.0
+        version: 0.4.0
       '@fast-csv/format':
         specifier: 5.0.2
         version: 5.0.2
@@ -1078,8 +1078,8 @@ importers:
   packages/mcp-common:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: ^0.3.3
-        version: 0.3.3
+        specifier: ^0.4.0
+        version: 0.4.0
       '@fast-csv/format':
         specifier: 5.0.2
         version: 5.0.2
@@ -1541,8 +1541,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@cloudflare/workers-oauth-provider@0.3.3':
-    resolution: {integrity: sha512-n0PrX+KZNdyXx2x6EFfIZKWj254LtiWZTCLcrOVHO4MeoFcGtYyG0a1fD/H365XGlpsCScOVCAS/Pc4JymqKJQ==}
+  '@cloudflare/workers-oauth-provider@0.4.0':
+    resolution: {integrity: sha512-UtbV8hjC2NloB+Ds6J6v/9HiG8rx8MbdeYGCyFwOACT5vANWzDL6SKo3W5UZymsXiameAgC7jAmtUx4cc+Qpaw==}
 
   '@cloudflare/workers-types@4.20250410.0':
     resolution: {integrity: sha512-Yx9VUi6QpmXtUIhOL+em+V02gue12kmVBVL6RGH5mhFh50M0x9JyOmm6wKwKZUny2uQd+22nuouE2q3z1OrsIQ==}
@@ -6626,7 +6626,7 @@ snapshots:
   '@cloudflare/workerd-windows-64@1.20250507.0':
     optional: true
 
-  '@cloudflare/workers-oauth-provider@0.3.3': {}
+  '@cloudflare/workers-oauth-provider@0.4.0': {}
 
   '@cloudflare/workers-types@4.20250410.0': {}
 


### PR DESCRIPTION
## Summary
- Bumps `@cloudflare/workers-oauth-provider` from `^0.3.2` to `^0.4.0` across all 18 packages
- Adds `resourceMatchOriginOnly: true` migration flag to all 14 apps (TODO: remove after 2026-05-01)
- Adds `refreshTokenTTL: 2592000` (30 days) to all apps so old grants expire
- Includes changesets for every affected package

## Context
v0.4.0 introduces path-aware resource URIs (RFC 9728). The `resourceMatchOriginOnly` flag ensures existing grants with origin-only resources continue to work during the migration period.

## Test plan
- [x] Tested on cloudflare-mcp staging
- [x] Verified existing tokens work with the migration flag
- [x] Verified tokens break without the flag (confirming the flag is needed)
- [ ] CI passes