### PR TITLE
fix(dns-analytics): make dns_report work on Free and Pro plan zones

### DIFF
--- a/.changeset/fix-dns-report-plan-compatibility.md
+++ b/.changeset/fix-dns-report-plan-compatibility.md
@@ -1,0 +1,14 @@
+---
+'dns-analytics': patch
+---
+
+Fix `dns_report` tool failing with 403 on Free and Pro plan zones
+
+The tool hardcoded `responseCached` in the dimensions list, which is gated to Business plan and above. Free and Pro accounts received:
+
+```
+"Response Cached is not available for your plan.
+ Upgrade to the business plan to see DNS analytics by responseCached."
+```
+
+Removing `responseCached` from the default dimensions restores functionality for Free and Pro zones while keeping `responseCode` breakdown available to all plans. Business/Enterprise users who want `responseCached` analytics can query via the `cf-graphql` MCP server's `dnsAnalyticsAdaptiveGroups` dataset.

--- a/apps/dns-analytics/src/tools/dex-analytics.tools.ts
+++ b/apps/dns-analytics/src/tools/dex-analytics.tools.ts
@@ -31,7 +31,7 @@ export function registerAnalyticTools(agent: DNSAnalyticsMCP) {
 				const params: ReportGetParams = {
 					zone_id: zone,
 					metrics: 'responseTimeAvg,queryCount,uncachedCount,staleCount',
-					dimensions: 'responseCode,responseCached',
+					dimensions: 'responseCode',
 					since: start_date,
 				}
 				const result = await client.dns.analytics.reports.get(params)


### PR DESCRIPTION
## Problem

The \`dns_report\` tool in the DNS Analytics MCP server fails with HTTP 403 on Free and Pro plan zones:

\`\`\`
Error fetching DNS report: 403 {"result":null,"success":false,
  "errors":[{"code":1034,
  "message":"Response Cached is not available for your plan. Upgrade to the business plan to see DNS analytics by responseCached."}]}
\`\`\`

## Root cause

[\`apps/dns-analytics/src/tools/dex-analytics.tools.ts:34\`](https://github.com/cloudflare/mcp-server-cloudflare/blob/main/apps/dns-analytics/src/tools/dex-analytics.tools.ts#L34) hardcodes the \`responseCached\` dimension, which the DNS Analytics REST API (\`GET /zones/{zone_id}/dns_analytics/report\`) gates to Business plan and above.

\`\`\`ts
const params: ReportGetParams = {
    zone_id: zone,
    metrics: 'responseTimeAvg,queryCount,uncachedCount,staleCount',
    dimensions: 'responseCode,responseCached',  // responseCached requires Business+
    since: start_date,
}
\`\`\`

Every Free/Pro zone request returns 403 because of this single hardcoded dimension.

## Evidence this is unintended

- The [announcement blog post](https://blog.cloudflare.com/thirteen-new-mcp-servers-from-cloudflare) describes the DNS Analytics server as working across "all domains in your account" with no plan-tier caveat.
- DNS Analytics itself is a feature offered on all Cloudflare plans.
- The tool exposes no parameter to customize dimensions, so Free/Pro users cannot work around the 403.
- No existing issue or PR tracking this (searched for \`responseCached\`, \`dns_report\`, \`1034\`, \`"not available for your plan"\`, \`business plan\` — zero prior reports).
- The API error message is explicit and helpful, suggesting the field was added without testing against a non-Business account.

## Fix

Remove \`responseCached\` from the default dimensions. \`responseCode\` breakdown remains available to all plan tiers.

\`\`\`diff
-       dimensions: 'responseCode,responseCached',
+       dimensions: 'responseCode',
\`\`\`

Business/Enterprise users who want the cached-vs-uncached breakdown can query the \`dnsAnalyticsAdaptiveGroups\` dataset via the \`cf-graphql\` MCP server (\`responseCached\` is an available dimension there on Business+ accounts).

## Reproduction

Tested against \`signflower.co\` (Pro plan). Before this patch: \`dns_report\` returns 403 with code 1034. After this patch: returns expected DNS report payload.

## Changeset

Included \`.changeset/fix-dns-report-plan-compatibility.md\` marking this as a \`patch\` to the \`dns-analytics\` package, per repo conventions.

## Follow-up (not included in this PR)

A richer fix would accept a \`dimensions\` parameter on the tool, letting callers opt into Business-gated fields when they have access. Happy to follow up with that as a separate PR if the maintainers prefer it.