### PR TITLE
fix(auditlogs): add 'api' to actorContexts enum

### DIFF
--- a/apps/auditlogs/src/tools/auditlogs.tools.ts
+++ b/apps/auditlogs/src/tools/auditlogs.tools.ts
@@ -7,7 +7,7 @@ import type { AuditlogMCP } from '../auditlogs.app'
 
 export const actionResults = z.enum(['success', 'failure', ''])
 export const actionTypes = z.enum(['create', 'delete', 'view', 'update', 'login'])
-export const actorContexts = z.enum(['api_key', 'api_token', 'dash', 'oauth', 'origin_ca_key'])
+export const actorContexts = z.enum(['api', 'api_key', 'api_token', 'dash', 'oauth', 'origin_ca_key'])
 export const actorTypes = z.enum(['cloudflare_admin', 'account', 'user', 'system'])
 export const resourceScopes = z.enum(['memberships', 'accounts', 'user', 'zones'])
 export const sortDirections = z.enum(['desc', 'asc'])


### PR DESCRIPTION
## Summary
- Add `'api'` to the `actorContexts` enum in `auditLogs.tools.ts`
- Cloudflare's Audit Log API now returns `actor.context = "api"` for many entries
- Previously, any audit log entry with `actor.context = "api"` caused Zod validation to fail, resulting in the entire response being rejected

## Test plan
- [x] Syntax verified — one-line enum change
- [x] Build errors in project are pre-existing (Cloudflare Workers/Workers-types configuration issues unrelated to this change)

## Fixes
Fixes Issue #352

🤖 Generated with [Claude Code](https://claude.com/claude-code)