### PR TITLE
chore(autorag): deprecate in favor of mcp.cloudflare.com

### DIFF
--- a/.changeset/deprecate-autorag.md
+++ b/.changeset/deprecate-autorag.md
@@ -1,0 +1,9 @@
+---
+"cloudflare-autorag-mcp-server": patch
+---
+
+Deprecate the AutoRAG MCP server. AutoRAG has been superseded by Cloudflare AI Search, which is covered by the unified Cloudflare MCP server at https://mcp.cloudflare.com/mcp (see https://github.com/cloudflare/mcp).
+
+Tools continue to function. The server now exposes a migration guide via the MCP `instructions` field, and the `autorag.mcp.cloudflare.com` entries have been removed from `server.json` so registries stop advertising the deprecated server.
+
+**Action required:** migrate to `https://mcp.cloudflare.com/mcp` at your earliest convenience.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ The following servers are included in this repository:
 | [**Browser rendering server**](/apps/browser-rendering)        | Fetch web pages, convert them to markdown and take screenshots                                  | `https://browser.mcp.cloudflare.com/mcp`       |
 | [**Logpush server**](/apps/logpush)                            | Get quick summaries for Logpush job health                                                      | `https://logs.mcp.cloudflare.com/mcp`          |
 | [**AI Gateway server**](/apps/ai-gateway)                      | Search your logs, get details about the prompts and responses                                   | `https://ai-gateway.mcp.cloudflare.com/mcp`    |
-| [**AutoRAG server**](/apps/autorag)                            | List and search documents on your AutoRAGs                                                      | `https://autorag.mcp.cloudflare.com/mcp`       |
 | [**Audit Logs server**](/apps/auditlogs)                       | Query audit logs and generate reports for review                                                | `https://auditlogs.mcp.cloudflare.com/mcp`     |
 | [**DNS Analytics server**](/apps/dns-analytics)                | Optimize DNS performance and debug issues based on current set up                               | `https://dns-analytics.mcp.cloudflare.com/mcp` |
 | [**Digital Experience Monitoring server**](/apps/dex-analysis) | Get quick insight on critical applications for your organization                                | `https://dex.mcp.cloudflare.com/mcp`           |

--- a/apps/autorag/CONTRIBUTING.md
+++ b/apps/autorag/CONTRIBUTING.md
@@ -1,5 +1,7 @@
 # Setup
 
+> ⚠️ **This server is deprecated.** See [`README.md`](./README.md) for the migration path to [`mcp.cloudflare.com/mcp`](https://mcp.cloudflare.com/mcp). Bug fixes are welcome; new features will generally not be accepted — please direct new work at the unified [`cloudflare/mcp`](https://github.com/cloudflare/mcp) repository instead.
+
 If you'd like to iterate and test your MCP server, you can do so in local development.
 
 ## Local Development

--- a/apps/autorag/README.md
+++ b/apps/autorag/README.md
@@ -1,5 +1,34 @@
 # Cloudflare AutoRAG MCP Server 📡
 
+## ⚠️ Deprecated
+
+**This server is deprecated.** AutoRAG has been superseded by [Cloudflare AI Search](https://developers.cloudflare.com/ai-search/), and the unified Cloudflare MCP server at [`mcp.cloudflare.com/mcp`](https://mcp.cloudflare.com/mcp) already covers AI Search (along with the rest of the Cloudflare API).
+
+All new work should move to the unified server:
+
+```json
+{
+	"mcpServers": {
+		"cloudflare-api": {
+			"url": "https://mcp.cloudflare.com/mcp"
+		}
+	}
+}
+```
+
+That server uses [Code Mode](https://blog.cloudflare.com/code-mode-mcp/) — two generic tools (`search` and `execute`) that give agents access to the full Cloudflare API through code execution. It supports both OAuth (connect to the URL and authorize) and Cloudflare API tokens (send as a bearer token). See [`cloudflare/mcp`](https://github.com/cloudflare/mcp) for details.
+
+### What about my existing AutoRAG instances?
+
+- **Existing AutoRAG instances have been migrated to AI Search.** They remain reachable via both the legacy AutoRAG endpoints and the new AI Search endpoints — the underlying instance is the same, just exposed through both APIs.
+- Because your instances are already available through AI Search, they are accessible through the unified [`mcp.cloudflare.com/mcp`](https://mcp.cloudflare.com/mcp) server (which covers AI Search) without any data migration on your part.
+- The **AutoRAG REST API endpoints are no longer recommended** for new work. Refer to [Migrate from AutoRAG REST API](https://developers.cloudflare.com/ai-search/api/migration/rest-api/) for moving client code to AI Search.
+- This MCP server continues to respond for now, but will be retired.
+
+The tools below still function. Please migrate at your earliest convenience.
+
+---
+
 This is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction) server that supports remote MCP
 connections, with Cloudflare OAuth built-in.
 
@@ -15,8 +44,6 @@ Currently available tools:
 | `search`    | Searches documents in a specified AutoRAG using a query (URL, title, or snippet) |
 | `ai_search` | Performs AI-powered search on documents in a specified AutoRAG                   |
 
-This MCP server is still a work in progress, and we plan to add more tools in the future.
-
 ### Prompt Examples
 
 - `List all AutoRAGs in my account.`
@@ -25,7 +52,9 @@ This MCP server is still a work in progress, and we plan to add more tools in th
 
 ## Access the remote MCP server from any MCP Client
 
-If your MCP client has first class support for remote MCP servers, the client will provide a way to accept the server URL (`https://autorag.mcp.cloudflare.com`) directly within its interface (for example in[Cloudflare AI Playground](https://playground.ai.cloudflare.com/)).
+> The following setup documentation is retained for existing users. New users should follow the migration path to [`mcp.cloudflare.com/mcp`](https://mcp.cloudflare.com/mcp) documented above.
+
+If your MCP client has first class support for remote MCP servers, the client will provide a way to accept the server URL (`https://autorag.mcp.cloudflare.com`) directly within its interface (for example in [Cloudflare AI Playground](https://playground.ai.cloudflare.com/)).
 
 If your client does not yet support remote MCP servers, you will need to set up its respective configuration file using mcp-remote (https://www.npmjs.com/package/mcp-remote) to specify which servers your client can access.
 

--- a/apps/autorag/src/autorag.app.ts
+++ b/apps/autorag/src/autorag.app.ts
@@ -28,6 +28,38 @@ const metrics = new MetricsTracker(env.MCP_METRICS, {
 	version: env.MCP_SERVER_VERSION,
 })
 
+// NOTE: This server is deprecated. AutoRAG has been superseded by Cloudflare AI
+// Search, and the unified Cloudflare MCP server at https://mcp.cloudflare.com/mcp
+// already covers AI Search (see https://github.com/cloudflare/mcp).
+//
+// The deprecation notice is surfaced via the MCP `instructions` field on the
+// initialize response. Humans see it in MCP-client UIs that render
+// `instructions`; it is also documented in README.md and CONTRIBUTING.md.
+export const DEPRECATION_INSTRUCTIONS = `⚠️ DEPRECATED: This AutoRAG MCP server is deprecated.
+
+AutoRAG has been superseded by Cloudflare AI Search. All new work should move
+to the unified Cloudflare MCP server at:
+
+    https://mcp.cloudflare.com/mcp
+
+That server covers the full Cloudflare API — including AI Search, which
+replaces AutoRAG — via Code Mode (two generic tools: \`search\` and \`execute\`).
+It supports both OAuth (connect to the URL and authorize) and Cloudflare API
+tokens (send as a bearer token).
+
+Example MCP client configuration:
+
+    {
+      "mcpServers": {
+        "cloudflare-api": {
+          "url": "https://mcp.cloudflare.com/mcp"
+        }
+      }
+    }
+
+This AutoRAG server continues to respond for now, but will be retired. Please
+migrate at your earliest convenience.`
+
 // Context from the auth process, encrypted & stored in the auth token
 // and provided to the DurableMCP as this.props
 type Props = AuthProps
@@ -62,11 +94,14 @@ export class AutoRAGMCP extends McpAgent<Env, State, Props> {
 				name: this.env.MCP_SERVER_NAME,
 				version: this.env.MCP_SERVER_VERSION,
 			},
+			options: {
+				instructions: DEPRECATION_INSTRUCTIONS,
+			},
 		})
 
 		registerAccountTools(this)
 
-		// Register Cloudflare Log Push tools
+		// Register Cloudflare AutoRAG tools
 		registerAutoRAGTools(this)
 	}
 

--- a/server.json
+++ b/server.json
@@ -110,18 +110,6 @@
 			]
 		},
 		{
-			"url": "https://autorag.mcp.cloudflare.com/mcp",
-			"type": "streamable-http",
-			"headers": [
-				{
-					"name": "Authentication",
-					"description": "Optional Cloudflare API key for authentication if not using OAuth. Can use User or Account owned tokens as a Bearer token.",
-					"is_required": false,
-					"is_secret": true
-				}
-			]
-		},
-		{
 			"url": "https://auditlogs.mcp.cloudflare.com/mcp",
 			"type": "streamable-http",
 			"headers": [
@@ -272,18 +260,6 @@
 		},
 		{
 			"url": "https://ai-gateway.mcp.cloudflare.com/sse",
-			"type": "sse",
-			"headers": [
-				{
-					"name": "Authentication",
-					"description": "Optional Cloudflare API key for authentication if not using OAuth. Can use User or Account owned tokens as a Bearer token.",
-					"is_required": false,
-					"is_secret": true
-				}
-			]
-		},
-		{
-			"url": "https://autorag.mcp.cloudflare.com/sse",
 			"type": "sse",
 			"headers": [
 				{


### PR DESCRIPTION
## Summary

AutoRAG has been superseded by [Cloudflare AI Search](https://developers.cloudflare.com/ai-search/), which is already covered by the unified Cloudflare MCP server at [`mcp.cloudflare.com/mcp`](https://mcp.cloudflare.com/mcp) ([`cloudflare/mcp`](https://github.com/cloudflare/mcp)). Rather than building a new `apps/ai-search` server in this repo, this PR deprecates the existing AutoRAG MCP server and steers users toward the unified server.

Per a prior conversation on the Cloudflare side (Matt), the plan is:

1. Don't add a new AI Search MCP server to this repo — `mcp.cloudflare.com` already handles AI Search.
2. Deprecate `apps/autorag` with a clear migration path.

Existing AutoRAG instances have been migrated to AI Search and remain reachable via both the legacy AutoRAG endpoints and the new AI Search endpoints — the underlying instance is the same, just exposed through both APIs. As a result, existing instances are already accessible through `mcp.cloudflare.com/mcp` without any data migration on the user's part.

Tools continue to function; the AutoRAG Worker is **not** being taken down as part of this PR. The deprecation notice is surfaced via the MCP `instructions` field.

## Changes

- **`apps/autorag/src/autorag.app.ts`** — pass a `DEPRECATION_INSTRUCTIONS` string into `CloudflareMCPServer`'s `options.instructions` so MCP clients that surface server instructions see the full migration guide at initialize time.
- **`apps/autorag/README.md`** — prominent "⚠️ Deprecated" section at the top with the migration snippet for `mcp.cloudflare.com/mcp` and an updated "What about my existing AutoRAG instances?" section explaining the migration. Existing setup docs retained below with a note that they're retained for existing users only.
- **`apps/autorag/CONTRIBUTING.md`** — short deprecation banner at the top so would-be contributors see it before investing in the deprecated server.
- **`README.md`** (root) — annotate the AutoRAG row with _(deprecated)_ and a migration note; add a callout block between the server table and the "Which Cloudflare MCP server should you use?" section.
- **`server.json`** — remove the `autorag.mcp.cloudflare.com` `/mcp` and `/sse` entries. See rationale below.
- **`.changeset/deprecate-autorag.md`** — patch bump for `cloudflare-autorag-mcp-server`.

## Why remove the `server.json` entries?

`server.json` is the machine-readable registry advertisement consumed by MCP registries (the `com.cloudflare.mcp/mcp` entry gets crawled into registries such as `registry.modelcontextprotocol.io`). For a deprecated-but-running server, the right behaviour is:

- Stop advertising to **new** users discovering via registries → remove from `server.json`.
- Keep the URL documented in READMEs for **existing** users so their current configs still make sense and they have a breadcrumb to migration docs → retained as-is.

The server continues to respond; existing configurations are unaffected. Happy to revert this specific file if reviewers disagree — just let me know.

## Messaging

Server `instructions` (shown at initialize):

> ⚠️ DEPRECATED: This AutoRAG MCP server is deprecated. AutoRAG has been superseded by Cloudflare AI Search. All new work should move to the unified Cloudflare MCP server at `https://mcp.cloudflare.com/mcp` … [full migration guide + config snippet]

## Verification

- [x] `pnpm install`
- [x] `pnpm -F cloudflare-autorag-mcp-server check:types`
- [x] `pnpm -F cloudflare-autorag-mcp-server check:lint`
- [x] `pnpm check:turbo` (all 37 tasks pass)
- [x] `pnpm check:format`
- [x] `pnpm check:deps`
