### PR TITLE
fix(auditlogs): add 'api' to actorContexts enum

### DIFF
--- a/apps/auditlogs/src/tools/auditlogs.tools.ts
+++ b/apps/auditlogs/src/tools/auditlogs.tools.ts
@@ -7,7 +7,7 @@ import type { AuditlogMCP } from '../auditlogs.app'
 
 export const actionResults = z.enum(['success', 'failure', ''])
 export const actionTypes = z.enum(['create', 'delete', 'view', 'update', 'login'])
-export const actorContexts = z.enum(['api_key', 'api_token', 'dash', 'oauth', 'origin_ca_key'])
+export const actorContexts = z.enum(['api', 'api_key', 'api_token', 'dash', 'oauth', 'origin_ca_key'])
 export const actorTypes = z.enum(['cloudflare_admin', 'account', 'user', 'system'])
 export const resourceScopes = z.enum(['memberships', 'accounts', 'user', 'zones'])
 export const sortDirections = z.enum(['desc', 'asc'])


### PR DESCRIPTION
## Summary

The Cloudflare Audit Log API now returns `actor.context = "api"` for generic API-driven changes, distinct from `api_key` / `api_token`. The existing `actorContexts` enum did not include this new value, causing Zod validation to fail for all audit log entries with this context.

## Problem

Every audit log entry with `actor.context = "api"` fails validation:
```
Invalid enum value. Expected 'api_key' | 'api_token' | 'dash' | 'oauth' | 'origin_ca_key', received 'api'
```

This results in the tool returning no data even though the upstream API call succeeds.

## Changes

Added `'api'` to the `actorContexts` enum in `apps/auditlogs/src/tools/auditlogs.tools.ts`.

## Fixes

Fixes #352