### PR TITLE
fix(mcp-common): support workflow eventType in observability schema

### DIFF
--- a/.changeset/fix-workers-observability-workflow-event-type.md
+++ b/.changeset/fix-workers-observability-workflow-event-type.md
@@ -1,0 +1,9 @@
+---
+'@repo/mcp-common': patch
+---
+
+fix(mcp-common): allow `workflow` `eventType` and treat `wallTimeMs`/`cpuTimeMs` as optional in observability response schema
+
+The Workers Observability response schema (`zCloudflareMiniEvent` / `zCloudflareEvent` in `packages/mcp-common/src/types/workers-logs.types.ts`) was missing `'workflow'` from the `eventType` enum, and `zCloudflareEvent` re-declared `cpuTimeMs` / `wallTimeMs` as required. Cloudflare Workflow events emit `eventType: "workflow"` and do not always include the time fields, so the workers-observability MCP's `query_worker_observability` tool would reject any response containing a workflow event with a Zod validation error and return no data to the caller.
+
+This left the MCP unable to surface logs from any Worker built on Cloudflare Workflows. Adding `'workflow'` to the enum and making the time fields optional unblocks those queries.

--- a/packages/mcp-common/src/types/workers-logs.types.ts
+++ b/packages/mcp-common/src/types/workers-logs.types.ts
@@ -259,6 +259,7 @@ export const zCloudflareMiniEvent = z.object({
 		'tail',
 		'rpc',
 		'websocket',
+		'workflow',
 		'unknown',
 	]),
 	entrypoint: z.string().optional(),
@@ -287,8 +288,8 @@ export const zCloudflareEvent = zCloudflareMiniEvent.extend({
 		)
 		.optional(),
 	dispatchNamespace: z.string().optional(),
-	wallTimeMs: z.number(),
-	cpuTimeMs: z.number(),
+	wallTimeMs: z.number().optional(),
+	cpuTimeMs: z.number().optional(),
 })
 
 const zSourceSchema = z.object({


### PR DESCRIPTION
## `workers-observability` MCP cannot return events from Cloudflare Workflows

### Reproducing

Any `query_worker_observability` call whose result set contains at least one event with `$workers.eventType == "workflow"` fails with a `ZodError: Invalid enum value. Expected 'fetch' | 'scheduled' | ... received 'workflow'` and returns no data to the MCP client.

Minimal repro (against any account that has a Worker built on Cloudflare Workflows):

```json
{
  "queryId": "observability-overview",
  "view": "events",
  "limit": 5,
  "parameters": {
    "datasets": [],
    "filters": [
      {"key": "$workers.eventType", "operation": "eq", "type": "string", "value": "workflow"}
    ],
    "filterCombination": "and"
  },
  "timeframe": {"from": "2026-04-28T08:48:00Z", "to": "2026-04-28T10:48:00Z"}
}
```

The equivalent query against the dashboard's internal `workers/observability/telemetry/query` endpoint succeeds and returns the workflow events normally — the underlying API is fine; only the MCP's response decoder rejects them.

### Root cause

[`packages/mcp-common/src/types/workers-logs.types.ts`](https://github.com/cloudflare/mcp-server-cloudflare/blob/main/packages/mcp-common/src/types/workers-logs.types.ts):

1. Lines 252–263: `eventType` enum is missing `'workflow'`.
2. Lines 290–291: `zCloudflareEvent` re-declares `cpuTimeMs` / `wallTimeMs` as required (`z.number()`), overriding the optional declarations from `zCloudflareMiniEvent`. Workflow events don't carry these fields, so the schema rejects them.

### Fix

```diff
 eventType: z.enum([
   'fetch',
   'scheduled',
   'alarm',
   'cron',
   'queue',
   'email',
   'tail',
   'rpc',
   'websocket',
+  'workflow',
   'unknown',
 ]),
```

```diff
 export const zCloudflareEvent = zCloudflareMiniEvent.extend({
   // ...
-  wallTimeMs: z.number(),
-  cpuTimeMs: z.number(),
+  wallTimeMs: z.number().optional(),
+  cpuTimeMs: z.number().optional(),
 })
```

A more defensive future-proofing would be to use `.catchall('unknown')` on the enum (or fall back to `z.string()`) so that further trigger types added by the platform don't silently break the MCP again — happy to amend if you'd prefer that approach.

### Real-world impact

Today (2026-04-29) we needed to investigate a customer-facing bug in our Workflow-based ingestion worker. The MCP was unusable for this — every relevant log line was emitted from a Workflow step, so every needle/filter query returned a Zod validation error. We fell back to scripting against the dashboard's internal API directly. The MCP's primitives (needle/filters/time range) would have been a strictly better DX *if* it could decode workflow events.

### Changeset

Included as `@repo/mcp-common: patch`.
