### PR TITLE
fix(mcp-common): flatten ToolAnnotations to spec-compliant wire shape

### DIFF
--- a/.changeset/flatten-tool-annotations.md
+++ b/.changeset/flatten-tool-annotations.md
@@ -1,0 +1,14 @@
+---
+'@repo/mcp-common': patch
+---
+
+fix(mcp-common): flatten ToolAnnotations objects passed to `agent.server.tool`
+
+The 4th argument to `McpServer.tool()` is `ToolAnnotations` itself; nesting
+`annotations: { readOnlyHint: true }` inside that argument produces a
+double-nested `tool.annotations.annotations.readOnlyHint` on the wire,
+which spec-compliant clients cannot read.
+
+This flattens all 29 call sites across `packages/mcp-common/src/tools/*.tools.ts`
+so hint flags appear at `tool.annotations.readOnlyHint` /
+`tool.annotations.destructiveHint` as the spec requires.

--- a/packages/mcp-common/src/tools/account.tools.ts
+++ b/packages/mcp-common/src/tools/account.tools.ts
@@ -14,9 +14,7 @@ export function registerAccountTools(agent: CloudflareMcpAgent) {
 		{},
 		{
 			title: 'List accounts',
-			annotations: {
-				readOnlyHint: true,
-			},
+			readOnlyHint: true,
 		},
 		async () => {
 			try {
@@ -82,10 +80,8 @@ export function registerAccountTools(agent: CloudflareMcpAgent) {
 			},
 			{
 				title: 'Set active account',
-				annotations: {
-					readOnlyHint: false,
-					destructiveHint: false,
-				},
+				readOnlyHint: false,
+				destructiveHint: false,
 			},
 			async (params) => {
 				try {

--- a/packages/mcp-common/src/tools/d1.tools.ts
+++ b/packages/mcp-common/src/tools/d1.tools.ts
@@ -23,9 +23,7 @@ export function registerD1Tools(agent: CloudflareMcpAgent) {
 		},
 		{
 			title: 'List D1 databases',
-			annotations: {
-				readOnlyHint: true,
-			},
+			readOnlyHint: true,
 		},
 		async ({ name, page, per_page }) => {
 			const account_id = await agent.getActiveAccountId()
@@ -75,10 +73,8 @@ export function registerD1Tools(agent: CloudflareMcpAgent) {
 		},
 		{
 			title: 'Create D1 database',
-			annotations: {
-				readOnlyHint: false,
-				destructiveHint: false,
-			},
+			readOnlyHint: false,
+			destructiveHint: false,
 		},
 		async ({ name, primary_location_hint }) => {
 			const account_id = await agent.getActiveAccountId()
@@ -121,10 +117,8 @@ export function registerD1Tools(agent: CloudflareMcpAgent) {
 		{ database_id: z.string() },
 		{
 			title: 'Delete D1 database',
-			annotations: {
-				readOnlyHint: false,
-				destructiveHint: true,
-			},
+			readOnlyHint: false,
+			destructiveHint: true,
 		},
 		async ({ database_id }) => {
 			const account_id = await agent.getActiveAccountId()
@@ -164,9 +158,7 @@ export function registerD1Tools(agent: CloudflareMcpAgent) {
 		{ database_id: z.string() },
 		{
 			title: 'Get D1 database',
-			annotations: {
-				readOnlyHint: true,
-			},
+			readOnlyHint: true,
 		},
 		async ({ database_id }) => {
 			const account_id = await agent.getActiveAccountId()
@@ -211,10 +203,8 @@ export function registerD1Tools(agent: CloudflareMcpAgent) {
 		},
 		{
 			title: 'Query D1 database',
-			annotations: {
-				readOnlyHint: false,
-				destructiveHint: false,
-			},
+			readOnlyHint: false,
+			destructiveHint: false,
 		},
 		async ({ database_id, sql, params }) => {
 			const account_id = await agent.getActiveAccountId()

--- a/packages/mcp-common/src/tools/docs-ai-search.tools.ts
+++ b/packages/mcp-common/src/tools/docs-ai-search.tools.ts
@@ -56,9 +56,7 @@ export function registerDocsTools(server: McpServer, env: RequiredEnv) {
 		},
 		{
 			title: 'Search Cloudflare docs',
-			annotations: {
-				readOnlyHint: true,
-			},
+			readOnlyHint: true,
 		},
 		async ({ query }) => {
 			const results = await queryAiSearch(env.AI, query)
@@ -87,9 +85,7 @@ ${result.text}
 		{},
 		{
 			title: 'Get Pages migration guide',
-			annotations: {
-				readOnlyHint: true,
-			},
+			readOnlyHint: true,
 		},
 		async () => {
 			const res = await fetch(

--- a/packages/mcp-common/src/tools/docs-vectorize.tools.ts
+++ b/packages/mcp-common/src/tools/docs-vectorize.tools.ts
@@ -32,9 +32,7 @@ export function registerDocsTools(server: McpServer, env: RequiredEnv) {
 		},
 		{
 			title: 'Search Cloudflare docs',
-			annotations: {
-				readOnlyHint: true,
-			},
+			readOnlyHint: true,
 		},
 		async ({ query }) => {
 			const results = await queryVectorize(env.AI, env.VECTORIZE, query, TOP_K)
@@ -63,9 +61,7 @@ ${result.text}
 		{},
 		{
 			title: 'Get Pages migration guide',
-			annotations: {
-				readOnlyHint: true,
-			},
+			readOnlyHint: true,
 		},
 		async () => {
 			const res = await fetch(

--- a/packages/mcp-common/src/tools/hyperdrive.tools.ts
+++ b/packages/mcp-common/src/tools/hyperdrive.tools.ts
@@ -46,9 +46,7 @@ export function registerHyperdriveTools(agent: CloudflareMcpAgent) {
 		},
 		{
 			title: 'List Hyperdrive configs',
-			annotations: {
-				readOnlyHint: true,
-			},
+			readOnlyHint: true,
 		},
 		async ({ page, per_page, order, direction }) => {
 			const account_id = await agent.getActiveAccountId()
@@ -174,10 +172,8 @@ export function registerHyperdriveTools(agent: CloudflareMcpAgent) {
 		},
 		{
 			title: 'Delete Hyperdrive config',
-			annotations: {
-				readOnlyHint: false,
-				destructiveHint: true,
-			},
+			readOnlyHint: false,
+			destructiveHint: true,
 		},
 		async ({ hyperdrive_id }) => {
 			const account_id = await agent.getActiveAccountId()
@@ -220,9 +216,7 @@ export function registerHyperdriveTools(agent: CloudflareMcpAgent) {
 		},
 		{
 			title: 'Get Hyperdrive config',
-			annotations: {
-				readOnlyHint: true,
-			},
+			readOnlyHint: true,
 		},
 		async ({ hyperdrive_id }) => {
 			const account_id = await agent.getActiveAccountId()
@@ -277,10 +271,8 @@ export function registerHyperdriveTools(agent: CloudflareMcpAgent) {
 		},
 		{
 			title: 'Edit Hyperdrive config',
-			annotations: {
-				readOnlyHint: false,
-				destructiveHint: false,
-			},
+			readOnlyHint: false,
+			destructiveHint: false,
 		},
 		async ({
 			hyperdrive_id,

--- a/packages/mcp-common/src/tools/kv_namespace.tools.ts
+++ b/packages/mcp-common/src/tools/kv_namespace.tools.ts
@@ -32,9 +32,7 @@ export function registerKVTools(agent: CloudflareMcpAgent) {
 		{ params: KvNamespacesListParamsSchema.optional() },
 		{
 			title: 'List KV namespaces',
-			annotations: {
-				readOnlyHint: true,
-			},
+			readOnlyHint: true,
 		},
 		async ({ params }) => {
 			const account_id = await agent.getActiveAccountId()
@@ -90,10 +88,8 @@ export function registerKVTools(agent: CloudflareMcpAgent) {
 		},
 		{
 			title: 'Create KV namespace',
-			annotations: {
-				readOnlyHint: false,
-				destructiveHint: false,
-			},
+			readOnlyHint: false,
+			destructiveHint: false,
 		},
 		async ({ title }) => {
 			const account_id = await agent.getActiveAccountId()
@@ -136,10 +132,8 @@ export function registerKVTools(agent: CloudflareMcpAgent) {
 		},
 		{
 			title: 'Delete KV namespace',
-			annotations: {
-				readOnlyHint: false,
-				destructiveHint: true,
-			},
+			readOnlyHint: false,
+			destructiveHint: true,
 		},
 		async ({ namespace_id }) => {
 			const account_id = await agent.getActiveAccountId()
@@ -189,9 +183,7 @@ export function registerKVTools(agent: CloudflareMcpAgent) {
 		},
 		{
 			title: 'Get KV namespace',
-			annotations: {
-				readOnlyHint: true,
-			},
+			readOnlyHint: true,
 		},
 		async ({ namespace_id }) => {
 			const account_id = await agent.getActiveAccountId()
@@ -235,10 +227,8 @@ export function registerKVTools(agent: CloudflareMcpAgent) {
 		},
 		{
 			title: 'Update KV namespace',
-			annotations: {
-				readOnlyHint: false,
-				destructiveHint: false,
-			},
+			readOnlyHint: false,
+			destructiveHint: false,
 		},
 		async ({ namespace_id, title }) => {
 			const account_id = await agent.getActiveAccountId()

--- a/packages/mcp-common/src/tools/r2_bucket.tools.ts
+++ b/packages/mcp-common/src/tools/r2_bucket.tools.ts
@@ -24,9 +24,7 @@ export function registerR2BucketTools(agent: CloudflareMcpAgent) {
 		},
 		{
 			title: 'List R2 buckets',
-			annotations: {
-				readOnlyHint: true,
-			},
+			readOnlyHint: true,
 		},
 		async ({ cursor, direction, name_contains, per_page, start_after }) => {
 			const account_id = await agent.getActiveAccountId()
@@ -75,10 +73,8 @@ export function registerR2BucketTools(agent: CloudflareMcpAgent) {
 		{ name: BucketNameSchema },
 		{
 			title: 'Create R2 bucket',
-			annotations: {
-				readOnlyHint: false,
-				destructiveHint: false,
-			},
+			readOnlyHint: false,
+			destructiveHint: false,
 		},
 		async ({ name }) => {
 			const account_id = await agent.getActiveAccountId()
@@ -119,9 +115,7 @@ export function registerR2BucketTools(agent: CloudflareMcpAgent) {
 		{ name: BucketNameSchema },
 		{
 			title: 'Get R2 bucket',
-			annotations: {
-				readOnlyHint: true,
-			},
+			readOnlyHint: true,
 		},
 		async ({ name }) => {
 			const account_id = await agent.getActiveAccountId()
@@ -159,10 +153,8 @@ export function registerR2BucketTools(agent: CloudflareMcpAgent) {
 		{ name: BucketNameSchema },
 		{
 			title: 'Delete R2 bucket',
-			annotations: {
-				readOnlyHint: false,
-				destructiveHint: true,
-			},
+			readOnlyHint: false,
+			destructiveHint: true,
 		},
 		async ({ name }) => {
 			const account_id = await agent.getActiveAccountId()

--- a/packages/mcp-common/src/tools/worker.tools.ts
+++ b/packages/mcp-common/src/tools/worker.tools.ts
@@ -32,10 +32,8 @@ export function registerWorkersTools(agent: CloudflareMcpAgent) {
 		{},
 		{
 			title: 'List Workers',
-			annotations: {
-				readOnlyHint: true,
-				destructiveHint: false,
-			},
+			readOnlyHint: true,
+			destructiveHint: false,
 		},
 		async () => {
 			const accountId = await agent.getActiveAccountId()
@@ -106,10 +104,8 @@ export function registerWorkersTools(agent: CloudflareMcpAgent) {
 		},
 		{
 			title: 'Get Worker details',
-			annotations: {
-				readOnlyHint: true,
-				destructiveHint: false,
-			},
+			readOnlyHint: true,
+			destructiveHint: false,
 		},
 		async (params) => {
 			const accountId = await agent.getActiveAccountId()
@@ -178,10 +174,8 @@ export function registerWorkersTools(agent: CloudflareMcpAgent) {
 		{ scriptName: workerNameParam },
 		{
 			title: 'Get Worker code',
-			annotations: {
-				readOnlyHint: true,
-				destructiveHint: false,
-			},
+			readOnlyHint: true,
+			destructiveHint: false,
 		},
 		async (params) => {
 			const accountId = await agent.getActiveAccountId()

--- a/packages/mcp-common/src/tools/zone.tools.ts
+++ b/packages/mcp-common/src/tools/zone.tools.ts
@@ -31,10 +31,8 @@ export function registerZoneTools(agent: CloudflareMcpAgent) {
 		},
 		{
 			title: 'List zones',
-			annotations: {
-				readOnlyHint: true,
-				destructiveHint: false,
-			},
+			readOnlyHint: true,
+			destructiveHint: false,
 		},
 		async (params) => {
 			const accountId = await agent.getActiveAccountId()
@@ -95,10 +93,8 @@ export function registerZoneTools(agent: CloudflareMcpAgent) {
 		},
 		{
 			title: 'Get zone details',
-			annotations: {
-				readOnlyHint: true,
-				destructiveHint: false,
-			},
+			readOnlyHint: true,
+			destructiveHint: false,
 		},
 		async (params) => {
 			const accountId = await agent.getActiveAccountId()


### PR DESCRIPTION
## Summary

`tools/list` on every hosted Cloudflare MCP server (`bindings`, `observability`, `radar`, `auditlogs`, `dns-analytics`, `logpush`, …) returns `readOnlyHint` and `destructiveHint` at the wrong path, so spec-compliant clients can't read them.

## What clients see today

```json
{
  "name": "accounts_list",
  "annotations": {
    "title": "List accounts",
    "annotations": {
      "readOnlyHint": true
    }
  }
}
```

A client following the MCP 2025-06-18 spec reads `tool.annotations.readOnlyHint` and gets `undefined` for every tool. Same for `destructiveHint`. Also reproducible against `bindings.mcp.cloudflare.com/mcp` and `observability.mcp.cloudflare.com/mcp`.

## What the spec requires

Per the [MCP 2025-06-18 schema](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/schema/2025-06-18/schema.ts) (`ToolAnnotations`), the hint flags are siblings of `title` directly on `tool.annotations`:

```json
{
  "name": "accounts_list",
  "annotations": {
    "title": "List accounts",
    "readOnlyHint": true
  }
}
```

Reference: [Server Tools — Tool annotations](https://modelcontextprotocol.io/specification/2025-06-18/server/tools).

## Root cause

The 4th argument to `McpServer.tool(name, description, schema, annotations, handler)` is the `ToolAnnotations` object itself. The repo nests an inner `annotations: { ... }` *inside* that argument, so the SDK serializes the whole thing under `tool.annotations` and the hint flags end up one level too deep.

Introduced by #218.

```ts
// before — produces tool.annotations.annotations.readOnlyHint on the wire
{
  title: 'List accounts',
  annotations: {
    readOnlyHint: true,
  },
}

// after — produces tool.annotations.readOnlyHint as the spec requires
{
  title: 'List accounts',
  readOnlyHint: true,
}
```

## Change

Flattens all 29 call sites in `packages/mcp-common/src/tools/*.tools.ts`. Mechanical: drop the inner `annotations: { ... }` wrapper, lift the hint flag(s) up one level. No semantic change at the call sites — only the wire format changes.

## Verification

- `pnpm -r run test` — all 91 tests in `@repo/mcp-common` pass.
- `tsc --noEmit` — clean.
- End-to-end check against `@modelcontextprotocol/sdk@1.20.2` over `InMemoryTransport`: a client calling `listTools()` on a server registered with the new shape reads `tool.annotations.readOnlyHint === true`. Re-registering with the old shape (control) reproduces the exact double-nest seen on the live hosted servers.

## Impact

- Clients that auto-approve based on `readOnlyHint` (Claude.ai, Cursor, custom subagents) can finally tell read-only tools from destructive ones.
- Surfaces destructive tools (`kv_namespace_delete`, `r2_bucket_delete`, `d1_database_delete`, `hyperdrive_config_delete`) correctly so clients can warn users.
- Realises the intent of #218 on the wire.

## Notes for reviewers

- Changeset added: `.changeset/flatten-tool-annotations.md` (`@repo/mcp-common: patch`).
- No app-level changes; the apps register tools through `mcp-common`.
- Title is preserved at `tool.annotations.title` (unchanged path).