### PR TITLE
fix(auditlogs): accept API actor context

### DIFF
--- a/apps/auditlogs/src/tools/auditlogs.tools.test.ts
+++ b/apps/auditlogs/src/tools/auditlogs.tools.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+
+import { auditLogsResponseSchema } from './auditlogs.tools'
+
+describe('auditLogsResponseSchema', () => {
+	it('accepts audit log entries created by API actors', () => {
+		expect(() =>
+			auditLogsResponseSchema.parse({
+				success: true,
+				result: [
+					{
+						id: 'audit-log-id',
+						account: {
+							id: 'account-id',
+							name: 'Account',
+						},
+						action: {
+							result: 'success',
+							time: '2026-05-06T00:00:00.000Z',
+							type: 'view',
+						},
+						actor: {
+							context: 'api',
+							type: 'user',
+						},
+					},
+				],
+				result_info: {
+					count: 1,
+				},
+			})
+		).not.toThrow()
+	})
+})

--- a/apps/auditlogs/src/tools/auditlogs.tools.ts
+++ b/apps/auditlogs/src/tools/auditlogs.tools.ts
@@ -7,7 +7,7 @@ import type { AuditlogMCP } from '../auditlogs.app'
 
 export const actionResults = z.enum(['success', 'failure', ''])
 export const actionTypes = z.enum(['create', 'delete', 'view', 'update', 'login'])
-export const actorContexts = z.enum(['api_key', 'api_token', 'dash', 'oauth', 'origin_ca_key'])
+export const actorContexts = z.enum(['api', 'api_key', 'api_token', 'dash', 'oauth', 'origin_ca_key'])
 export const actorTypes = z.enum(['cloudflare_admin', 'account', 'user', 'system'])
 export const resourceScopes = z.enum(['memberships', 'accounts', 'user', 'zones'])
 export const sortDirections = z.enum(['desc', 'asc'])


### PR DESCRIPTION
## Summary
- Adds `api` as an accepted audit log actor context
- Adds a regression test for parsing audit log responses from API actors

Fixes #352.

## Verification
- pnpm --filter auditlogs check:types
- pnpm --filter auditlogs test src/tools/auditlogs.tools.test.ts