### PR TITLE
docs: document MCP server permissions

### DIFF
--- a/apps/ai-gateway/README.md
+++ b/apps/ai-gateway/README.md
@@ -28,6 +28,17 @@ This MCP server is still a work in progress, and we plan to add more tools in th
 - `Show logs for gateway 'gateway-001' between January 1, 2023, and January 31, 2023.`
 - `Fetch the latest errors from gateway-001 and debug what might have happened wrongly`
 
+## Required Cloudflare permissions
+
+When using Cloudflare OAuth, this server requests the following scopes:
+
+| OAuth scope      | API token permission                    |
+| ---------------- | --------------------------------------- |
+| `user:read`      | User Details Read                       |
+| `offline_access` | OAuth only; not an API token permission |
+| `account:read`   | Account Settings Read                   |
+| `aig:read`       | AI Gateway Read                         |
+
 ## Access the remote MCP server from any MCP Client
 
 If your MCP client has first class support for remote MCP servers, the client will provide a way to accept the server URL (`https://ai-gateway.mcp.cloudflare.com`) directly within its interface (for example in[Cloudflare AI Playground](https://playground.ai.cloudflare.com/)).

--- a/apps/auditlogs/README.md
+++ b/apps/auditlogs/README.md
@@ -18,6 +18,17 @@ Currently available tools:
 - `Were there any suspicious changes made to my Cloudflare account yesterday around lunch time?`
 - `When was the last activity that updated a DNS record?`
 
+## Required Cloudflare permissions
+
+When using Cloudflare OAuth, this server requests the following scopes:
+
+| OAuth scope      | API token permission                         |
+| ---------------- | -------------------------------------------- |
+| `user:read`      | User Details Read                            |
+| `offline_access` | OAuth only; not an API token permission      |
+| `account:read`   | Account Settings Read                        |
+| `auditlogs:read` | Account Settings Read for account audit logs |
+
 ## Access the remote MCP server from any MCP Client
 
 If your MCP client has first class support for remote MCP servers, the client will provide a way to accept the server URL (`https://auditlogs.mcp.cloudflare.com/mcp`) directly within its interface (for example in [Cloudflare AI Playground](https://playground.ai.cloudflare.com/)).

--- a/apps/autorag/README.md
+++ b/apps/autorag/README.md
@@ -50,6 +50,17 @@ Currently available tools:
 - `Search for documents in AutoRAG with ID 'rag123' using the query 'cloudflare security'.`
 - `Perform an AI search in AutoRAG with ID 'rag456' for 'best practices for vector stores'.`
 
+## Required Cloudflare permissions
+
+When using Cloudflare OAuth, this server requests the following scopes:
+
+| OAuth scope      | API token permission                    |
+| ---------------- | --------------------------------------- |
+| `user:read`      | User Details Read                       |
+| `offline_access` | OAuth only; not an API token permission |
+| `account:read`   | Account Settings Read                   |
+| `rag:write`      | Auto Rag Write                          |
+
 ## Access the remote MCP server from any MCP Client
 
 > The following setup documentation is retained for existing users. New users should follow the migration path to [`mcp.cloudflare.com/mcp`](https://mcp.cloudflare.com/mcp) documented above.

--- a/apps/browser-rendering/README.md
+++ b/apps/browser-rendering/README.md
@@ -26,6 +26,17 @@ This MCP server is still a work in progress, and we plan to add more tools in th
 - `Convert https://example.com to Markdown.`
 - `Take a screenshot of https://example.com.`
 
+## Required Cloudflare permissions
+
+When using Cloudflare OAuth, this server requests the following scopes:
+
+| OAuth scope      | API token permission                    |
+| ---------------- | --------------------------------------- |
+| `user:read`      | User Details Read                       |
+| `offline_access` | OAuth only; not an API token permission |
+| `account:read`   | Account Settings Read                   |
+| `browser:write`  | Browser Rendering Write                 |
+
 ## Access the remote MCP server from any MCP Client
 
 If your MCP client has first class support for remote MCP servers, the client will provide a way to accept the server URL (`https://browser.mcp.cloudflare.com`) directly within its interface (for example in[Cloudflare AI Playground](https://playground.ai.cloudflare.com/)).

--- a/apps/cloudflare-one-casb/README.md
+++ b/apps/cloudflare-one-casb/README.md
@@ -4,6 +4,17 @@ This is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/introdu
 
 You should use this as a template to build an MCP server for Cloudflare, provided by Cloudflare at `server-name.mcp.cloudflare.com`. It has a basic set of tools `apps/template-start-here/src/tools/logpush.tools.ts` — you can modify these to do what you need
 
+## Required Cloudflare permissions
+
+When using Cloudflare OAuth, this server requests the following scopes:
+
+| OAuth scope      | API token permission                     |
+| ---------------- | ---------------------------------------- |
+| `user:read`      | User Details Read                        |
+| `offline_access` | OAuth only; not an API token permission  |
+| `account:read`   | Account Settings Read                    |
+| `teams:read`     | Zero Trust Read and Cloudflare CASB Read |
+
 ## Getting Started
 
 - Set secrets via Wrangler

--- a/apps/dex-analysis/README.md
+++ b/apps/dex-analysis/README.md
@@ -43,6 +43,17 @@ This MCP server is still a work in progress, and we plan to add more tools in th
 - `Which Cloudflare colo is most used by my users in the EU running DEX application tests?`
 - `Look at the latest WARP diag for user@cloudflare.com and tell me if you see anything notable in dns logs`
 
+## Required Cloudflare permissions
+
+When using Cloudflare OAuth, this server requests the following scopes:
+
+| OAuth scope      | API token permission                    |
+| ---------------- | --------------------------------------- |
+| `user:read`      | User Details Read                       |
+| `offline_access` | OAuth only; not an API token permission |
+| `account:read`   | Account Settings Read                   |
+| `dex:write`      | Cloudflare DEX Edit                     |
+
 ## Access the remote MCP server from any MCP Client
 
 If your MCP client has first class support for remote MCP servers, the client will provide a way to accept the server URL (`https://dex.mcp.cloudflare.com`) directly within its interface (for example in [Cloudflare AI Playground](https://playground.ai.cloudflare.com/)).

--- a/apps/dns-analytics/README.md
+++ b/apps/dns-analytics/README.md
@@ -28,6 +28,19 @@ This MCP server is still a work in progress, and we plan to add more tools in th
 - `Read Cloudflare's documentation on managing DNS records and tell me how to optimize my DNS settings.`
 - `Show me DNS Report for https://example.com in the last X days.`
 
+## Required Cloudflare permissions
+
+When using Cloudflare OAuth, this server requests the following scopes:
+
+| OAuth scope          | API token permission                    |
+| -------------------- | --------------------------------------- |
+| `user:read`          | User Details Read                       |
+| `offline_access`     | OAuth only; not an API token permission |
+| `account:read`       | Account Settings Read                   |
+| `zone:read`          | Zone Read                               |
+| `dns_settings:read`  | DNS Read                                |
+| `dns_analytics:read` | Analytics Read                          |
+
 ## Access the remote MCP server from any MCP Client
 
 If your MCP client has first class support for remote MCP servers, the client will provide a way to accept the server URL (`https://dns-analytics.mcp.cloudflare.com`) directly within its interface (for example in [Cloudflare AI Playground](https://playground.ai.cloudflare.com/)).

--- a/apps/graphql/README.md
+++ b/apps/graphql/README.md
@@ -23,6 +23,17 @@ Currently available tools:
 - `Can you generate a link to the Cloudflare GraphQL API Explorer with a pre-populated query and variables?`
 - `I need to monitor HTTP requests and responses for a specific domain. Can you help me with that using the Cloudflare GraphQL API?`
 
+## Required Cloudflare permissions
+
+When using Cloudflare OAuth, this server requests the following scopes:
+
+| OAuth scope      | API token permission                    |
+| ---------------- | --------------------------------------- |
+| `user:read`      | User Details Read                       |
+| `offline_access` | OAuth only; not an API token permission |
+| `account:read`   | Account Settings Read                   |
+| `zone:read`      | Zone Read                               |
+
 ## Access the remote MCP server from Claude Desktop
 
 If your MCP client has first class support for remote MCP servers, the client will provide a way to accept the server URL (`https://graphql.mcp.cloudflare.com/mcp`) directly within its interface (for example in [Cloudflare AI Playground](https://playground.ai.cloudflare.com/)).

--- a/apps/logpush/README.md
+++ b/apps/logpush/README.md
@@ -21,6 +21,17 @@ This MCP server is still a work in progress, and we plan to add more tools in th
 - `Do any of my Logpush jobs in my <insert name> account have errors?`
 - `Can you list all the enabled job failures from today?`
 
+## Required Cloudflare permissions
+
+When using Cloudflare OAuth, this server requests the following scopes:
+
+| OAuth scope      | API token permission                    |
+| ---------------- | --------------------------------------- |
+| `user:read`      | User Details Read                       |
+| `offline_access` | OAuth only; not an API token permission |
+| `account:read`   | Account Settings Read                   |
+| `logpush:write`  | Logs Edit                               |
+
 ## Access the remote MCP server from any MCP Client
 
 If your MCP client has first class support for remote MCP servers, the client will provide a way to accept the server URL (`https://logs.mcp.cloudflare.com`) directly within its interface (for example in [Cloudflare AI Playground](https://playground.ai.cloudflare.com/)).

--- a/apps/radar/README.md
+++ b/apps/radar/README.md
@@ -178,6 +178,18 @@ Currently available tools:
 - `What are the details of IP address 8.8.8.8?`
 - `Give me full information about IP 1.1.1.1 including ASN details.`
 
+## Required Cloudflare permissions
+
+When using Cloudflare OAuth, this server requests the following scopes:
+
+| OAuth scope         | API token permission                    |
+| ------------------- | --------------------------------------- |
+| `user:read`         | User Details Read                       |
+| `offline_access`    | OAuth only; not an API token permission |
+| `account:read`      | Account Settings Read                   |
+| `radar:read`        | User Details Read                       |
+| `url_scanner:write` | URL Scanner Edit                        |
+
 ## Access the remote MCP server from any MCP Client
 
 If your MCP client has first class support for remote MCP servers, the client will provide a way to accept the server URL (`https://radar.mcp.cloudflare.com`) directly within its interface (for example in [Cloudflare AI Playground](https://playground.ai.cloudflare.com/)).

--- a/apps/sandbox-container/README.md
+++ b/apps/sandbox-container/README.md
@@ -24,6 +24,16 @@ This MCP server is still a work in progress, and we plan to add more tools in th
 - `Clone and explore this github repo: [repo link]. Setup and run the tests in your development environment`
 - `Analyze this data using Python`
 
+## Required Cloudflare permissions
+
+When using Cloudflare OAuth, this server requests the following scopes:
+
+| OAuth scope      | API token permission                    |
+| ---------------- | --------------------------------------- |
+| `user:read`      | User Details Read                       |
+| `offline_access` | OAuth only; not an API token permission |
+| `account:read`   | Account Settings Read                   |
+
 ## Access the remote MCP server from any MCP Client
 
 If your MCP client has first class support for remote MCP servers, the client will provide a way to accept the server URL (`https://containers.mcp.cloudflare.com`) directly within its interface (for example in [Cloudflare AI Playground](https://playground.ai.cloudflare.com/)).

--- a/apps/workers-bindings/README.md
+++ b/apps/workers-bindings/README.md
@@ -63,6 +63,18 @@ This MCP server is still a work in progress, and we plan to add more tools in th
 - `Update the cache settings for Hyperdrive config 'YOUR_HYPERDRIVE_ID'.` (Replace YOUR_HYPERDRIVE_ID)
 - `Delete the Hyperdrive config 'OLD_HYPERDRIVE_ID'.` (Replace OLD_HYPERDRIVE_ID)
 
+## Required Cloudflare permissions
+
+When using Cloudflare OAuth, this server requests the following scopes:
+
+| OAuth scope      | API token permission                    |
+| ---------------- | --------------------------------------- |
+| `user:read`      | User Details Read                       |
+| `offline_access` | OAuth only; not an API token permission |
+| `account:read`   | Account Settings Read                   |
+| `workers:write`  | Workers Scripts Edit                    |
+| `d1:write`       | D1 Edit                                 |
+
 ## Access the remote MCP server from any MCP Client
 
 If your MCP client has first class support for remote MCP servers, the client will provide a way to accept the server URL (`https://bindings.mcp.cloudflare.com`) directly within its interface (for example in [Cloudflare AI Playground](https://playground.ai.cloudflare.com/)).

--- a/apps/workers-builds/README.md
+++ b/apps/workers-builds/README.md
@@ -26,6 +26,18 @@ This MCP server is still a work in progress, and we plan to add more tools in th
 - `Show me the logs for build my latest build.`
 - `Did the latest build for worker frontend-app succeed?`
 
+## Required Cloudflare permissions
+
+When using Cloudflare OAuth, this server requests the following scopes:
+
+| OAuth scope           | API token permission                    |
+| --------------------- | --------------------------------------- |
+| `user:read`           | User Details Read                       |
+| `offline_access`      | OAuth only; not an API token permission |
+| `account:read`        | Account Settings Read                   |
+| `workers:read`        | Workers Scripts Read                    |
+| `workers_builds:read` | Workers CI Read                         |
+
 ## Access the remote MCP server from from any MCP Client
 
 If your MCP client has first class support for remote MCP servers, the client will provide a way to accept the server URL (`https://builds.mcp.cloudflare.com`) directly within its interface (for example in [Cloudflare AI Playground](https://playground.ai.cloudflare.com/)).

--- a/apps/workers-observability/README.md
+++ b/apps/workers-observability/README.md
@@ -26,6 +26,20 @@ This MCP server is still a work in progress, and we plan to add more tools in th
 - `How many requests were made to my worker 'my-app' broken down by HTTP status code?`
 - `Compare the error rates between my production and staging workers`
 
+## Required Cloudflare permissions
+
+When using Cloudflare OAuth, this server requests the following scopes:
+
+| OAuth scope                  | API token permission                    |
+| ---------------------------- | --------------------------------------- |
+| `user:read`                  | User Details Read                       |
+| `offline_access`             | OAuth only; not an API token permission |
+| `account:read`               | Account Settings Read                   |
+| `workers:read`               | Workers Scripts Read                    |
+| `workers_observability:read` | Workers Observability Read              |
+
+For API tokens, telemetry query tools may require Workers Observability Write.
+
 ## Access the remote MCP server from any MCP Client
 
 If your MCP client has first class support for remote MCP servers, the client will provide a way to accept the server URL (`https://observability.mcp.cloudflare.com`) directly within its interface (for example in [Cloudflare AI Playground](https://playground.ai.cloudflare.com/)).


### PR DESCRIPTION
## Summary

- Adds a `Required Cloudflare permissions` section to each MCP server README that declares Cloudflare OAuth scopes in its app entrypoint.
- Lists the corresponding API token permission names users should look for when configuring token-based access.
- Calls out OAuth-only `offline_access` and the Workers Observability telemetry query permission nuance.

Closes #307.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm exec prettier --check apps/*/README.md`
- `git diff --check`
- `pnpm check:format` (exits 0; emits existing `[prettier-plugin-sort-imports]` parser warning before reporting all matched files formatted)
- `pnpm test` (8 files, 97 tests passed)
