### PR TITLE
fix(auditlogs): accept api actor context

### DIFF
--- a/.changeset/audit-api-actor-context.md
+++ b/.changeset/audit-api-actor-context.md
@@ -1,0 +1,5 @@
+---
+"auditlogs": patch
+---
+
+Accept API actor context in audit log formatting.

--- a/apps/auditlogs/src/tools/auditlogs.tools.test.ts
+++ b/apps/auditlogs/src/tools/auditlogs.tools.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+
+import { auditLogsResponseSchema } from './auditlogs.tools'
+
+describe('auditLogsResponseSchema', () => {
+	it('accepts audit log entries with api actor context', () => {
+		const result = auditLogsResponseSchema.safeParse({
+			success: true,
+			errors: [],
+			result: [
+				{
+					id: '00000000-0000-0000-0000-000000000000',
+					account: {
+						id: 'account-id',
+						name: 'Example Account',
+					},
+					action: {
+						result: 'success',
+						time: '2026-05-15T17:30:00.000Z',
+						type: 'update',
+					},
+					actor: {
+						context: 'api',
+						type: 'user',
+					},
+				},
+			],
+			result_info: {
+				count: 1,
+			},
+		})
+
+		expect(result.success).toBe(true)
+	})
+})

--- a/apps/auditlogs/src/tools/auditlogs.tools.ts
+++ b/apps/auditlogs/src/tools/auditlogs.tools.ts
@@ -7,7 +7,14 @@ import type { AuditlogMCP } from '../auditlogs.app'
 
 export const actionResults = z.enum(['success', 'failure', ''])
 export const actionTypes = z.enum(['create', 'delete', 'view', 'update', 'login'])
-export const actorContexts = z.enum(['api_key', 'api_token', 'dash', 'oauth', 'origin_ca_key'])
+export const actorContexts = z.enum([
+	'api',
+	'api_key',
+	'api_token',
+	'dash',
+	'oauth',
+	'origin_ca_key',
+])
 export const actorTypes = z.enum(['cloudflare_admin', 'account', 'user', 'system'])
 export const resourceScopes = z.enum(['memberships', 'accounts', 'user', 'zones'])
 export const sortDirections = z.enum(['desc', 'asc'])


### PR DESCRIPTION
Summary
- Accept `actor.context: "api"` in audit log responses.
- Add a regression test for an audit log response containing the live API actor context value.

Fixes #352.

Verification
- `pnpm --filter auditlogs test -- src/tools/auditlogs.tools.test.ts`
- `pnpm --filter auditlogs check:types`
- `pnpm exec prettier apps/auditlogs/src/tools/auditlogs.tools.ts apps/auditlogs/src/tools/auditlogs.tools.test.ts --check`
- `git diff --check`

Note
- The targeted Vitest run emits the existing Wrangler config warning about `observability.traces`; the test passes.