### PR TITLE
fix: preserve Workers log source fields

### DIFF
--- a/.changeset/preserve-log-source-fields.md
+++ b/.changeset/preserve-log-source-fields.md
@@ -1,0 +1,5 @@
+---
+"@repo/mcp-common": patch
+---
+
+Preserve Workers log source fields when normalizing log payloads.

--- a/packages/mcp-common/src/types/workers-logs.types.spec.ts
+++ b/packages/mcp-common/src/types/workers-logs.types.spec.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+
+import { zReturnedTelemetryEvent } from './workers-logs.types'
+
+describe('zReturnedTelemetryEvent', () => {
+	it('preserves custom Workers log source fields', () => {
+		const event = zReturnedTelemetryEvent.parse({
+			dataset: 'cloudflare-workers',
+			timestamp: 1775208144119,
+			source: {
+				event: 'sync_complete',
+				userId: 'abc-123',
+				synced: 10,
+				durationMs: 1307,
+			},
+			$metadata: {
+				id: 'log-event-id',
+			},
+		})
+
+		expect(event.source).toEqual({
+			event: 'sync_complete',
+			userId: 'abc-123',
+			synced: 10,
+			durationMs: 1307,
+		})
+	})
+})

--- a/packages/mcp-common/src/types/workers-logs.types.ts
+++ b/packages/mcp-common/src/types/workers-logs.types.ts
@@ -292,16 +292,18 @@ export const zCloudflareEvent = zCloudflareMiniEvent.extend({
 	cpuTimeMs: z.number().optional(),
 })
 
-const zSourceSchema = z.object({
-	exception: z
-		.object({
-			stack: z.string().optional(),
-			name: z.string().optional(),
-			message: z.string().optional(),
-			timestamp: z.number().optional(),
-		})
-		.optional(),
-})
+const zSourceSchema = z
+	.object({
+		exception: z
+			.object({
+				stack: z.string().optional(),
+				name: z.string().optional(),
+				message: z.string().optional(),
+				timestamp: z.number().optional(),
+			})
+			.optional(),
+	})
+	.passthrough()
 
 export const zReturnedTelemetryEvent = z.object({
 	dataset: z.string(),


### PR DESCRIPTION
Summary
- Preserve unknown object fields in Workers telemetry `source` payloads instead of stripping them during Zod parsing.
- Add a regression test for structured `console.log()` fields such as `event`, `userId`, and duration values.

Context
- Fixes #342.

Verification
- `pnpm --filter @repo/mcp-common test -- workers-logs.types.spec.ts`
- `pnpm --filter @repo/mcp-common check:types`
- `pnpm prettier packages/mcp-common/src/types/workers-logs.types.ts packages/mcp-common/src/types/workers-logs.types.spec.ts --check`
- `git diff --check`