### PR TITLE
chore(radar): deprecate in favor of mcp.cloudflare.com

### DIFF
--- a/.changeset/deprecate-radar.md
+++ b/.changeset/deprecate-radar.md
@@ -1,0 +1,9 @@
+---
+"cloudflare-radar-mcp-server": patch
+---
+
+Deprecate the Radar MCP server. The unified Cloudflare MCP server at https://mcp.cloudflare.com/mcp already covers all Radar API endpoints via Code Mode (see https://github.com/cloudflare/mcp).
+
+Tools continue to function. The server now exposes a deprecation notice via the MCP `instructions` field, and the `radar.mcp.cloudflare.com` entries have been removed from `server.json` so registries stop advertising the deprecated server.
+
+**Action required:** migrate to `https://mcp.cloudflare.com/mcp` at your earliest convenience.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ The following servers are included in this repository:
 | [**Workers Bindings server**](/apps/workers-bindings)          | Build Workers applications with storage, AI, and compute primitives                             | `https://bindings.mcp.cloudflare.com/mcp`      |
 | [**Workers Builds server**](/apps/workers-builds)              | Get insights and manage your Cloudflare Workers Builds                                          | `https://builds.mcp.cloudflare.com/mcp`        |
 | [**Observability server**](/apps/workers-observability)        | Debug and get insight into your application's logs and analytics                                | `https://observability.mcp.cloudflare.com/mcp` |
-| [**Radar server**](/apps/radar)                                | Get global Internet traffic insights, trends, URL scans, and other utilities                    | `https://radar.mcp.cloudflare.com/mcp`         |
 | [**Container server**](/apps/sandbox-container)                | Spin up a sandbox development environment                                                       | `https://containers.mcp.cloudflare.com/mcp`    |
 | [**Browser rendering server**](/apps/browser-rendering)        | Fetch web pages, convert them to markdown and take screenshots                                  | `https://browser.mcp.cloudflare.com/mcp`       |
 | [**Logpush server**](/apps/logpush)                            | Get quick summaries for Logpush job health                                                      | `https://logs.mcp.cloudflare.com/mcp`          |

--- a/apps/radar/CONTRIBUTING.md
+++ b/apps/radar/CONTRIBUTING.md
@@ -1,5 +1,7 @@
 # Setup
 
+> ⚠️ **This server is deprecated.** See [`README.md`](./README.md) for the migration path to [`mcp.cloudflare.com/mcp`](https://mcp.cloudflare.com/mcp). Bug fixes are welcome; new features will generally not be accepted — please direct new work at the unified [`cloudflare/mcp`](https://github.com/cloudflare/mcp) repository instead.
+
 If you'd like to iterate and test your MCP server, you can do so in local development.
 
 ## Local Development

--- a/apps/radar/README.md
+++ b/apps/radar/README.md
@@ -8,11 +8,11 @@ All new work should move to the unified server:
 
 ```json
 {
-  "mcpServers": {
-    "cloudflare-api": {
-      "url": "https://mcp.cloudflare.com/mcp"
-    }
-  }
+	"mcpServers": {
+		"cloudflare-api": {
+			"url": "https://mcp.cloudflare.com/mcp"
+		}
+	}
 }
 ```
 

--- a/apps/radar/README.md
+++ b/apps/radar/README.md
@@ -1,5 +1,27 @@
 # Cloudflare Radar MCP Server 📡
 
+## ⚠️ Deprecated
+
+**This server is deprecated.** The unified Cloudflare MCP server at [`mcp.cloudflare.com/mcp`](https://mcp.cloudflare.com/mcp) already covers all Radar API endpoints (along with the rest of the Cloudflare API).
+
+All new work should move to the unified server:
+
+```json
+{
+  "mcpServers": {
+    "cloudflare-api": {
+      "url": "https://mcp.cloudflare.com/mcp"
+    }
+  }
+}
+```
+
+That server uses [Code Mode](https://blog.cloudflare.com/code-mode-mcp/) — two generic tools (`search` and `execute`) that give agents access to the full Cloudflare API through code execution. It supports both OAuth (connect to the URL and authorize) and Cloudflare API tokens (send as a bearer token). See [`cloudflare/mcp`](https://github.com/cloudflare/mcp) for details.
+
+The tools below still function. No new features will be added. Please migrate at your earliest convenience.
+
+---
+
 This is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction) server that supports remote MCP
 connections, with Cloudflare OAuth built-in.
 

--- a/apps/radar/src/radar.app.ts
+++ b/apps/radar/src/radar.app.ts
@@ -92,7 +92,7 @@ export class RadarMCP extends McpAgent<Env, State, Props> {
 				name: this.env.MCP_SERVER_NAME,
 				version: this.env.MCP_SERVER_VERSION,
 			},
-			options: { instructions: DEPRECATION_INSTRUCTIONS },
+			options: { instructions: DEPRECATION_INSTRUCTIONS + '\n\n---\n\n' + BASE_INSTRUCTIONS },
 		})
 
 		registerAccountTools(this)

--- a/apps/radar/src/radar.app.ts
+++ b/apps/radar/src/radar.app.ts
@@ -30,6 +30,34 @@ const metrics = new MetricsTracker(env.MCP_METRICS, {
 	version: env.MCP_SERVER_VERSION,
 })
 
+// NOTE: This server is deprecated. The unified Cloudflare MCP server at
+// https://mcp.cloudflare.com/mcp already covers all Radar API endpoints
+// (see https://github.com/cloudflare/mcp).
+//
+// The deprecation notice is surfaced via the MCP `instructions` field on the
+// initialize response. Humans see it in MCP-client UIs that render
+// `instructions`; it is also documented in README.md and CONTRIBUTING.md.
+export const DEPRECATION_INSTRUCTIONS = `⚠️ DEPRECATED: This Radar MCP server is deprecated.
+
+The unified Cloudflare MCP server at mcp.cloudflare.com/mcp already covers all
+Radar API endpoints (along with the rest of the Cloudflare API) via Code Mode —
+two generic tools (\`search\` and \`execute\`) that give agents access to the full
+Cloudflare API through code execution. It supports both OAuth (connect to the URL
+and authorize) and Cloudflare API tokens (send as a bearer token).
+
+Example MCP client configuration:
+
+{
+  "mcpServers": {
+    "cloudflare-api": {
+      "url": "https://mcp.cloudflare.com/mcp"
+    }
+  }
+}
+
+This Radar server continues to respond for now, but will be retired. Please
+migrate at your earliest convenience.`
+
 // Context from the auth process, encrypted & stored in the auth token
 // and provided to the DurableMCP as this.props
 type Props = AuthProps
@@ -64,7 +92,7 @@ export class RadarMCP extends McpAgent<Env, State, Props> {
 				name: this.env.MCP_SERVER_NAME,
 				version: this.env.MCP_SERVER_VERSION,
 			},
-			options: { instructions: BASE_INSTRUCTIONS },
+			options: { instructions: DEPRECATION_INSTRUCTIONS },
 		})
 
 		registerAccountTools(this)

--- a/server.json
+++ b/server.json
@@ -49,18 +49,7 @@
 				}
 			]
 		},
-		{
-			"url": "https://radar.mcp.cloudflare.com/mcp",
-			"type": "streamable-http",
-			"headers": [
-				{
-					"name": "Authentication",
-					"description": "Optional Cloudflare API key for authentication if not using OAuth. Can use User or Account owned tokens as a Bearer token.",
-					"is_required": false,
-					"is_secret": true
-				}
-			]
-		},
+
 		{
 			"url": "https://containers.mcp.cloudflare.com/mcp",
 			"type": "streamable-http",
@@ -210,18 +199,7 @@
 				}
 			]
 		},
-		{
-			"url": "https://radar.mcp.cloudflare.com/sse",
-			"type": "sse",
-			"headers": [
-				{
-					"name": "Authentication",
-					"description": "Optional Cloudflare API key for authentication if not using OAuth. Can use User or Account owned tokens as a Bearer token.",
-					"is_required": false,
-					"is_secret": true
-				}
-			]
-		},
+
 		{
 			"url": "https://containers.mcp.cloudflare.com/sse",
 			"type": "sse",

--- a/server.json
+++ b/server.json
@@ -49,7 +49,6 @@
 				}
 			]
 		},
-
 		{
 			"url": "https://containers.mcp.cloudflare.com/mcp",
 			"type": "streamable-http",
@@ -199,7 +198,6 @@
 				}
 			]
 		},
-
 		{
 			"url": "https://containers.mcp.cloudflare.com/sse",
 			"type": "sse",


### PR DESCRIPTION
## Summary

Marks the Radar MCP server as deprecated in favor of the unified Cloudflare MCP server at [`mcp.cloudflare.com/mcp`](https://mcp.cloudflare.com/mcp).

### Changes

- Added a deprecation notice to `apps/radar/README.md` with:
  - `## ⚠️ Deprecated` heading (matching the AutoRAG deprecation style from #354)
  - Migration instructions with JSON config snippet
  - Link to the Code Mode blog post and `cloudflare/mcp` repo
  - Note that no new features will be added

### Context

The unified Cloudflare MCP server at `mcp.cloudflare.com/mcp` already covers all Radar API endpoints via Code Mode. Testing confirmed data parity across all Radar endpoint categories (HTTP traffic, BGP, DNS, domain rankings, IP details, outages, etc.).

Related: [RADAR-7106](https://jira.cfdata.org/browse/RADAR-7106)