### PR TITLE
fix(release): use env var to prevent shell injection in Save Published Packages step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,9 +31,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Save Published Packages
         if: steps.create-release-pr.outputs.published == 'true'
-        run: |
-          echo '${{steps.create-release-pr.outputs.publishedPackages}}' \
-            > ${{ github.workspace }}/published-packages.json
+        env:
+          PUBLISHED_PACKAGES: ${{ steps.create-release-pr.outputs.publishedPackages }}
+        run: echo "$PUBLISHED_PACKAGES" > ${{ github.workspace }}/published-packages.json
       - name: Upload Published Packages
         if: steps.create-release-pr.outputs.published == 'true'
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
\`${{steps.create-release-pr.outputs.publishedPackages}}\` was interpolated directly into the shell command. A package name with a single quote breaks out of the quoted string and executes arbitrary code on the runner, with access to \`CLOUDFLARE_API_TOKEN\` and \`GITHUB_TOKEN\`.

Fix: assign the expression to an env var so the shell receives it as a value, not as part of the command string.

Ref: https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable