### PR TITLE
chore: upgrade @cloudflare/workers-oauth-provider 0.4.0 → 0.7.0

### DIFF
--- a/.changeset/bump-workers-oauth-provider.md
+++ b/.changeset/bump-workers-oauth-provider.md
@@ -1,0 +1,25 @@
+---
+'cloudflare-ai-gateway-mcp-server': patch
+'cloudflare-autorag-mcp-server': patch
+'cloudflare-browser-mcp-server': patch
+'cloudflare-casb-mcp-server': patch
+'cloudflare-radar-mcp-server': patch
+'graphql-mcp-server': patch
+'workers-observability': patch
+'workers-bindings': patch
+'workers-builds': patch
+'containers-mcp': patch
+'dex-analysis': patch
+'dns-analytics': patch
+'docs-ai-search': patch
+'docs-autorag': patch
+'docs-vectorize': patch
+'auditlogs': patch
+'logpush': patch
+---
+
+Upgrade `@cloudflare/workers-oauth-provider` 0.4.0 → 0.7.0.
+
+No tool or behavior changes. The only API change affecting this repo is that
+`TokenExchangeCallbackOptions` now carries a required `grantId` field, which only
+touched a test fixture (the provider supplies it at runtime).

--- a/apps/ai-gateway/package.json
+++ b/apps/ai-gateway/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.4.0",
+		"@cloudflare/workers-oauth-provider": "0.7.0",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.29.0",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/auditlogs/package.json
+++ b/apps/auditlogs/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.4.0",
+		"@cloudflare/workers-oauth-provider": "0.7.0",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.29.0",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/autorag/package.json
+++ b/apps/autorag/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.4.0",
+		"@cloudflare/workers-oauth-provider": "0.7.0",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.29.0",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/browser-rendering/package.json
+++ b/apps/browser-rendering/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.4.0",
+		"@cloudflare/workers-oauth-provider": "0.7.0",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.29.0",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/cloudflare-one-casb/package.json
+++ b/apps/cloudflare-one-casb/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.4.0",
+		"@cloudflare/workers-oauth-provider": "0.7.0",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.29.0",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/dex-analysis/package.json
+++ b/apps/dex-analysis/package.json
@@ -13,7 +13,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.4.0",
+		"@cloudflare/workers-oauth-provider": "0.7.0",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.29.0",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/dns-analytics/package.json
+++ b/apps/dns-analytics/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.4.0",
+		"@cloudflare/workers-oauth-provider": "0.7.0",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.29.0",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/docs-ai-search/package.json
+++ b/apps/docs-ai-search/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.4.0",
+		"@cloudflare/workers-oauth-provider": "0.7.0",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.29.0",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/docs-autorag/package.json
+++ b/apps/docs-autorag/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.4.0",
+		"@cloudflare/workers-oauth-provider": "0.7.0",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.29.0",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/docs-vectorize/package.json
+++ b/apps/docs-vectorize/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.4.0",
+		"@cloudflare/workers-oauth-provider": "0.7.0",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.29.0",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/graphql/package.json
+++ b/apps/graphql/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.4.0",
+		"@cloudflare/workers-oauth-provider": "0.7.0",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.29.0",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/logpush/package.json
+++ b/apps/logpush/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.4.0",
+		"@cloudflare/workers-oauth-provider": "0.7.0",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.29.0",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/radar/package.json
+++ b/apps/radar/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.4.0",
+		"@cloudflare/workers-oauth-provider": "0.7.0",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.29.0",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/sandbox-container/package.json
+++ b/apps/sandbox-container/package.json
@@ -19,7 +19,7 @@
 		"eval:ci": "start-server-and-test --expect 404 eval:server http://localhost:8976 'vitest run --testTimeout=60000 --config vitest.config.evals.ts'"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.4.0",
+		"@cloudflare/workers-oauth-provider": "0.7.0",
 		"@hono/node-server": "1.13.8",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.29.0",

--- a/apps/workers-bindings/package.json
+++ b/apps/workers-bindings/package.json
@@ -25,7 +25,7 @@
 		"wrangler": "4.96.0"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.4.0",
+		"@cloudflare/workers-oauth-provider": "0.7.0",
 		"@modelcontextprotocol/sdk": "1.29.0",
 		"@n8n/json-schema-to-zod": "1.1.0",
 		"@repo/eval-tools": "workspace:*",

--- a/apps/workers-builds/package.json
+++ b/apps/workers-builds/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.4.0",
+		"@cloudflare/workers-oauth-provider": "0.7.0",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.29.0",
 		"@repo/mcp-common": "workspace:*",

--- a/apps/workers-observability/package.json
+++ b/apps/workers-observability/package.json
@@ -12,7 +12,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.4.0",
+		"@cloudflare/workers-oauth-provider": "0.7.0",
 		"@fast-csv/format": "5.0.2",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.29.0",

--- a/packages/mcp-common/package.json
+++ b/packages/mcp-common/package.json
@@ -11,7 +11,7 @@
 		"test:coverage": "run-vitest-coverage"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "0.4.0",
+		"@cloudflare/workers-oauth-provider": "0.7.0",
 		"@fast-csv/format": "5.0.2",
 		"@hono/zod-validator": "0.4.3",
 		"@modelcontextprotocol/sdk": "1.29.0",

--- a/packages/mcp-common/src/cloudflare-oauth-handler.spec.ts
+++ b/packages/mcp-common/src/cloudflare-oauth-handler.spec.ts
@@ -31,6 +31,7 @@ afterEach(() => {
 function makeRefreshOptions(propsOverride: Record<string, unknown>): TokenExchangeCallbackOptions {
 	return {
 		grantType: GrantType.REFRESH_TOKEN,
+		grantId: 'test-grant-id',
 		props: propsOverride,
 		clientId: 'test',
 		userId: 'test-user',
@@ -252,6 +253,7 @@ describe('handleTokenExchangeCallback', () => {
 		it('returns undefined for authorization_code grant type', async () => {
 			const options: TokenExchangeCallbackOptions = {
 				grantType: GrantType.AUTHORIZATION_CODE,
+				grantId: 'test-grant-id',
 				props: {},
 				clientId: 'test',
 				userId: 'test-user',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,8 +52,8 @@ importers:
   apps/ai-gateway:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.4.0
-        version: 0.4.0
+        specifier: 0.7.0
+        version: 0.7.0
       '@hono/zod-validator':
         specifier: 0.4.3
         version: 0.4.3(hono@4.7.6)(zod@4.4.3)
@@ -101,8 +101,8 @@ importers:
   apps/auditlogs:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.4.0
-        version: 0.4.0
+        specifier: 0.7.0
+        version: 0.7.0
       '@hono/zod-validator':
         specifier: 0.4.3
         version: 0.4.3(hono@4.7.6)(zod@4.4.3)
@@ -150,8 +150,8 @@ importers:
   apps/autorag:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.4.0
-        version: 0.4.0
+        specifier: 0.7.0
+        version: 0.7.0
       '@hono/zod-validator':
         specifier: 0.4.3
         version: 0.4.3(hono@4.7.6)(zod@4.4.3)
@@ -199,8 +199,8 @@ importers:
   apps/browser-rendering:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.4.0
-        version: 0.4.0
+        specifier: 0.7.0
+        version: 0.7.0
       '@hono/zod-validator':
         specifier: 0.4.3
         version: 0.4.3(hono@4.7.6)(zod@4.4.3)
@@ -248,8 +248,8 @@ importers:
   apps/cloudflare-one-casb:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.4.0
-        version: 0.4.0
+        specifier: 0.7.0
+        version: 0.7.0
       '@hono/zod-validator':
         specifier: 0.4.3
         version: 0.4.3(hono@4.7.6)(zod@4.4.3)
@@ -334,8 +334,8 @@ importers:
   apps/dex-analysis:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.4.0
-        version: 0.4.0
+        specifier: 0.7.0
+        version: 0.7.0
       '@hono/zod-validator':
         specifier: 0.4.3
         version: 0.4.3(hono@4.7.6)(zod@4.4.3)
@@ -389,8 +389,8 @@ importers:
   apps/dns-analytics:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.4.0
-        version: 0.4.0
+        specifier: 0.7.0
+        version: 0.7.0
       '@hono/zod-validator':
         specifier: 0.4.3
         version: 0.4.3(hono@4.7.6)(zod@4.4.3)
@@ -438,8 +438,8 @@ importers:
   apps/docs-ai-search:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.4.0
-        version: 0.4.0
+        specifier: 0.7.0
+        version: 0.7.0
       '@hono/zod-validator':
         specifier: 0.4.3
         version: 0.4.3(hono@4.7.6)(zod@4.4.3)
@@ -490,8 +490,8 @@ importers:
   apps/docs-autorag:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.4.0
-        version: 0.4.0
+        specifier: 0.7.0
+        version: 0.7.0
       '@hono/zod-validator':
         specifier: 0.4.3
         version: 0.4.3(hono@4.7.6)(zod@4.4.3)
@@ -542,8 +542,8 @@ importers:
   apps/docs-vectorize:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.4.0
-        version: 0.4.0
+        specifier: 0.7.0
+        version: 0.7.0
       '@hono/zod-validator':
         specifier: 0.4.3
         version: 0.4.3(hono@4.7.6)(zod@4.4.3)
@@ -594,8 +594,8 @@ importers:
   apps/graphql:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.4.0
-        version: 0.4.0
+        specifier: 0.7.0
+        version: 0.7.0
       '@hono/zod-validator':
         specifier: 0.4.3
         version: 0.4.3(hono@4.7.6)(zod@4.4.3)
@@ -646,8 +646,8 @@ importers:
   apps/logpush:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.4.0
-        version: 0.4.0
+        specifier: 0.7.0
+        version: 0.7.0
       '@hono/zod-validator':
         specifier: 0.4.3
         version: 0.4.3(hono@4.7.6)(zod@4.4.3)
@@ -695,8 +695,8 @@ importers:
   apps/radar:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.4.0
-        version: 0.4.0
+        specifier: 0.7.0
+        version: 0.7.0
       '@hono/zod-validator':
         specifier: 0.4.3
         version: 0.4.3(hono@4.7.6)(zod@4.4.3)
@@ -744,8 +744,8 @@ importers:
   apps/sandbox-container:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.4.0
-        version: 0.4.0
+        specifier: 0.7.0
+        version: 0.7.0
       '@hono/node-server':
         specifier: 1.13.8
         version: 1.13.8(hono@4.7.6)
@@ -823,8 +823,8 @@ importers:
   apps/workers-bindings:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.4.0
-        version: 0.4.0
+        specifier: 0.7.0
+        version: 0.7.0
       '@modelcontextprotocol/sdk':
         specifier: 1.29.0
         version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)
@@ -884,8 +884,8 @@ importers:
   apps/workers-builds:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.4.0
-        version: 0.4.0
+        specifier: 0.7.0
+        version: 0.7.0
       '@hono/zod-validator':
         specifier: 0.4.3
         version: 0.4.3(hono@4.7.6)(zod@4.4.3)
@@ -939,8 +939,8 @@ importers:
   apps/workers-observability:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.4.0
-        version: 0.4.0
+        specifier: 0.7.0
+        version: 0.7.0
       '@fast-csv/format':
         specifier: 5.0.2
         version: 5.0.2
@@ -1067,8 +1067,8 @@ importers:
   packages/mcp-common:
     dependencies:
       '@cloudflare/workers-oauth-provider':
-        specifier: 0.4.0
-        version: 0.4.0
+        specifier: 0.7.0
+        version: 0.7.0
       '@fast-csv/format':
         specifier: 5.0.2
         version: 5.0.2
@@ -1627,8 +1627,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@cloudflare/workers-oauth-provider@0.4.0':
-    resolution: {integrity: sha512-UtbV8hjC2NloB+Ds6J6v/9HiG8rx8MbdeYGCyFwOACT5vANWzDL6SKo3W5UZymsXiameAgC7jAmtUx4cc+Qpaw==}
+  '@cloudflare/workers-oauth-provider@0.7.0':
+    resolution: {integrity: sha512-w0s740/aV76mOkCgTcAQ31Lcju38Bt2BN3gbWPfhF9TvN6ED8nv08TSkNPARJa7X2AZzWhxqRlMrbWzEDPcY+Q==}
 
   '@cloudflare/workers-types@4.20250416.0':
     resolution: {integrity: sha512-i37TX0Clp+MrPdXMBdvKZM7JghCrWD9GtG7E+8ANOAPmtZjUkZfEy9qq46IG3XlNpagPaWDkY3SgJ3s01gPxCw==}
@@ -6030,7 +6030,7 @@ snapshots:
   '@cloudflare/workerd-windows-64@1.20260529.1':
     optional: true
 
-  '@cloudflare/workers-oauth-provider@0.4.0': {}
+  '@cloudflare/workers-oauth-provider@0.7.0': {}
 
   '@cloudflare/workers-types@4.20250416.0': {}
 


### PR DESCRIPTION
## Summary

Upgrades `@cloudflare/workers-oauth-provider` **0.4.0 → 0.7.0** across all 17 OAuth-enabled MCP servers and `@repo/mcp-common`.

## Changes
- Bump the dependency pin in all 18 `package.json` files (syncpack-consistent) + refresh the lockfile.
- The only source-level API change between 0.4 and 0.7: `TokenExchangeCallbackOptions` now carries a required `grantId` field. Production code doesn't construct this type (the provider supplies it at runtime); the change only touched two test fixtures in `cloudflare-oauth-handler.spec.ts`.
- No tool, behavior, or public-API changes to the servers. The `new OAuthProvider({...})` constructor options and the `OAuthHelpers` / `AuthRequest` / `ClientInfo` / `GrantType` types are all compatible.

## Verification
- `check:types`, `check:lint`, `check:format`, `check:deps` (syncpack) all green (37/37).
- `@repo/mcp-common` tests pass (110).

## Changeset
- `bump-workers-oauth-provider` (patch, all 17 OAuth servers).