### PR TITLE
fix(graphql): add deleted_classes:[UserDetails] migration to unblock deploys

### DIFF
--- a/.changeset/graphql-delete-userdetails-migration.md
+++ b/.changeset/graphql-delete-userdetails-migration.md
@@ -1,0 +1,16 @@
+---
+'graphql-mcp-server': patch
+---
+
+Add a `deleted_classes: ["UserDetails"]` Durable Object migration to the graphql server.
+
+\#384 removed the `UserDetails` Durable Object (and its bindings) from every server, and added the
+required delete-class migration to the two servers that *own* the class (`workers-observability`,
+`workers-builds`). The graphql worker's already-deployed version still depends on `UserDetails`, so
+`wrangler deploy` rejected the new version with `code: 10064` ("New version of script does not export
+class 'UserDetails' which is depended on by existing Durable Objects"), which aborted the staging and
+production deploys. Adding the delete-class migration lets graphql deploy and releases the binding that
+was blocking `workers-observability` from applying its own `deleted_classes` migration (`code: 10061`).
+
+Validated on staging: graphql + observability deploy cleanly and the staging `UserDetails` namespace is
+removed.

--- a/apps/graphql/wrangler.jsonc
+++ b/apps/graphql/wrangler.jsonc
@@ -12,6 +12,10 @@
 		{
 			"new_sqlite_classes": ["GraphQLMCP"],
 			"tag": "v1"
+		},
+		{
+			"deleted_classes": ["UserDetails"],
+			"tag": "v2"
 		}
 	],
 	"observability": {


### PR DESCRIPTION
## Problem

The staging and production deploys of #384 (which removed the `UserDetails` Durable Object) **failed**, leaving most servers undeployed:

- **graphql** → `code: 10064` — *"New version of script does not export class 'UserDetails' which is depended on by existing Durable Objects … use a delete-class migration."*
- **workers-observability** → `code: 10061` — *"Cannot apply --delete-class migration to class 'UserDetails' without also removing the binding that references it."*

Because `turbo deploy` aborts on first failure, graphql's failure halted the whole release.

## Root cause

#384 removed the `UserDetails` DO and its bindings from every server, and correctly added a `deleted_classes: ["UserDetails"]` migration to the two servers that **own** the class (`workers-observability`, `workers-builds`). It did **not** add one to **graphql**, whose already-deployed worker still depends on `UserDetails` — so `wrangler deploy` refuses the new version (10064). graphql is also the last consumer still holding a cross-script binding to `observability`'s `UserDetails`, which is what blocked observability's own delete-class migration (10061).

## Fix

Add the delete-class migration to graphql:

```jsonc
"migrations": [
  { "new_sqlite_classes": ["GraphQLMCP"], "tag": "v1" },
  { "deleted_classes": ["UserDetails"], "tag": "v2" }
]
```

graphql owns no actual `UserDetails` namespace (only `observability` does), so this just clears graphql's dependency on the class and releases the binding that was blocking observability.

## Validation

Deployed the full set to **staging** in order (consumers first, owners last):

- graphql-staging and workers-observability-staging now deploy cleanly (10064 / 10061 gone).
- All staging servers respond 200 on the new build (`accounts_list` tool gone).
- The staging `UserDetails` Durable Object namespace is **deleted**; only the production one remains (pending the prod redeploy).

## Follow-up / deploy note

Production `graphql` + `workers-observability` are still on the pre-#384 build (their failed deploys left the old version running — no downtime, `UserDetails` data intact). After this merges, redeploy them to production **in order** (graphql → observability) so observability's delete-class migration succeeds.