### PR TITLE
Fix refresh invalid_grant retry storms

### DIFF
--- a/.changeset/refresh-invalid-grant-loop.md
+++ b/.changeset/refresh-invalid-grant-loop.md
@@ -1,0 +1,21 @@
+---
+"@repo/mcp-common": patch
+"auditlogs": patch
+"cloudflare-ai-gateway-mcp-server": patch
+"cloudflare-autorag-mcp-server": patch
+"cloudflare-browser-mcp-server": patch
+"cloudflare-casb-mcp-server": patch
+"cloudflare-radar-mcp-server": patch
+"containers-mcp": patch
+"dex-analysis": patch
+"dns-analytics": patch
+"docs-ai-search": patch
+"docs-vectorize": patch
+"graphql-mcp-server": patch
+"logpush": patch
+"workers-bindings": patch
+"workers-builds": patch
+"workers-observability": patch
+---
+
+Guard upstream refresh-token exchanges against invalid-grant retry storms, cache terminal refresh failures, and revoke downstream grants when the upstream refresh token is permanently invalid.

--- a/apps/ai-gateway/src/ai-gateway.app.ts
+++ b/apps/ai-gateway/src/ai-gateway.app.ts
@@ -1,8 +1,9 @@
-import OAuthProvider from '@cloudflare/workers-oauth-provider'
+import OAuthProvider, { getOAuthApi } from '@cloudflare/workers-oauth-provider'
 import { McpAgent } from 'agents/mcp'
 
 import { AccountManager } from '@repo/mcp-common/src/account-manager'
 import { handleApiTokenMode, isApiTokenRequest } from '@repo/mcp-common/src/api-token-mode'
+import { handleBenignDisconnect } from '@repo/mcp-common/src/benign-disconnect'
 import {
 	createAuthHandlers,
 	handleTokenExchangeCallback,
@@ -78,10 +79,10 @@ const AIGatewayScopes = {
 export default {
 	fetch: async (req: Request, env: Env, ctx: ExecutionContext) => {
 		if (await isApiTokenRequest(req, env)) {
-			return await handleApiTokenMode(AIGatewayMCP, req, env, ctx)
+			return await handleBenignDisconnect(handleApiTokenMode(AIGatewayMCP, req, env, ctx))
 		}
 
-		return new OAuthProvider({
+		const oauthOptions: ConstructorParameters<typeof OAuthProvider<Env>>[0] = {
 			apiHandlers: {
 				'/mcp': AIGatewayMCP.serve('/mcp'),
 				'/sse': AIGatewayMCP.serveSSE('/sse'),
@@ -93,7 +94,9 @@ export default {
 				handleTokenExchangeCallback(
 					options,
 					env.CLOUDFLARE_CLIENT_ID,
-					env.CLOUDFLARE_CLIENT_SECRET
+					env.CLOUDFLARE_CLIENT_SECRET,
+					env.OAUTH_KV,
+					() => getOAuthApi(oauthOptions, env)
 				),
 			// Cloudflare access token TTL
 			accessTokenTTL: 3600,
@@ -101,6 +104,7 @@ export default {
 			// TODO: Remove after 2026-05-01 — all pre-0.4.0 grants will have expired by then
 			resourceMatchOriginOnly: true,
 			clientRegistrationEndpoint: '/register',
-		}).fetch(req, env, ctx)
+		}
+		return handleBenignDisconnect(new OAuthProvider(oauthOptions).fetch(req, env, ctx))
 	},
 }

--- a/apps/auditlogs/src/auditlogs.app.ts
+++ b/apps/auditlogs/src/auditlogs.app.ts
@@ -1,8 +1,9 @@
-import OAuthProvider from '@cloudflare/workers-oauth-provider'
+import OAuthProvider, { getOAuthApi } from '@cloudflare/workers-oauth-provider'
 import { McpAgent } from 'agents/mcp'
 
 import { AccountManager } from '@repo/mcp-common/src/account-manager'
 import { handleApiTokenMode, isApiTokenRequest } from '@repo/mcp-common/src/api-token-mode'
+import { handleBenignDisconnect } from '@repo/mcp-common/src/benign-disconnect'
 import {
 	createAuthHandlers,
 	handleTokenExchangeCallback,
@@ -79,10 +80,10 @@ const AuditlogScopes = {
 export default {
 	fetch: async (req: Request, env: Env, ctx: ExecutionContext) => {
 		if (await isApiTokenRequest(req, env)) {
-			return await handleApiTokenMode(AuditlogMCP, req, env, ctx)
+			return await handleBenignDisconnect(handleApiTokenMode(AuditlogMCP, req, env, ctx))
 		}
 
-		return new OAuthProvider({
+		const oauthOptions: ConstructorParameters<typeof OAuthProvider<Env>>[0] = {
 			apiHandlers: {
 				'/mcp': AuditlogMCP.serve('/mcp'),
 				'/sse': AuditlogMCP.serveSSE('/sse'),
@@ -94,7 +95,9 @@ export default {
 				handleTokenExchangeCallback(
 					options,
 					env.CLOUDFLARE_CLIENT_ID,
-					env.CLOUDFLARE_CLIENT_SECRET
+					env.CLOUDFLARE_CLIENT_SECRET,
+					env.OAUTH_KV,
+					() => getOAuthApi(oauthOptions, env)
 				),
 			// Cloudflare access token TTL
 			accessTokenTTL: 3600,
@@ -102,6 +105,7 @@ export default {
 			// TODO: Remove after 2026-05-01 — all pre-0.4.0 grants will have expired by then
 			resourceMatchOriginOnly: true,
 			clientRegistrationEndpoint: '/register',
-		}).fetch(req, env, ctx)
+		}
+		return handleBenignDisconnect(new OAuthProvider(oauthOptions).fetch(req, env, ctx))
 	},
 }

--- a/apps/autorag/src/autorag.app.ts
+++ b/apps/autorag/src/autorag.app.ts
@@ -1,8 +1,9 @@
-import OAuthProvider from '@cloudflare/workers-oauth-provider'
+import OAuthProvider, { getOAuthApi } from '@cloudflare/workers-oauth-provider'
 import { McpAgent } from 'agents/mcp'
 
 import { AccountManager } from '@repo/mcp-common/src/account-manager'
 import { handleApiTokenMode, isApiTokenRequest } from '@repo/mcp-common/src/api-token-mode'
+import { handleBenignDisconnect } from '@repo/mcp-common/src/benign-disconnect'
 import {
 	createAuthHandlers,
 	handleTokenExchangeCallback,
@@ -112,10 +113,10 @@ const LogPushScopes = {
 export default {
 	fetch: async (req: Request, env: Env, ctx: ExecutionContext) => {
 		if (await isApiTokenRequest(req, env)) {
-			return await handleApiTokenMode(AutoRAGMCP, req, env, ctx)
+			return await handleBenignDisconnect(handleApiTokenMode(AutoRAGMCP, req, env, ctx))
 		}
 
-		return new OAuthProvider({
+		const oauthOptions: ConstructorParameters<typeof OAuthProvider<Env>>[0] = {
 			apiHandlers: {
 				'/mcp': AutoRAGMCP.serve('/mcp'),
 				'/sse': AutoRAGMCP.serveSSE('/sse'),
@@ -127,7 +128,9 @@ export default {
 				handleTokenExchangeCallback(
 					options,
 					env.CLOUDFLARE_CLIENT_ID,
-					env.CLOUDFLARE_CLIENT_SECRET
+					env.CLOUDFLARE_CLIENT_SECRET,
+					env.OAUTH_KV,
+					() => getOAuthApi(oauthOptions, env)
 				),
 			// Cloudflare access token TTL
 			accessTokenTTL: 3600,
@@ -135,6 +138,7 @@ export default {
 			// TODO: Remove after 2026-05-01 — all pre-0.4.0 grants will have expired by then
 			resourceMatchOriginOnly: true,
 			clientRegistrationEndpoint: '/register',
-		}).fetch(req, env, ctx)
+		}
+		return handleBenignDisconnect(new OAuthProvider(oauthOptions).fetch(req, env, ctx))
 	},
 }

--- a/apps/browser-rendering/src/browser.app.ts
+++ b/apps/browser-rendering/src/browser.app.ts
@@ -1,8 +1,9 @@
-import OAuthProvider from '@cloudflare/workers-oauth-provider'
+import OAuthProvider, { getOAuthApi } from '@cloudflare/workers-oauth-provider'
 import { McpAgent } from 'agents/mcp'
 
 import { AccountManager } from '@repo/mcp-common/src/account-manager'
 import { handleApiTokenMode, isApiTokenRequest } from '@repo/mcp-common/src/api-token-mode'
+import { handleBenignDisconnect } from '@repo/mcp-common/src/benign-disconnect'
 import {
 	createAuthHandlers,
 	handleTokenExchangeCallback,
@@ -78,10 +79,10 @@ const BrowserScopes = {
 export default {
 	fetch: async (req: Request, env: Env, ctx: ExecutionContext) => {
 		if (await isApiTokenRequest(req, env)) {
-			return await handleApiTokenMode(BrowserMCP, req, env, ctx)
+			return await handleBenignDisconnect(handleApiTokenMode(BrowserMCP, req, env, ctx))
 		}
 
-		return new OAuthProvider({
+		const oauthOptions: ConstructorParameters<typeof OAuthProvider<Env>>[0] = {
 			apiHandlers: {
 				'/mcp': BrowserMCP.serve('/mcp'),
 				'/sse': BrowserMCP.serveSSE('/sse'),
@@ -93,7 +94,9 @@ export default {
 				handleTokenExchangeCallback(
 					options,
 					env.CLOUDFLARE_CLIENT_ID,
-					env.CLOUDFLARE_CLIENT_SECRET
+					env.CLOUDFLARE_CLIENT_SECRET,
+					env.OAUTH_KV,
+					() => getOAuthApi(oauthOptions, env)
 				),
 			// Cloudflare access token TTL
 			accessTokenTTL: 3600,
@@ -101,6 +104,7 @@ export default {
 			// TODO: Remove after 2026-05-01 — all pre-0.4.0 grants will have expired by then
 			resourceMatchOriginOnly: true,
 			clientRegistrationEndpoint: '/register',
-		}).fetch(req, env, ctx)
+		}
+		return handleBenignDisconnect(new OAuthProvider(oauthOptions).fetch(req, env, ctx))
 	},
 }

--- a/apps/cloudflare-one-casb/src/cf1-casb.app.ts
+++ b/apps/cloudflare-one-casb/src/cf1-casb.app.ts
@@ -1,8 +1,9 @@
-import OAuthProvider from '@cloudflare/workers-oauth-provider'
+import OAuthProvider, { getOAuthApi } from '@cloudflare/workers-oauth-provider'
 import { McpAgent } from 'agents/mcp'
 
 import { AccountManager } from '@repo/mcp-common/src/account-manager'
 import { handleApiTokenMode, isApiTokenRequest } from '@repo/mcp-common/src/api-token-mode'
+import { handleBenignDisconnect } from '@repo/mcp-common/src/benign-disconnect'
 import {
 	createAuthHandlers,
 	handleTokenExchangeCallback,
@@ -79,10 +80,10 @@ const CloudflareOneCasbScopes = {
 export default {
 	fetch: async (req: Request, env: Env, ctx: ExecutionContext) => {
 		if (await isApiTokenRequest(req, env)) {
-			return await handleApiTokenMode(CASBMCP, req, env, ctx)
+			return await handleBenignDisconnect(handleApiTokenMode(CASBMCP, req, env, ctx))
 		}
 
-		return new OAuthProvider({
+		const oauthOptions: ConstructorParameters<typeof OAuthProvider<Env>>[0] = {
 			apiHandlers: {
 				'/mcp': CASBMCP.serve('/mcp'),
 				'/sse': CASBMCP.serveSSE('/sse'),
@@ -94,7 +95,9 @@ export default {
 				handleTokenExchangeCallback(
 					options,
 					env.CLOUDFLARE_CLIENT_ID,
-					env.CLOUDFLARE_CLIENT_SECRET
+					env.CLOUDFLARE_CLIENT_SECRET,
+					env.OAUTH_KV,
+					() => getOAuthApi(oauthOptions, env)
 				),
 			// Cloudflare access token TTL
 			accessTokenTTL: 3600,
@@ -102,6 +105,7 @@ export default {
 			// TODO: Remove after 2026-05-01 — all pre-0.4.0 grants will have expired by then
 			resourceMatchOriginOnly: true,
 			clientRegistrationEndpoint: '/register',
-		}).fetch(req, env, ctx)
+		}
+		return handleBenignDisconnect(new OAuthProvider(oauthOptions).fetch(req, env, ctx))
 	},
 }

--- a/apps/cloudflare-one-casb/src/cf1-casb.context.ts
+++ b/apps/cloudflare-one-casb/src/cf1-casb.context.ts
@@ -5,6 +5,7 @@ export interface Env {
 	MCP_SERVER_NAME: string
 	MCP_SERVER_VERSION: string
 	MCP_OBJECT: DurableObjectNamespace<CASBMCP>
+	OAUTH_KV: KVNamespace
 	MCP_METRICS: AnalyticsEngineDataset
 	AI: Ai
 	CLOUDFLARE_CLIENT_ID: string

--- a/apps/dex-analysis/src/dex-analysis.app.ts
+++ b/apps/dex-analysis/src/dex-analysis.app.ts
@@ -1,8 +1,9 @@
-import OAuthProvider from '@cloudflare/workers-oauth-provider'
+import OAuthProvider, { getOAuthApi } from '@cloudflare/workers-oauth-provider'
 import { McpAgent } from 'agents/mcp'
 
 import { AccountManager } from '@repo/mcp-common/src/account-manager'
 import { handleApiTokenMode, isApiTokenRequest } from '@repo/mcp-common/src/api-token-mode'
+import { handleBenignDisconnect } from '@repo/mcp-common/src/benign-disconnect'
 import {
 	createAuthHandlers,
 	handleTokenExchangeCallback,
@@ -82,10 +83,10 @@ const DexScopes = {
 export default {
 	fetch: async (req: Request, env: Env, ctx: ExecutionContext) => {
 		if (await isApiTokenRequest(req, env)) {
-			return await handleApiTokenMode(CloudflareDEXMCP, req, env, ctx)
+			return await handleBenignDisconnect(handleApiTokenMode(CloudflareDEXMCP, req, env, ctx))
 		}
 
-		return new OAuthProvider({
+		const oauthOptions: ConstructorParameters<typeof OAuthProvider<Env>>[0] = {
 			apiHandlers: {
 				'/mcp': CloudflareDEXMCP.serve('/mcp'),
 				'/sse': CloudflareDEXMCP.serveSSE('/sse'),
@@ -97,7 +98,9 @@ export default {
 				handleTokenExchangeCallback(
 					options,
 					env.CLOUDFLARE_CLIENT_ID,
-					env.CLOUDFLARE_CLIENT_SECRET
+					env.CLOUDFLARE_CLIENT_SECRET,
+					env.OAUTH_KV,
+					() => getOAuthApi(oauthOptions, env)
 				),
 			// Cloudflare access token TTL
 			accessTokenTTL: 3600,
@@ -105,6 +108,7 @@ export default {
 			// TODO: Remove after 2026-05-01 — all pre-0.4.0 grants will have expired by then
 			resourceMatchOriginOnly: true,
 			clientRegistrationEndpoint: '/register',
-		}).fetch(req, env, ctx)
+		}
+		return handleBenignDisconnect(new OAuthProvider(oauthOptions).fetch(req, env, ctx))
 	},
 }

--- a/apps/dns-analytics/src/dns-analytics.app.ts
+++ b/apps/dns-analytics/src/dns-analytics.app.ts
@@ -1,8 +1,9 @@
-import OAuthProvider from '@cloudflare/workers-oauth-provider'
+import OAuthProvider, { getOAuthApi } from '@cloudflare/workers-oauth-provider'
 import { McpAgent } from 'agents/mcp'
 
 import { AccountManager } from '@repo/mcp-common/src/account-manager'
 import { handleApiTokenMode, isApiTokenRequest } from '@repo/mcp-common/src/api-token-mode'
+import { handleBenignDisconnect } from '@repo/mcp-common/src/benign-disconnect'
 import {
 	createAuthHandlers,
 	handleTokenExchangeCallback,
@@ -85,10 +86,10 @@ const AnalyticsScopes = {
 export default {
 	fetch: async (req: Request, env: Env, ctx: ExecutionContext) => {
 		if (await isApiTokenRequest(req, env)) {
-			return await handleApiTokenMode(DNSAnalyticsMCP, req, env, ctx)
+			return await handleBenignDisconnect(handleApiTokenMode(DNSAnalyticsMCP, req, env, ctx))
 		}
 
-		return new OAuthProvider({
+		const oauthOptions: ConstructorParameters<typeof OAuthProvider<Env>>[0] = {
 			apiHandlers: {
 				'/mcp': DNSAnalyticsMCP.serve('/mcp'),
 				'/sse': DNSAnalyticsMCP.serveSSE('/sse'),
@@ -100,7 +101,9 @@ export default {
 				handleTokenExchangeCallback(
 					options,
 					env.CLOUDFLARE_CLIENT_ID,
-					env.CLOUDFLARE_CLIENT_SECRET
+					env.CLOUDFLARE_CLIENT_SECRET,
+					env.OAUTH_KV,
+					() => getOAuthApi(oauthOptions, env)
 				),
 			// Cloudflare access token TTL
 			accessTokenTTL: 3600,
@@ -108,6 +111,7 @@ export default {
 			// TODO: Remove after 2026-05-01 — all pre-0.4.0 grants will have expired by then
 			resourceMatchOriginOnly: true,
 			clientRegistrationEndpoint: '/register',
-		}).fetch(req, env, ctx)
+		}
+		return handleBenignDisconnect(new OAuthProvider(oauthOptions).fetch(req, env, ctx))
 	},
 }

--- a/apps/docs-ai-search/src/docs-ai-search.app.ts
+++ b/apps/docs-ai-search/src/docs-ai-search.app.ts
@@ -1,5 +1,6 @@
 import { createMcpHandler, McpAgent } from 'agents/mcp'
 
+import { handleBenignDisconnect } from '@repo/mcp-common/src/benign-disconnect'
 import { getEnv } from '@repo/mcp-common/src/env'
 import { registerPrompts } from '@repo/mcp-common/src/prompts/docs-ai-search.prompts'
 import { initSentry } from '@repo/mcp-common/src/sentry'
@@ -40,12 +41,12 @@ export default {
 	fetch: async (req: Request, env: Env, ctx: ExecutionContext) => {
 		const url = new URL(req.url)
 		if (url.pathname === '/sse' || url.pathname === '/sse/message') {
-			return sseHandler.fetch(req, env, ctx)
+			return handleBenignDisconnect(sseHandler.fetch(req, env, ctx))
 		}
 		if (url.pathname === '/mcp') {
 			const server = createMcpServer(env, ctx, req)
 			const mcpHandler = createMcpHandler(server)
-			return mcpHandler(req, env, ctx)
+			return handleBenignDisconnect(mcpHandler(req, env, ctx))
 		}
 		return new Response('Not found', { status: 404 })
 	},

--- a/apps/docs-vectorize/src/docs-vectorize.app.ts
+++ b/apps/docs-vectorize/src/docs-vectorize.app.ts
@@ -1,5 +1,6 @@
 import { createMcpHandler, McpAgent } from 'agents/mcp'
 
+import { handleBenignDisconnect } from '@repo/mcp-common/src/benign-disconnect'
 import { getEnv } from '@repo/mcp-common/src/env'
 import { registerPrompts } from '@repo/mcp-common/src/prompts/docs-vectorize.prompts'
 import { initSentry } from '@repo/mcp-common/src/sentry'
@@ -40,12 +41,12 @@ export default {
 	fetch: async (req: Request, env: Env, ctx: ExecutionContext) => {
 		const url = new URL(req.url)
 		if (url.pathname === '/sse' || url.pathname === '/sse/message') {
-			return sseHandler.fetch(req, env, ctx)
+			return handleBenignDisconnect(sseHandler.fetch(req, env, ctx))
 		}
 		if (url.pathname === '/mcp') {
 			const server = createMcpServer(env, ctx, req)
 			const mcpHandler = createMcpHandler(server)
-			return mcpHandler(req, env, ctx)
+			return handleBenignDisconnect(mcpHandler(req, env, ctx))
 		}
 		return new Response('Not found', { status: 404 })
 	},

--- a/apps/graphql/src/graphql.app.ts
+++ b/apps/graphql/src/graphql.app.ts
@@ -1,8 +1,9 @@
-import OAuthProvider from '@cloudflare/workers-oauth-provider'
+import OAuthProvider, { getOAuthApi } from '@cloudflare/workers-oauth-provider'
 import { McpAgent } from 'agents/mcp'
 
 import { AccountManager } from '@repo/mcp-common/src/account-manager'
 import { handleApiTokenMode, isApiTokenRequest } from '@repo/mcp-common/src/api-token-mode'
+import { handleBenignDisconnect } from '@repo/mcp-common/src/benign-disconnect'
 import {
 	createAuthHandlers,
 	handleTokenExchangeCallback,
@@ -87,10 +88,10 @@ const GraphQLScopes = {
 export default {
 	fetch: async (req: Request, env: Env, ctx: ExecutionContext) => {
 		if (await isApiTokenRequest(req, env)) {
-			return await handleApiTokenMode(GraphQLMCP, req, env, ctx)
+			return await handleBenignDisconnect(handleApiTokenMode(GraphQLMCP, req, env, ctx))
 		}
 
-		return new OAuthProvider({
+		const oauthOptions: ConstructorParameters<typeof OAuthProvider<Env>>[0] = {
 			apiHandlers: {
 				'/mcp': GraphQLMCP.serve('/mcp'),
 				'/sse': GraphQLMCP.serveSSE('/sse'),
@@ -102,7 +103,9 @@ export default {
 				handleTokenExchangeCallback(
 					options,
 					env.CLOUDFLARE_CLIENT_ID,
-					env.CLOUDFLARE_CLIENT_SECRET
+					env.CLOUDFLARE_CLIENT_SECRET,
+					env.OAUTH_KV,
+					() => getOAuthApi(oauthOptions, env)
 				),
 			// Cloudflare access token TTL
 			accessTokenTTL: 3600,
@@ -110,6 +113,7 @@ export default {
 			// TODO: Remove after 2026-05-01 — all pre-0.4.0 grants will have expired by then
 			resourceMatchOriginOnly: true,
 			clientRegistrationEndpoint: '/register',
-		}).fetch(req, env, ctx)
+		}
+		return handleBenignDisconnect(new OAuthProvider(oauthOptions).fetch(req, env, ctx))
 	},
 }

--- a/apps/logpush/src/logpush.app.ts
+++ b/apps/logpush/src/logpush.app.ts
@@ -1,8 +1,9 @@
-import OAuthProvider from '@cloudflare/workers-oauth-provider'
+import OAuthProvider, { getOAuthApi } from '@cloudflare/workers-oauth-provider'
 import { McpAgent } from 'agents/mcp'
 
 import { AccountManager } from '@repo/mcp-common/src/account-manager'
 import { handleApiTokenMode, isApiTokenRequest } from '@repo/mcp-common/src/api-token-mode'
+import { handleBenignDisconnect } from '@repo/mcp-common/src/benign-disconnect'
 import {
 	createAuthHandlers,
 	handleTokenExchangeCallback,
@@ -79,10 +80,10 @@ const LogPushScopes = {
 export default {
 	fetch: async (req: Request, env: Env, ctx: ExecutionContext) => {
 		if (await isApiTokenRequest(req, env)) {
-			return await handleApiTokenMode(LogsMCP, req, env, ctx)
+			return await handleBenignDisconnect(handleApiTokenMode(LogsMCP, req, env, ctx))
 		}
 
-		return new OAuthProvider({
+		const oauthOptions: ConstructorParameters<typeof OAuthProvider<Env>>[0] = {
 			apiHandlers: {
 				'/mcp': LogsMCP.serve('/mcp'),
 				'/sse': LogsMCP.serveSSE('/sse'),
@@ -94,7 +95,9 @@ export default {
 				handleTokenExchangeCallback(
 					options,
 					env.CLOUDFLARE_CLIENT_ID,
-					env.CLOUDFLARE_CLIENT_SECRET
+					env.CLOUDFLARE_CLIENT_SECRET,
+					env.OAUTH_KV,
+					() => getOAuthApi(oauthOptions, env)
 				),
 			// Cloudflare access token TTL
 			accessTokenTTL: 3600,
@@ -102,6 +105,7 @@ export default {
 			// TODO: Remove after 2026-05-01 — all pre-0.4.0 grants will have expired by then
 			resourceMatchOriginOnly: true,
 			clientRegistrationEndpoint: '/register',
-		}).fetch(req, env, ctx)
+		}
+		return handleBenignDisconnect(new OAuthProvider(oauthOptions).fetch(req, env, ctx))
 	},
 }

--- a/apps/radar/src/radar.app.ts
+++ b/apps/radar/src/radar.app.ts
@@ -1,8 +1,9 @@
-import OAuthProvider from '@cloudflare/workers-oauth-provider'
+import OAuthProvider, { getOAuthApi } from '@cloudflare/workers-oauth-provider'
 import { McpAgent } from 'agents/mcp'
 
 import { AccountManager } from '@repo/mcp-common/src/account-manager'
 import { handleApiTokenMode, isApiTokenRequest } from '@repo/mcp-common/src/api-token-mode'
+import { handleBenignDisconnect } from '@repo/mcp-common/src/benign-disconnect'
 import {
 	createAuthHandlers,
 	handleTokenExchangeCallback,
@@ -115,10 +116,10 @@ const RadarScopes = {
 export default {
 	fetch: async (req: Request, env: Env, ctx: ExecutionContext) => {
 		if (await isApiTokenRequest(req, env)) {
-			return await handleApiTokenMode(RadarMCP, req, env, ctx)
+			return await handleBenignDisconnect(handleApiTokenMode(RadarMCP, req, env, ctx))
 		}
 
-		return new OAuthProvider({
+		const oauthOptions: ConstructorParameters<typeof OAuthProvider<Env>>[0] = {
 			apiHandlers: {
 				'/mcp': RadarMCP.serve('/mcp'),
 				'/sse': RadarMCP.serveSSE('/sse'),
@@ -130,7 +131,9 @@ export default {
 				handleTokenExchangeCallback(
 					options,
 					env.CLOUDFLARE_CLIENT_ID,
-					env.CLOUDFLARE_CLIENT_SECRET
+					env.CLOUDFLARE_CLIENT_SECRET,
+					env.OAUTH_KV,
+					() => getOAuthApi(oauthOptions, env)
 				),
 			// Cloudflare access token TTL
 			accessTokenTTL: 3600,
@@ -138,6 +141,7 @@ export default {
 			// TODO: Remove after 2026-05-01 — all pre-0.4.0 grants will have expired by then
 			resourceMatchOriginOnly: true,
 			clientRegistrationEndpoint: '/register',
-		}).fetch(req, env, ctx)
+		}
+		return handleBenignDisconnect(new OAuthProvider(oauthOptions).fetch(req, env, ctx))
 	},
 }

--- a/apps/sandbox-container/server/sandbox.server.app.ts
+++ b/apps/sandbox-container/server/sandbox.server.app.ts
@@ -1,7 +1,8 @@
-import OAuthProvider from '@cloudflare/workers-oauth-provider'
+import OAuthProvider, { getOAuthApi } from '@cloudflare/workers-oauth-provider'
 
 import { createApiHandler } from '@repo/mcp-common/src/api-handler'
 import { handleApiTokenMode, isApiTokenRequest } from '@repo/mcp-common/src/api-token-mode'
+import { handleBenignDisconnect } from '@repo/mcp-common/src/benign-disconnect'
 import {
 	createAuthHandlers,
 	handleTokenExchangeCallback,
@@ -38,10 +39,10 @@ const ContainerScopes = {
 export default {
 	fetch: async (req: Request, env: Env, ctx: ExecutionContext) => {
 		if (await isApiTokenRequest(req, env)) {
-			return await handleApiTokenMode(ContainerMcpAgent, req, env, ctx)
+			return await handleBenignDisconnect(handleApiTokenMode(ContainerMcpAgent, req, env, ctx))
 		}
 
-		return new OAuthProvider({
+		const oauthOptions: ConstructorParameters<typeof OAuthProvider<Env>>[0] = {
 			apiRoute: ['/mcp', '/sse'],
 			apiHandler: createApiHandler(ContainerMcpAgent),
 			defaultHandler: createAuthHandlers({ scopes: ContainerScopes, metrics }),
@@ -51,7 +52,9 @@ export default {
 				handleTokenExchangeCallback(
 					options,
 					env.CLOUDFLARE_CLIENT_ID,
-					env.CLOUDFLARE_CLIENT_SECRET
+					env.CLOUDFLARE_CLIENT_SECRET,
+					env.OAUTH_KV,
+					() => getOAuthApi(oauthOptions, env)
 				),
 			// Cloudflare access token TTL
 			accessTokenTTL: 3600,
@@ -59,6 +62,7 @@ export default {
 			// TODO: Remove after 2026-05-01 — all pre-0.4.0 grants will have expired by then
 			resourceMatchOriginOnly: true,
 			clientRegistrationEndpoint: '/register',
-		}).fetch(req, env, ctx)
+		}
+		return handleBenignDisconnect(new OAuthProvider(oauthOptions).fetch(req, env, ctx))
 	},
 }

--- a/apps/workers-bindings/src/bindings.app.ts
+++ b/apps/workers-bindings/src/bindings.app.ts
@@ -1,8 +1,9 @@
-import OAuthProvider from '@cloudflare/workers-oauth-provider'
+import OAuthProvider, { getOAuthApi } from '@cloudflare/workers-oauth-provider'
 import { McpAgent } from 'agents/mcp'
 
 import { AccountManager } from '@repo/mcp-common/src/account-manager'
 import { handleApiTokenMode, isApiTokenRequest } from '@repo/mcp-common/src/api-token-mode'
+import { handleBenignDisconnect } from '@repo/mcp-common/src/benign-disconnect'
 import {
 	createAuthHandlers,
 	handleTokenExchangeCallback,
@@ -95,10 +96,10 @@ export default {
 	fetch: async (req: Request, env: Env, ctx: ExecutionContext) => {
 		if (await isApiTokenRequest(req, env)) {
 			console.log('is token mode')
-			return await handleApiTokenMode(WorkersBindingsMCP, req, env, ctx)
+			return await handleBenignDisconnect(handleApiTokenMode(WorkersBindingsMCP, req, env, ctx))
 		}
 
-		return new OAuthProvider({
+		const oauthOptions: ConstructorParameters<typeof OAuthProvider<Env>>[0] = {
 			apiHandlers: {
 				'/mcp': WorkersBindingsMCP.serve('/mcp'),
 				'/sse': WorkersBindingsMCP.serveSSE('/sse'),
@@ -110,7 +111,9 @@ export default {
 				handleTokenExchangeCallback(
 					options,
 					env.CLOUDFLARE_CLIENT_ID,
-					env.CLOUDFLARE_CLIENT_SECRET
+					env.CLOUDFLARE_CLIENT_SECRET,
+					env.OAUTH_KV,
+					() => getOAuthApi(oauthOptions, env)
 				),
 			// Cloudflare access token TTL
 			accessTokenTTL: 3600,
@@ -118,6 +121,7 @@ export default {
 			// TODO: Remove after 2026-05-01 — all pre-0.4.0 grants will have expired by then
 			resourceMatchOriginOnly: true,
 			clientRegistrationEndpoint: '/register',
-		}).fetch(req, env, ctx)
+		}
+		return handleBenignDisconnect(new OAuthProvider(oauthOptions).fetch(req, env, ctx))
 	},
 }

--- a/apps/workers-builds/src/workers-builds.app.ts
+++ b/apps/workers-builds/src/workers-builds.app.ts
@@ -1,8 +1,9 @@
-import OAuthProvider from '@cloudflare/workers-oauth-provider'
+import OAuthProvider, { getOAuthApi } from '@cloudflare/workers-oauth-provider'
 import { McpAgent } from 'agents/mcp'
 
 import { AccountManager } from '@repo/mcp-common/src/account-manager'
 import { handleApiTokenMode, isApiTokenRequest } from '@repo/mcp-common/src/api-token-mode'
+import { handleBenignDisconnect } from '@repo/mcp-common/src/benign-disconnect'
 import {
 	createAuthHandlers,
 	handleTokenExchangeCallback,
@@ -142,10 +143,10 @@ const BuildsScopes = {
 export default {
 	fetch: async (req: Request, env: Env, ctx: ExecutionContext) => {
 		if (await isApiTokenRequest(req, env)) {
-			return await handleApiTokenMode(BuildsMCP, req, env, ctx)
+			return await handleBenignDisconnect(handleApiTokenMode(BuildsMCP, req, env, ctx))
 		}
 
-		return new OAuthProvider({
+		const oauthOptions: ConstructorParameters<typeof OAuthProvider<Env>>[0] = {
 			apiHandlers: {
 				'/mcp': BuildsMCP.serve('/mcp'),
 				'/sse': BuildsMCP.serveSSE('/sse'),
@@ -157,7 +158,9 @@ export default {
 				handleTokenExchangeCallback(
 					options,
 					env.CLOUDFLARE_CLIENT_ID,
-					env.CLOUDFLARE_CLIENT_SECRET
+					env.CLOUDFLARE_CLIENT_SECRET,
+					env.OAUTH_KV,
+					() => getOAuthApi(oauthOptions, env)
 				),
 			// Cloudflare access token TTL
 			accessTokenTTL: 3600,
@@ -165,6 +168,7 @@ export default {
 			// TODO: Remove after 2026-05-01 — all pre-0.4.0 grants will have expired by then
 			resourceMatchOriginOnly: true,
 			clientRegistrationEndpoint: '/register',
-		}).fetch(req, env, ctx)
+		}
+		return handleBenignDisconnect(new OAuthProvider(oauthOptions).fetch(req, env, ctx))
 	},
 }

--- a/apps/workers-observability/src/workers-observability.app.ts
+++ b/apps/workers-observability/src/workers-observability.app.ts
@@ -1,8 +1,9 @@
-import OAuthProvider from '@cloudflare/workers-oauth-provider'
+import OAuthProvider, { getOAuthApi } from '@cloudflare/workers-oauth-provider'
 import { McpAgent } from 'agents/mcp'
 
 import { AccountManager } from '@repo/mcp-common/src/account-manager'
 import { handleApiTokenMode, isApiTokenRequest } from '@repo/mcp-common/src/api-token-mode'
+import { handleBenignDisconnect } from '@repo/mcp-common/src/benign-disconnect'
 import {
 	createAuthHandlers,
 	handleTokenExchangeCallback,
@@ -101,10 +102,10 @@ const ObservabilityScopes = {
 export default {
 	fetch: async (req: Request, env: Env, ctx: ExecutionContext) => {
 		if (await isApiTokenRequest(req, env)) {
-			return await handleApiTokenMode(ObservabilityMCP, req, env, ctx)
+			return await handleBenignDisconnect(handleApiTokenMode(ObservabilityMCP, req, env, ctx))
 		}
 
-		return new OAuthProvider({
+		const oauthOptions: ConstructorParameters<typeof OAuthProvider<Env>>[0] = {
 			apiHandlers: {
 				'/mcp': ObservabilityMCP.serve('/mcp'),
 				'/sse': ObservabilityMCP.serveSSE('/sse'),
@@ -116,7 +117,9 @@ export default {
 				handleTokenExchangeCallback(
 					options,
 					env.CLOUDFLARE_CLIENT_ID,
-					env.CLOUDFLARE_CLIENT_SECRET
+					env.CLOUDFLARE_CLIENT_SECRET,
+					env.OAUTH_KV,
+					() => getOAuthApi(oauthOptions, env)
 				),
 			// Cloudflare access token TTL
 			accessTokenTTL: 3600,
@@ -124,6 +127,7 @@ export default {
 			// TODO: Remove after 2026-05-01 — all pre-0.4.0 grants will have expired by then
 			resourceMatchOriginOnly: true,
 			clientRegistrationEndpoint: '/register',
-		}).fetch(req, env, ctx)
+		}
+		return handleBenignDisconnect(new OAuthProvider(oauthOptions).fetch(req, env, ctx))
 	},
 }

--- a/packages/mcp-common/src/benign-disconnect.ts
+++ b/packages/mcp-common/src/benign-disconnect.ts
@@ -1,0 +1,15 @@
+export function isBenignDisconnectError(error: unknown): boolean {
+	return error instanceof Error && error.message === 'destroyed'
+}
+
+export async function handleBenignDisconnect(response: Promise<Response>): Promise<Response> {
+	try {
+		return await response
+	} catch (error) {
+		if (isBenignDisconnectError(error)) {
+			console.warn('MCP connection closed while request was in flight', error)
+			return new Response(null, { status: 499 })
+		}
+		throw error
+	}
+}

--- a/packages/mcp-common/src/cloudflare-oauth-handler.spec.ts
+++ b/packages/mcp-common/src/cloudflare-oauth-handler.spec.ts
@@ -1,4 +1,4 @@
-import { GrantType } from '@cloudflare/workers-oauth-provider'
+import { GrantType, OAuthError as ProviderOAuthError } from '@cloudflare/workers-oauth-provider'
 import { http, HttpResponse } from 'msw'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -196,7 +196,8 @@ describe('handleTokenExchangeCallback', () => {
 				expect(e).toBeInstanceOf(OAuthError)
 				const err = e as OAuthError
 				expect(err.code).toBe('temporarily_unavailable')
-				expect(err.statusCode).toBe(503)
+				expect(err.statusCode).toBe(429)
+				expect(err).toBeInstanceOf(ProviderOAuthError)
 			}
 		})
 

--- a/packages/mcp-common/src/cloudflare-oauth-handler.ts
+++ b/packages/mcp-common/src/cloudflare-oauth-handler.ts
@@ -54,6 +54,226 @@ function mcpErrorToOAuthResponse(e: McpError): Response {
 	return new OAuthError(oauthCode, e.message, e.code >= 500 ? 500 : e.code).toResponse()
 }
 
+const REFRESH_GUARD_PREFIX = 'oauth:refresh-guard'
+const REFRESH_IN_FLIGHT_TTL_SECONDS = 60
+const REFRESH_FAILURE_TTL_SECONDS = 3600
+const refreshInFlight = new Map<string, Promise<TokenExchangeCallbackResult | undefined>>()
+
+type RefreshGuardContext = {
+	userId?: string
+	clientId?: string
+	getHelpers?: () => OAuthHelpers
+}
+
+type RefreshFailureKind = 'upstream_terminal' | 'cached_replay' | 'in_flight_collision'
+
+async function sha256Hex(value: string): Promise<string> {
+	const data = new TextEncoder().encode(value)
+	const digest = await crypto.subtle.digest('SHA-256', data)
+	return Array.from(new Uint8Array(digest))
+		.map((byte) => byte.toString(16).padStart(2, '0'))
+		.join('')
+}
+
+function refreshGuardKeys(refreshTokenHash: string): { inFlight: string; failure: string } {
+	return {
+		inFlight: `${REFRESH_GUARD_PREFIX}:${refreshTokenHash}:in-flight`,
+		failure: `${REFRESH_GUARD_PREFIX}:${refreshTokenHash}:failure`,
+	}
+}
+
+function isTerminalRefreshError(error: unknown): error is OAuthError {
+	return (
+		error instanceof OAuthError &&
+		['invalid_grant', 'invalid_client', 'unauthorized_client'].includes(error.code)
+	)
+}
+
+function logRefreshTelemetry(event: {
+	kind: RefreshFailureKind
+	code: string
+	refreshTokenHash: string
+	userId?: string
+	clientId?: string
+	grantsRevoked?: number
+}): void {
+	console.warn(`[refresh-telemetry] ${JSON.stringify({ ...event, at: Date.now() })}`)
+}
+
+async function revokeGrantsForClient(
+	helpers: OAuthHelpers,
+	userId: string,
+	clientId: string
+): Promise<number> {
+	let revoked = 0
+	let cursor: string | undefined
+	do {
+		const page = await helpers.listUserGrants(userId, cursor ? { cursor } : undefined)
+		for (const grant of page.items) {
+			if (grant.clientId !== clientId) continue
+			await helpers.revokeGrant(grant.id, userId)
+			revoked++
+		}
+		cursor = page.cursor
+	} while (cursor)
+	return revoked
+}
+
+async function getCachedRefreshFailure(
+	kv: KVNamespace,
+	failureKey: string
+): Promise<{ code?: string; description?: string } | null> {
+	try {
+		const failure = await kv.get(failureKey, { type: 'json' })
+		if (!failure || typeof failure !== 'object') return null
+		return failure as { code?: string; description?: string }
+	} catch (error) {
+		console.warn('Refresh guard: failed to read cached refresh failure', error)
+		return null
+	}
+}
+
+async function isRefreshInFlight(kv: KVNamespace, inFlightKey: string): Promise<boolean> {
+	try {
+		return Boolean(await kv.get(inFlightKey))
+	} catch (error) {
+		console.warn('Refresh guard: failed to read in-flight marker', error)
+		return false
+	}
+}
+
+async function markRefreshInFlight(kv: KVNamespace, inFlightKey: string): Promise<void> {
+	try {
+		await kv.put(inFlightKey, JSON.stringify({ startedAt: Date.now() }), {
+			expirationTtl: REFRESH_IN_FLIGHT_TTL_SECONDS,
+		})
+	} catch (error) {
+		console.warn('Refresh guard: failed to write in-flight marker', error)
+	}
+}
+
+async function cacheRefreshFailure(
+	kv: KVNamespace,
+	failureKey: string,
+	error: OAuthError
+): Promise<void> {
+	try {
+		await kv.put(
+			failureKey,
+			JSON.stringify({
+				code: error.code,
+				description: 'Token refresh failed; reauthorization is required',
+				failedAt: Date.now(),
+			}),
+			{ expirationTtl: REFRESH_FAILURE_TTL_SECONDS }
+		)
+	} catch (cacheError) {
+		console.warn('Refresh guard: failed to cache terminal refresh failure', cacheError)
+	}
+}
+
+async function clearRefreshInFlight(kv: KVNamespace, inFlightKey: string): Promise<void> {
+	try {
+		await kv.delete(inFlightKey)
+	} catch (error) {
+		console.warn('Refresh guard: failed to clear in-flight marker', error)
+	}
+}
+
+export async function guardRefreshTokenExchange(
+	kv: KVNamespace,
+	refreshToken: string,
+	refresh: () => Promise<TokenExchangeCallbackResult | undefined>,
+	context: RefreshGuardContext = {}
+): Promise<TokenExchangeCallbackResult | undefined> {
+	const refreshTokenHash = await sha256Hex(refreshToken)
+	const keys = refreshGuardKeys(refreshTokenHash)
+	const existingRefresh = refreshInFlight.get(refreshTokenHash)
+	if (existingRefresh) return existingRefresh
+
+	const refreshPromise = (async () => {
+		try {
+			const cachedFailure = await getCachedRefreshFailure(kv, keys.failure)
+			if (cachedFailure) {
+				const code = cachedFailure.code || 'invalid_grant'
+				logRefreshTelemetry({
+					kind: 'cached_replay',
+					code,
+					refreshTokenHash,
+					userId: context.userId,
+					clientId: context.clientId,
+				})
+				throw new OAuthError(
+					code,
+					cachedFailure.description || 'Token refresh recently failed; reauthorization is required',
+					400
+				)
+			}
+
+			if (await isRefreshInFlight(kv, keys.inFlight)) {
+				logRefreshTelemetry({
+					kind: 'in_flight_collision',
+					code: 'temporarily_unavailable',
+					refreshTokenHash,
+					userId: context.userId,
+					clientId: context.clientId,
+				})
+				throw new OAuthError(
+					'temporarily_unavailable',
+					'Token refresh is already in progress; retry shortly',
+					429,
+					{ 'Retry-After': '30' }
+				)
+			}
+
+			await markRefreshInFlight(kv, keys.inFlight)
+
+			try {
+				return await refresh()
+			} catch (error) {
+				if (isTerminalRefreshError(error)) {
+					await cacheRefreshFailure(kv, keys.failure, error)
+
+					let grantsRevoked = 0
+					if (
+						error.code === 'invalid_grant' &&
+						context.userId &&
+						context.clientId &&
+						context.getHelpers
+					) {
+						try {
+							grantsRevoked = await revokeGrantsForClient(
+								context.getHelpers(),
+								context.userId,
+								context.clientId
+							)
+						} catch (revokeError) {
+							console.warn('Refresh guard: failed to revoke grant after invalid_grant', revokeError)
+						}
+					}
+
+					logRefreshTelemetry({
+						kind: 'upstream_terminal',
+						code: error.code,
+						refreshTokenHash,
+						userId: context.userId,
+						clientId: context.clientId,
+						grantsRevoked,
+					})
+				}
+				throw error
+			} finally {
+				await clearRefreshInFlight(kv, keys.inFlight)
+			}
+		} finally {
+			refreshInFlight.delete(refreshTokenHash)
+		}
+	})()
+
+	refreshInFlight.set(refreshTokenHash, refreshPromise)
+	return refreshPromise
+}
+
 type AuthContext = {
 	Bindings: {
 		OAUTH_PROVIDER: OAuthHelpers
@@ -270,7 +490,9 @@ async function getTokenAndUserDetails(
 export async function handleTokenExchangeCallback(
 	options: TokenExchangeCallbackOptions,
 	clientId: string,
-	clientSecret: string
+	clientSecret: string,
+	kv?: KVNamespace,
+	getHelpers?: () => OAuthHelpers
 ): Promise<TokenExchangeCallbackResult | undefined> {
 	// options.props contains the current props
 	if (options.grantType === GrantType.REFRESH_TOKEN) {
@@ -283,50 +505,58 @@ export async function handleTokenExchangeCallback(
 			throw new OAuthError('invalid_grant', 'No refresh token available for this grant', 400)
 		}
 
-		// handle token refreshes — convert upstream McpErrors to OAuth-compliant errors
-		let accessToken: string
-		let refreshToken: string
-		let expires_in: number
-		try {
-			const result = await refreshAuthToken({
-				client_id: clientId,
-				client_secret: clientSecret,
-				refresh_token: props.refreshToken,
-			})
-			accessToken = result.access_token
-			refreshToken = result.refresh_token
-			expires_in = result.expires_in
-		} catch (e) {
-			if (e instanceof McpError) {
-				// Map upstream failures to OAuth error codes per RFC 6749
-				let oauthCode: string
-				let httpStatus: number
-				if (e.code >= 500) {
-					oauthCode = 'server_error'
-					httpStatus = 500
-				} else if (e.code === 429) {
-					oauthCode = 'temporarily_unavailable'
-					httpStatus = 503
-				} else if (e.code === 401) {
-					oauthCode = 'invalid_client'
-					httpStatus = 401
-				} else {
-					oauthCode = 'invalid_grant'
-					httpStatus = 400
+		const upstreamRefreshToken = props.refreshToken
+		const refresh = async (): Promise<TokenExchangeCallbackResult | undefined> => {
+			try {
+				const result = await refreshAuthToken({
+					client_id: clientId,
+					client_secret: clientSecret,
+					refresh_token: upstreamRefreshToken,
+				})
+
+				return {
+					newProps: {
+						...options.props,
+						accessToken: result.access_token,
+						refreshToken: result.refresh_token,
+					} satisfies AuthProps,
+					accessTokenTTL: result.expires_in,
 				}
-				throw new OAuthError(oauthCode, e.message, httpStatus)
+			} catch (e) {
+				if (e instanceof McpError) {
+					// Map upstream failures to OAuth error codes per RFC 6749
+					let oauthCode: string
+					let httpStatus: number
+					const headers: Record<string, string> = {}
+					if (e.code >= 500) {
+						oauthCode = 'server_error'
+						httpStatus = 500
+					} else if (e.code === 429) {
+						oauthCode = 'temporarily_unavailable'
+						httpStatus = 429
+						headers['Retry-After'] = '30'
+					} else if (e.code === 401) {
+						oauthCode = 'invalid_client'
+						httpStatus = 401
+					} else {
+						oauthCode = 'invalid_grant'
+						httpStatus = 400
+					}
+					throw new OAuthError(oauthCode, e.message, httpStatus, headers)
+				}
+				throw e
 			}
-			throw e
 		}
 
-		return {
-			newProps: {
-				...options.props,
-				accessToken,
-				refreshToken,
-			} satisfies AuthProps,
-			accessTokenTTL: expires_in,
+		if (!kv) {
+			return refresh()
 		}
+
+		return guardRefreshTokenExchange(kv, upstreamRefreshToken, refresh, {
+			userId: options.userId,
+			clientId: options.clientId,
+			getHelpers,
+		})
 	}
 }
 

--- a/packages/mcp-common/src/workers-oauth-utils.ts
+++ b/packages/mcp-common/src/workers-oauth-utils.ts
@@ -1,3 +1,4 @@
+import { OAuthError as ProviderOAuthError } from '@cloudflare/workers-oauth-provider'
 import { z } from 'zod'
 
 import type { AuthRequest, ClientInfo } from '@cloudflare/workers-oauth-provider'
@@ -6,16 +7,19 @@ const COOKIE_NAME = '__Host-MCP_APPROVED_CLIENTS'
 const ONE_YEAR_IN_SECONDS = 31536000
 
 /**
- * OAuth error class for handling OAuth-specific errors
+ * OAuth error class for handling OAuth-specific errors.
+ *
+ * Extends the provider's OAuthError so errors thrown from tokenExchangeCallback
+ * are converted into structured /token responses instead of surfacing as 500s.
  */
-export class OAuthError extends Error {
+export class OAuthError extends ProviderOAuthError {
 	constructor(
-		public code: string,
-		public description: string,
-		public statusCode = 400
+		code: string,
+		description: string,
+		statusCode = 400,
+		headers: Record<string, string> = {}
 	) {
-		super(description)
-		this.name = 'OAuthError'
+		super(code, { description, statusCode, headers })
 	}
 
 	toResponse(): Response {
@@ -26,7 +30,7 @@ export class OAuthError extends Error {
 			}),
 			{
 				status: this.statusCode,
-				headers: { 'Content-Type': 'application/json' },
+				headers: { 'Content-Type': 'application/json', ...this.headers },
 			}
 		)
 	}


### PR DESCRIPTION
## Summary

- Port the cloudflare-mcp refresh guard into shared `mcp-common`.
- Convert local OAuth errors to extend the provider OAuthError so token callback failures become structured `/token` OAuth responses instead of raw 500s.
- Add in-isolate singleflight, KV in-flight markers, terminal failure caching, and downstream grant revocation for upstream `invalid_grant`.
- Wrap MCP/DO request handling for benign `destroyed` disconnects and log them as warnings.

## Why

Fleet logs showed repeated upstream refresh-token `invalid_grant` errors across MCP workers. Once the upstream refresh token is permanently dead, retrying the downstream grant loops forever and floods logs. This makes the shared OAuth handler fail fast and force reauthorization.

## Validation

- `pnpm --filter @repo/mcp-common test`
- `pnpm exec turbo check:types --filter=@repo/mcp-common --filter=cloudflare-ai-gateway-mcp-server --filter=auditlogs --filter=cloudflare-autorag-mcp-server --filter=cloudflare-browser-mcp-server --filter=cloudflare-casb-mcp-server --filter=dex-analysis --filter=dns-analytics --filter=graphql-mcp-server --filter=logpush --filter=cloudflare-radar-mcp-server --filter=containers-mcp --filter=workers-bindings --filter=workers-builds --filter=workers-observability --filter=docs-ai-search --filter=docs-vectorize`
- `pnpm check:format` (passes; prettier plugin prints existing `import sorting aborted due to babel parsing error` warning)
