### PR TITLE
Fix malformed API token auth handling

### DIFF
--- a/.changeset/api-token-error-handling.md
+++ b/.changeset/api-token-error-handling.md
@@ -1,0 +1,5 @@
+---
+"@repo/mcp-common": patch
+---
+
+Handle malformed direct API-token requests as structured client auth responses, use credential ownership prefixes to avoid unnecessary identity probes while retaining Wrangler OAuth and legacy compatibility, preserve rate-limit backoff, and downgrade expected authentication failures from error logging.

--- a/apps/ai-gateway/src/auth-integration.spec.ts
+++ b/apps/ai-gateway/src/auth-integration.spec.ts
@@ -185,17 +185,16 @@ describe('AI Gateway exported Worker authentication', () => {
 			})
 		)
 
+		const tokens = ['a'.repeat(40), 'b'.repeat(40)]
 		const [first, second] = await Promise.all(
-			['api-a', 'api-b'].map((token) =>
-				worker.fetch(toolRequest(token), testEnv, executionContext())
-			)
+			tokens.map((token) => worker.fetch(toolRequest(token), testEnv, executionContext()))
 		)
 		const documents = await Promise.all([responseDocument(first), responseDocument(second)])
 
 		expect([first.status, second.status]).toEqual([200, 200])
-		expect(documents[0].result.content[0].text).toContain('account-api-a:api-a')
-		expect(documents[1].result.content[0].text).toContain('account-api-b:api-b')
-		expect(getCloudflareClientMock).toHaveBeenCalledWith('api-a')
-		expect(getCloudflareClientMock).toHaveBeenCalledWith('api-b')
+		expect(documents[0].result.content[0].text).toContain(`account-${tokens[0]}:${tokens[0]}`)
+		expect(documents[1].result.content[0].text).toContain(`account-${tokens[1]}:${tokens[1]}`)
+		expect(getCloudflareClientMock).toHaveBeenCalledWith(tokens[0])
+		expect(getCloudflareClientMock).toHaveBeenCalledWith(tokens[1])
 	})
 })

--- a/packages/mcp-common/src/api-token-mode.spec.ts
+++ b/packages/mcp-common/src/api-token-mode.spec.ts
@@ -38,8 +38,12 @@ function mockCloudflareIdentity() {
 }
 
 describe('API-token request scope', () => {
-	it('distinguishes external API tokens from provider-issued tokens', async () => {
-		expect(await isApiTokenRequest(request('opaque-api-token'), env)).toBe(true)
+	it('distinguishes Cloudflare bearer credentials from MCP provider tokens', async () => {
+		expect(await isApiTokenRequest(request('cfut_test-user-token'), env)).toBe(true)
+		expect(await isApiTokenRequest(request('cfat_test-account-token'), env)).toBe(true)
+		expect(await isApiTokenRequest(request('cfoat_test-wrangler-token'), env)).toBe(true)
+		expect(await isApiTokenRequest(request('a'.repeat(40)), env)).toBe(true)
+		expect(await isApiTokenRequest(request('legacy-unknown-shape'), env)).toBe(true)
 		expect(await isApiTokenRequest(request('user:grant:secret'), env)).toBe(false)
 	})
 
@@ -51,6 +55,85 @@ describe('API-token request scope', () => {
 			user: { id: 'user-1', email: 'user@example.com' },
 			accounts: [{ id: 'account-1', name: 'Account One' }],
 		})
+	})
+
+	it('uses only the accounts probe for a prefixed account token', async () => {
+		let userCalls = 0
+		let accountsCalls = 0
+		server.use(
+			http.get('https://api.cloudflare.com/client/v4/user', () => {
+				userCalls += 1
+				return HttpResponse.json({ success: false }, { status: 500 })
+			}),
+			http.get('https://api.cloudflare.com/client/v4/accounts', () => {
+				accountsCalls += 1
+				return HttpResponse.json({
+					success: true,
+					result: [{ id: 'account-1', name: 'Account One' }],
+					errors: [],
+					messages: [],
+				})
+			})
+		)
+
+		await expect(getApiTokenProps(request('cfat_test-account-token'), env)).resolves.toEqual({
+			type: 'account_token',
+			accessToken: 'cfat_test-account-token',
+			account: { id: 'account-1', name: 'Account One' },
+		})
+		expect(userCalls).toBe(0)
+		expect(accountsCalls).toBe(1)
+	})
+
+	it('rejects a prefixed account token that does not resolve to exactly one account', async () => {
+		server.use(
+			http.get('https://api.cloudflare.com/client/v4/accounts', () =>
+				HttpResponse.json({
+					success: true,
+					result: [
+						{ id: 'account-1', name: 'Account One' },
+						{ id: 'account-2', name: 'Account Two' },
+					],
+					errors: [],
+					messages: [],
+				})
+			)
+		)
+
+		await expect(getApiTokenProps(request('cfat_test-account-token'), env)).rejects.toMatchObject({
+			code: 401,
+		})
+	})
+
+	it('keeps both identity probes for user, Wrangler OAuth, and legacy tokens', async () => {
+		let userCalls = 0
+		let accountsCalls = 0
+		server.use(
+			http.get('https://api.cloudflare.com/client/v4/user', () => {
+				userCalls += 1
+				return HttpResponse.json({
+					success: true,
+					result: { id: 'user-1', email: 'user@example.com' },
+					errors: [],
+					messages: [],
+				})
+			}),
+			http.get('https://api.cloudflare.com/client/v4/accounts', () => {
+				accountsCalls += 1
+				return HttpResponse.json({
+					success: true,
+					result: [{ id: 'account-1', name: 'Account One' }],
+					errors: [],
+					messages: [],
+				})
+			})
+		)
+
+		await getApiTokenProps(request('cfut_test-user-token'), env)
+		await getApiTokenProps(request('cfoat_test-wrangler-token'), env)
+		await getApiTokenProps(request('l'.repeat(40)), env)
+		expect(userCalls).toBe(3)
+		expect(accountsCalls).toBe(3)
 	})
 
 	it('sets props only on the request ExecutionContext passed to the stateless handler', async () => {

--- a/packages/mcp-common/src/api-token-mode.ts
+++ b/packages/mcp-common/src/api-token-mode.ts
@@ -1,6 +1,8 @@
 import { getUserAndAccounts } from './cloudflare-oauth-handler'
+import { McpError } from './mcp-error'
 
 import type { AuthProps } from './auth-props'
+import type { CloudflareTokenOwner } from './cloudflare-oauth-handler'
 
 interface RequiredEnv {
 	DEV_CLOUDFLARE_API_TOKEN: string
@@ -10,6 +12,12 @@ interface RequiredEnv {
 
 export interface RequestHandler<Env> {
 	fetch(req: Request, env: Env, ctx: ExecutionContext): Response | Promise<Response>
+}
+
+function cloudflareTokenOwner(token: string): CloudflareTokenOwner {
+	if (token.startsWith('cfat_')) return 'account'
+	if (token.startsWith('cfoat_') || token.startsWith('cfut_')) return 'user'
+	return 'unknown'
 }
 
 export async function isApiTokenRequest(req: Request, env: RequiredEnv) {
@@ -23,7 +31,9 @@ export async function isApiTokenRequest(req: Request, env: RequiredEnv) {
 	const [type, token] = authHeader.split(' ')
 	if (type !== 'Bearer' || !token) return false
 
-	// OAuth Provider tokens have the provider's user:grant:secret format.
+	// MCP OAuth Provider tokens have a separate user:grant:secret format.
+	// Every other bearer value may be a Cloudflare API/OAuth credential; ownership
+	// prefixes are optimization hints, not an allowlist, so legacy values still work.
 	return token.split(':').length !== 3
 }
 
@@ -48,7 +58,7 @@ export async function getApiTokenProps(req: Request, env: RequiredEnv): Promise<
 		token = tokenValue
 	}
 
-	const { user, accounts } = await getUserAndAccounts(token, headers)
+	const { user, accounts } = await getUserAndAccounts(token, headers, cloudflareTokenOwner(token))
 	if (user === null) {
 		const account = accounts[0]
 		if (!account) {
@@ -79,7 +89,48 @@ export async function handleApiTokenMode<Env extends RequiredEnv>(
 	env: Env,
 	ctx: ExecutionContext
 ): Promise<Response> {
-	const props = await getApiTokenProps(req, env)
+	let props: AuthProps
+	try {
+		props = await getApiTokenProps(req, env)
+	} catch (error) {
+		if (error instanceof McpError) return apiTokenErrorResponse(req, error)
+		throw error
+	}
 	;(ctx as { props: AuthProps }).props = props
 	return handler.fetch(req, env, ctx)
+}
+
+function apiTokenErrorResponse(request: Request, error: McpError): Response {
+	let oauthCode: string
+	if (error.code >= 500) {
+		oauthCode = 'server_error'
+	} else if (error.code === 429) {
+		oauthCode = 'temporarily_unavailable'
+	} else if (error.code === 401) {
+		oauthCode = 'invalid_token'
+	} else if (error.code === 403) {
+		oauthCode = 'insufficient_scope'
+	} else {
+		oauthCode = 'invalid_request'
+	}
+	const headers: Record<string, string> = {
+		'Cache-Control': 'no-store',
+		'Content-Type': 'application/json',
+		Pragma: 'no-cache',
+		...error.headers,
+	}
+	if (error.code === 401 || error.code === 403) {
+		const url = new URL(request.url)
+		const resourceMetadata = `${url.origin}/.well-known/oauth-protected-resource${url.pathname}`
+		headers['WWW-Authenticate'] =
+			`Bearer realm="OAuth", resource_metadata="${resourceMetadata}", error="${oauthCode}"`
+	}
+
+	return new Response(
+		JSON.stringify({
+			error: oauthCode,
+			error_description: error.message,
+		}),
+		{ status: error.code, headers }
+	)
 }

--- a/packages/mcp-common/src/cloudflare-oauth-handler.spec.ts
+++ b/packages/mcp-common/src/cloudflare-oauth-handler.spec.ts
@@ -266,18 +266,18 @@ describe('handleTokenExchangeCallback', () => {
 	})
 })
 
-function mockUserResponse(status: number, body?: unknown) {
+function mockUserResponse(status: number, body?: unknown, headers?: HeadersInit) {
 	server.use(
 		http.get('https://api.cloudflare.com/client/v4/user', () =>
-			HttpResponse.text(body ? JSON.stringify(body) : '', { status })
+			HttpResponse.text(body ? JSON.stringify(body) : '', { status, headers })
 		)
 	)
 }
 
-function mockAccountsResponse(status: number, body?: unknown) {
+function mockAccountsResponse(status: number, body?: unknown, headers?: HeadersInit) {
 	server.use(
 		http.get('https://api.cloudflare.com/client/v4/accounts', () =>
-			HttpResponse.text(body ? JSON.stringify(body) : '', { status })
+			HttpResponse.text(body ? JSON.stringify(body) : '', { status, headers })
 		)
 	)
 }
@@ -312,6 +312,52 @@ describe('getUserAndAccounts', () => {
 		const result = await getUserAndAccounts('test-token')
 		expect(result.user).toBeNull()
 		expect(result.accounts).toEqual([{ id: 'acc-1', name: 'My Account' }])
+	})
+
+	it('does not infer an account token when the caller knows the token is user-owned', async () => {
+		mockUserResponse(401, { errors: [{ message: 'Unauthorized' }] })
+		mockAccountsResponse(200, v4Accounts)
+
+		await expect(getUserAndAccounts('test-token', undefined, 'user')).rejects.toMatchObject({
+			code: 401,
+		})
+	})
+
+	it('does not infer an account token when the user probe is rate limited', async () => {
+		mockUserResponse(429, undefined, { 'Retry-After': '17' })
+		mockAccountsResponse(200, v4Accounts)
+
+		await expect(getUserAndAccounts('legacy-token')).rejects.toMatchObject({
+			code: 429,
+			headers: { 'Retry-After': '17' },
+		})
+	})
+
+	it('returns a retryable 429 when the accounts probe is rate limited', async () => {
+		mockUserResponse(200, v4User)
+		mockAccountsResponse(429)
+
+		await expect(getUserAndAccounts('test-token', undefined, 'user')).rejects.toMatchObject({
+			code: 429,
+			headers: { 'Retry-After': '30' },
+		})
+	})
+
+	it('uses only the accounts probe and preserves 429 backoff for account tokens', async () => {
+		let userCalls = 0
+		server.use(
+			http.get('https://api.cloudflare.com/client/v4/user', () => {
+				userCalls += 1
+				return HttpResponse.json(v4User)
+			})
+		)
+		mockAccountsResponse(429, undefined, { 'Retry-After': '23' })
+
+		await expect(getUserAndAccounts('test-token', undefined, 'account')).rejects.toMatchObject({
+			code: 429,
+			headers: { 'Retry-After': '23' },
+		})
+		expect(userCalls).toBe(0)
 	})
 
 	describe('combined failure (both endpoints fail)', () => {
@@ -371,6 +417,23 @@ describe('getUserAndAccounts', () => {
 				expect(e).toBeInstanceOf(McpError)
 				const err = e as McpError
 				expect(err.code).toBe(403)
+				expect(err.message).toBe('Token lacks required user:read or account:read scope')
+				expect(err.reportToSentry).toBe(false)
+			}
+		})
+
+		it('maps malformed-token 400s to 401 invalid token', async () => {
+			mockUserResponse(400)
+			mockAccountsResponse(400)
+
+			try {
+				await getUserAndAccounts('malformed-token')
+				expect.unreachable()
+			} catch (e) {
+				expect(e).toBeInstanceOf(McpError)
+				const err = e as McpError
+				expect(err.code).toBe(401)
+				expect(err.message).toBe('Access token appears malformed; reauthenticate and try again')
 				expect(err.reportToSentry).toBe(false)
 			}
 		})
@@ -404,8 +467,8 @@ describe('getUserAndAccounts', () => {
 	})
 
 	describe('mixed-status priority in combined failures', () => {
-		it('prioritizes 5xx over 429 (401+500 → 502)', async () => {
-			mockUserResponse(401)
+		it('prioritizes 5xx over 429 (429+500 → 502)', async () => {
+			mockUserResponse(429)
 			mockAccountsResponse(500)
 
 			try {

--- a/packages/mcp-common/src/cloudflare-oauth-handler.ts
+++ b/packages/mcp-common/src/cloudflare-oauth-handler.ts
@@ -12,7 +12,7 @@ import {
 	getAuthToken,
 	refreshAuthToken,
 } from './cloudflare-auth'
-import { McpError, safeStatusCode, throwUpstreamApiError } from './mcp-error'
+import { McpError, safeStatusCode } from './mcp-error'
 import { useSentry } from './sentry'
 import { V4Schema } from './v4-api'
 import {
@@ -54,7 +54,7 @@ function mcpErrorToOAuthResponse(e: McpError): Response {
 	} else {
 		oauthCode = 'invalid_request'
 	}
-	return new OAuthError(oauthCode, e.message, e.code >= 500 ? 500 : e.code).toResponse()
+	return new OAuthError(oauthCode, e.message, e.code >= 500 ? 500 : e.code, e.headers).toResponse()
 }
 
 type AuthContext = {
@@ -81,50 +81,70 @@ type AccountsSchema = z.infer<typeof CloudflareAccountsSchema>
 export { AuthPropsSchema }
 export type { AuthProps } from './auth-props'
 
-/**
- * Throws an McpError for combined /user + /accounts failures.
- * Uses priority-based classification matching cloudflare-mcp patterns.
- */
-function throwCombinedApiError(userStatus: number, accountsStatus: number): never {
-	const statuses = [userStatus, accountsStatus]
+function retryAfterHeaders(...responses: Response[]): Record<string, string> {
+	return {
+		'Retry-After':
+			responses.find((response) => response.status === 429)?.headers.get('Retry-After') ?? '30',
+	}
+}
 
-	if (statuses.some((s) => s >= 500)) {
+/** Classifies one or more identity-probe failures by priority. */
+function throwIdentityProbeError(
+	statuses: readonly [number, ...number[]],
+	internalMessage: string,
+	headers: Record<string, string> = {}
+): never {
+	if (statuses.some((status) => status >= 500)) {
 		throw new McpError('Cloudflare API is temporarily unavailable', 502, {
 			reportToSentry: true,
-			internalMessage: `Upstream user=${userStatus}, accounts=${accountsStatus}`,
+			internalMessage,
 		})
 	}
-
 	if (statuses.includes(429)) {
 		throw new McpError('Rate limited, try again later', 429, {
 			reportToSentry: false,
-			internalMessage: `Upstream user=${userStatus}, accounts=${accountsStatus}`,
+			internalMessage,
+			headers,
 		})
 	}
-
 	if (statuses.includes(401)) {
 		throw new McpError('Access token is invalid or expired', 401, {
 			reportToSentry: false,
-			internalMessage: `Upstream user=${userStatus}, accounts=${accountsStatus}`,
+			internalMessage,
 		})
 	}
-
 	if (statuses.includes(403)) {
-		throw new McpError('Insufficient permissions', 403, {
+		throw new McpError('Token lacks required user:read or account:read scope', 403, {
 			reportToSentry: false,
-			internalMessage: `Upstream user=${userStatus}, accounts=${accountsStatus}`,
+			internalMessage,
 		})
 	}
-
-	throw new McpError('Failed to verify token', safeStatusCode(userStatus), {
+	if (statuses.includes(400)) {
+		throw new McpError('Access token appears malformed; reauthenticate and try again', 401, {
+			reportToSentry: false,
+			internalMessage,
+		})
+	}
+	throw new McpError('Failed to verify token', safeStatusCode(statuses[0]), {
 		reportToSentry: false,
-		internalMessage: `Upstream user=${userStatus}, accounts=${accountsStatus}`,
+		internalMessage,
 	})
 }
 
+function throwCombinedApiError(userResponse: Response, accountsResponse: Response): never {
+	throwIdentityProbeError(
+		[userResponse.status, accountsResponse.status],
+		`Upstream user=${userResponse.status}, accounts=${accountsResponse.status}`,
+		retryAfterHeaders(userResponse, accountsResponse)
+	)
+}
+
+export type CloudflareTokenOwner = 'account' | 'unknown' | 'user'
+
 export async function getUserAndAccounts(
 	accessToken: string,
-	devModeHeaders?: HeadersInit
+	devModeHeaders?: HeadersInit,
+	tokenOwner: CloudflareTokenOwner = 'unknown'
 ): Promise<{ user: UserSchema | null; accounts: AccountsSchema }> {
 	const headers = devModeHeaders
 		? devModeHeaders
@@ -132,12 +152,16 @@ export async function getUserAndAccounts(
 				Authorization: `Bearer ${accessToken}`,
 			}
 
-	// Fetch the user & accounts info from Cloudflare in parallel
-	let userResponse: Response
+	// Account-owned tokens cannot represent a user, so skip the unnecessary user probe.
+	let userResponse: Response | undefined
 	let accountsResponse: Response
 	try {
+		const userRequest =
+			tokenOwner === 'account'
+				? Promise.resolve(undefined)
+				: fetch('https://api.cloudflare.com/client/v4/user', { headers })
 		;[userResponse, accountsResponse] = await Promise.all([
-			fetch('https://api.cloudflare.com/client/v4/user', { headers }),
+			userRequest,
 			fetch('https://api.cloudflare.com/client/v4/accounts', { headers }),
 		])
 	} catch (error) {
@@ -148,12 +172,29 @@ export async function getUserAndAccounts(
 		})
 	}
 
-	// If both endpoints failed, use priority-based error classification
-	if (!userResponse.ok && !accountsResponse.ok) {
-		console.error(
-			`Cloudflare API error: user=${userResponse.status}, accounts=${accountsResponse.status}`
+	if (userResponse === undefined && !accountsResponse.ok) {
+		const message = `Cloudflare API error: accounts=${accountsResponse.status}`
+		if (accountsResponse.status >= 500) {
+			console.error(message)
+		} else {
+			console.warn(message)
+		}
+		throwIdentityProbeError(
+			[accountsResponse.status],
+			`Upstream accounts=${accountsResponse.status}`,
+			retryAfterHeaders(accountsResponse)
 		)
-		throwCombinedApiError(userResponse.status, accountsResponse.status)
+	}
+
+	// If both endpoints failed, use priority-based error classification
+	if (userResponse !== undefined && !userResponse.ok && !accountsResponse.ok) {
+		const message = `Cloudflare API error: user=${userResponse.status}, accounts=${accountsResponse.status}`
+		if (userResponse.status >= 500 || accountsResponse.status >= 500) {
+			console.error(message)
+		} else {
+			console.warn(message)
+		}
+		throwCombinedApiError(userResponse, accountsResponse)
 	}
 
 	// Parse accounts with safeParse for graceful degradation
@@ -170,11 +211,28 @@ export async function getUserAndAccounts(
 		} catch (error) {
 			console.error('Cloudflare API /accounts response is not valid JSON', error)
 		}
-	} else if (userResponse.ok) {
+	} else if (userResponse?.ok) {
 		// User succeeded but accounts failed — surface the accounts error
 		// (5xx should be reported, 4xx like 403 may indicate insufficient scopes)
-		console.error(`Cloudflare API /accounts failed with status ${accountsResponse.status}`)
-		throwUpstreamApiError(accountsResponse.status, 'Cloudflare API /accounts')
+		const message = `Cloudflare API /accounts failed with status ${accountsResponse.status}`
+		if (accountsResponse.status >= 500) {
+			console.error(message)
+		} else {
+			console.warn(message)
+		}
+		throwIdentityProbeError(
+			[accountsResponse.status],
+			`Upstream accounts=${accountsResponse.status}`,
+			retryAfterHeaders(accountsResponse)
+		)
+	}
+
+	if (userResponse === undefined) {
+		if (accounts.length === 1) return { user: null, accounts }
+		throw new McpError('Account token must resolve to exactly one Cloudflare account', 401, {
+			reportToSentry: false,
+			internalMessage: `accounts=${accountsResponse.status}, count=${accounts.length}`,
+		})
 	}
 
 	// Parse user with safeParse for graceful degradation
@@ -191,19 +249,24 @@ export async function getUserAndAccounts(
 		} catch (error) {
 			console.error('Cloudflare API /user response is not valid JSON', error)
 		}
-	} else if (accounts.length > 0) {
-		// User endpoint failed but accounts succeeded — account-scoped token
+	} else if (accounts.length > 0 && tokenOwner === 'unknown' && userResponse.status < 429) {
+		// Only legacy credentials need response-based account-token inference.
+		// Transient failures must never change the inferred credential owner.
 		return { user: null, accounts }
 	} else {
-		throwUpstreamApiError(userResponse.status, 'Cloudflare API /user')
+		throwIdentityProbeError(
+			[userResponse.status],
+			`Upstream user=${userResponse.status}`,
+			retryAfterHeaders(userResponse)
+		)
 	}
 
 	if (user) {
 		return { user, accounts }
 	}
 
-	// Account-scoped token — user is null but accounts are present
-	if (accounts.length > 0) {
+	// Only legacy unprefixed tokens need response-based account-token inference.
+	if (accounts.length > 0 && tokenOwner === 'unknown') {
 		return { user: null, accounts }
 	}
 
@@ -240,7 +303,8 @@ async function getTokenAndUserDetails(
 		code_verifier,
 	})
 
-	const { user, accounts } = await getUserAndAccounts(accessToken)
+	// Cloudflare OAuth authorization-code grants always represent a user principal.
+	const { user, accounts } = await getUserAndAccounts(accessToken, undefined, 'user')
 	// User cannot be null for OAuth flow
 	if (user === null) {
 		throw new McpError('Failed to fetch user', 500, { reportToSentry: true })

--- a/packages/mcp-common/src/mcp-error.ts
+++ b/packages/mcp-common/src/mcp-error.ts
@@ -38,6 +38,7 @@ export function throwUpstreamApiError(status: number, context: string, rawBody?:
 export class McpError extends Error {
 	public code: ContentfulStatusCode
 	public reportToSentry: boolean
+	public headers: Record<string, string>
 	// error message for internal use
 	public internalMessage?: string
 	public cause?: Error
@@ -48,12 +49,14 @@ export class McpError extends Error {
 			reportToSentry: boolean
 			internalMessage?: string
 			cause?: Error
+			headers?: Record<string, string>
 		} = { reportToSentry: false }
 	) {
 		super(message)
 		this.code = code
 		this.name = 'MCPError'
 		this.reportToSentry = opts.reportToSentry
+		this.headers = opts.headers ?? {}
 		this.internalMessage = opts.internalMessage
 		this.cause = opts.cause
 	}

--- a/packages/mcp-common/src/oauth-router.spec.ts
+++ b/packages/mcp-common/src/oauth-router.spec.ts
@@ -1,7 +1,9 @@
 import { resourceMatches } from '@cloudflare/workers-oauth-provider'
+import { http, HttpResponse } from 'msw'
 import { describe, expect, it } from 'vitest'
 
 import { createCloudflareOAuthRouter } from './oauth-router'
+import { server } from './test/msw-server'
 
 import type { MetricsTracker } from '@repo/mcp-observability'
 import type { CloudflareOAuthEnv } from './oauth-router'
@@ -17,6 +19,16 @@ const mcpRequestPolicy = {
 	allowedHostnames: ['mcp.example.com'],
 	allowedOriginHostnames: ['mcp.example.com'],
 }
+const env = {
+	DEV_CLOUDFLARE_API_TOKEN: '',
+	DEV_CLOUDFLARE_EMAIL: '',
+	DEV_DISABLE_OAUTH: 'false',
+} as CloudflareOAuthEnv
+const executionContext = {
+	props: {},
+	waitUntil() {},
+	passThroughOnException() {},
+} as ExecutionContext
 
 describe('OAuth router resource policy', () => {
 	it('uses exact RFC 8707 matching for same-origin resource paths', () => {
@@ -38,5 +50,83 @@ describe('OAuth router resource policy', () => {
 				provider: { resourceMatchOriginOnly: true } as never,
 			})
 		).toThrow('resourceMatchOriginOnly')
+	})
+
+	it('returns a retryable response when a Wrangler OAuth identity probe is rate limited', async () => {
+		server.use(
+			http.get('https://api.cloudflare.com/client/v4/user', () =>
+				HttpResponse.json({ success: false }, { status: 429, headers: { 'Retry-After': '17' } })
+			),
+			http.get('https://api.cloudflare.com/client/v4/accounts', () =>
+				HttpResponse.json({
+					success: true,
+					result: [{ id: 'account-1', name: 'Account One' }],
+					errors: [],
+					messages: [],
+				})
+			)
+		)
+		const router = createCloudflareOAuthRouter<CloudflareOAuthEnv>({
+			apiHandler,
+			scopes: {},
+			metrics,
+			mcpRequestPolicy,
+		})
+
+		const response = await router.fetch(
+			new Request('https://mcp.example.com/mcp', {
+				headers: {
+					Authorization: 'Bearer cfoat_test-wrangler-token',
+					Host: 'mcp.example.com',
+				},
+			}),
+			env,
+			executionContext
+		)
+
+		expect(response.status).toBe(429)
+		expect(response.headers.get('retry-after')).toBe('17')
+		await expect(response.json()).resolves.toEqual({
+			error: 'temporarily_unavailable',
+			error_description: 'Rate limited, try again later',
+		})
+	})
+
+	it('returns 401 instead of throwing when a direct token is malformed', async () => {
+		server.use(
+			http.get('https://api.cloudflare.com/client/v4/user', () =>
+				HttpResponse.json({ success: false }, { status: 400 })
+			),
+			http.get('https://api.cloudflare.com/client/v4/accounts', () =>
+				HttpResponse.json({ success: false }, { status: 400 })
+			)
+		)
+		const router = createCloudflareOAuthRouter<CloudflareOAuthEnv>({
+			apiHandler,
+			scopes: {},
+			metrics,
+			mcpRequestPolicy,
+		})
+
+		const response = await router.fetch(
+			new Request('https://mcp.example.com/mcp', {
+				headers: {
+					Authorization: 'Bearer malformed-token',
+					Host: 'mcp.example.com',
+				},
+			}),
+			env,
+			executionContext
+		)
+
+		expect(response.status).toBe(401)
+		expect(response.headers.get('cache-control')).toBe('no-store')
+		expect(response.headers.get('www-authenticate')).toBe(
+			'Bearer realm="OAuth", resource_metadata="https://mcp.example.com/.well-known/oauth-protected-resource/mcp", error="invalid_token"'
+		)
+		await expect(response.json()).resolves.toEqual({
+			error: 'invalid_token',
+			error_description: 'Access token appears malformed; reauthenticate and try again',
+		})
 	})
 })

--- a/packages/mcp-common/src/workers-oauth-utils.spec.ts
+++ b/packages/mcp-common/src/workers-oauth-utils.spec.ts
@@ -28,6 +28,14 @@ describe('OAuthError', () => {
 			error_description: 'Bad state',
 		})
 	})
+
+	it('preserves response headers', () => {
+		const response = new OAuthError('temporarily_unavailable', 'Try again later', 429, {
+			'Retry-After': '17',
+		}).toResponse()
+
+		expect(response.headers.get('retry-after')).toBe('17')
+	})
 })
 
 describe('parseRedirectApproval', () => {

--- a/packages/mcp-common/src/workers-oauth-utils.ts
+++ b/packages/mcp-common/src/workers-oauth-utils.ts
@@ -12,7 +12,8 @@ export class OAuthError extends Error {
 	constructor(
 		public code: string,
 		public description: string,
-		public statusCode = 400
+		public statusCode = 400,
+		public headers: Record<string, string> = {}
 	) {
 		super(description)
 		this.name = 'OAuthError'
@@ -26,7 +27,7 @@ export class OAuthError extends Error {
 			}),
 			{
 				status: this.statusCode,
-				headers: { 'Content-Type': 'application/json' },
+				headers: { 'Content-Type': 'application/json', ...this.headers },
 			}
 		)
 	}


### PR DESCRIPTION
## Summary

- Convert expected direct Cloudflare credential validation failures into structured OAuth resource responses instead of uncaught Worker exceptions.
- Use credential ownership prefixes as optimization hints before probing identity:
  - [`cfat_`](https://developers.cloudflare.com/fundamentals/api/get-started/token-formats/): only query `/accounts` and require exactly one account.
  - [`cfut_`](https://developers.cloudflare.com/fundamentals/api/get-started/token-formats/) and Wrangler OAuth `cfoat_`: query `/user` and `/accounts` in parallel and require user identity.
  - unprefixed/legacy credentials: retain response-based inference for backward compatibility.
- Treat the Cloudflare OAuth credential obtained during this server's authorization flow explicitly as user-owned.
- Map malformed-token 400 responses to `401 invalid_token` and return RFC 9728 `WWW-Authenticate` metadata with no-store headers.
- Return identity-probe rate limits as structured `429 temporarily_unavailable` responses and preserve upstream `Retry-After` (default 30 seconds).
- Never infer account-token ownership from a transient `/user` failure; any simultaneous 5xx continues to take precedence as `502`.
- Add exported-worker, HTTP-router, call-count, Wrangler OAuth, and mixed-status regression coverage.

## Root cause

The direct credential route inferred ownership entirely from `/user` and `/accounts` responses. Expected validation errors escaped as `McpError`, so malformed values could become Worker exception responses. It also sent both identity requests for account-owned credentials even though current account-token formats encode their owner.

The MCP OAuth token and the upstream Cloudflare credential are different layers: `workers-oauth-provider` validates its own token and restores the already-verified Cloudflare user context. Direct Cloudflare API and Wrangler OAuth credentials continue through the explicit credential-validation branch.

## Validation

- `pnpm check:deps`
- `pnpm check:turbo`
- `pnpm check:format`
- `pnpm test` — 283 tests
- `pnpm turbo deploy -- -e staging --dry-run` — 17 Workers
- Local GraphQL Worker + current `wrangler auth token --json` OAuth credential — authenticated initialize `200`
- Production GraphQL endpoint + current Wrangler OAuth credential — authenticated initialize `200`
