### PR TITLE
Add structured output to docs AI Search

### DIFF
--- a/.changeset/bright-crabs-search.md
+++ b/.changeset/bright-crabs-search.md
@@ -1,0 +1,5 @@
+---
+'@repo/mcp-common': patch
+---
+
+Add structured output for the Cloudflare documentation AI Search tool while preserving XML text content for older clients.

--- a/packages/mcp-common/src/tools/docs-ai-search.tools.spec.ts
+++ b/packages/mcp-common/src/tools/docs-ai-search.tools.spec.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { formatDocsResults, queryAiSearch, registerDocsTools } from './docs-ai-search.tools'
+
+const aiSearchResponse = {
+	object: 'vector_store.search_results.page',
+	search_query: 'workers kv binding example',
+	data: [
+		{
+			file_id: 'file-1',
+			filename: 'workers/runtime-apis/kv/index.md',
+			score: 0.93,
+			attributes: {},
+			content: [
+				{ id: 'chunk-1', type: 'text', text: 'Create a KV namespace.' },
+				{ id: 'chunk-2', type: 'text', text: 'Bind it to your Worker.' },
+			],
+		},
+	],
+	has_more: false,
+	next_page: null,
+}
+
+function makeAi(response: unknown): { ai: Ai; search: ReturnType<typeof vi.fn> } {
+	const search = vi.fn().mockResolvedValue(response)
+	return {
+		ai: {
+			autorag: vi.fn(() => ({ search })),
+		} as unknown as Ai,
+		search,
+	}
+}
+
+describe('docs AI Search tools', () => {
+	it('queries AI Search and maps results', async () => {
+		const { ai, search } = makeAi(aiSearchResponse)
+
+		const results = await queryAiSearch(ai, 'workers kv binding example')
+
+		expect(ai.autorag).toHaveBeenCalledWith('docs-mcp-rag')
+		expect(search).toHaveBeenCalledWith({
+			query: 'workers kv binding example',
+		})
+		expect(results).toEqual([
+			{
+				similarity: 0.93,
+				id: 'file-1',
+				url: 'https://developers.cloudflare.com/workers/runtime-apis/kv/',
+				title: 'kv',
+				text: 'Create a KV namespace.\nBind it to your Worker.',
+			},
+		])
+	})
+
+	it('formats unstructured content as XML-style result blocks', () => {
+		expect(
+			formatDocsResults([
+				{
+					similarity: 0.93,
+					id: 'file-1',
+					url: 'https://developers.cloudflare.com/workers/runtime-apis/kv/',
+					title: 'KV',
+					text: 'Create a KV namespace.',
+				},
+			])
+		).toBe(`<result>
+<url>https://developers.cloudflare.com/workers/runtime-apis/kv/</url>
+<title>KV</title>
+<text>
+Create a KV namespace.
+</text>
+</result>`)
+	})
+
+	it('registers outputSchema and returns structuredContent', async () => {
+		const { ai } = makeAi(aiSearchResponse)
+		const registeredTools = new Map<string, { options: any; handler: any }>()
+		const server = {
+			registerTool: vi.fn((name: string, options: any, handler: any) => {
+				registeredTools.set(name, { options, handler })
+			}),
+		}
+
+		registerDocsTools(server as any, { AI: ai })
+
+		const docsTool = registeredTools.get('search_cloudflare_documentation')
+		expect(docsTool?.options.outputSchema).toBeDefined()
+		expect(docsTool?.options.outputSchema.results).toBeDefined()
+
+		const response = await docsTool?.handler({ query: 'workers kv binding example' })
+
+		expect(response.structuredContent).toEqual({
+			results: [
+				{
+					similarity: 0.93,
+					id: 'file-1',
+					url: 'https://developers.cloudflare.com/workers/runtime-apis/kv/',
+					title: 'kv',
+					text: 'Create a KV namespace.\nBind it to your Worker.',
+				},
+			],
+		})
+		expect(response.content[0].text).toContain('<result>')
+	})
+})

--- a/packages/mcp-common/src/tools/docs-ai-search.tools.ts
+++ b/packages/mcp-common/src/tools/docs-ai-search.tools.ts
@@ -6,6 +6,18 @@ interface RequiredEnv {
 	AI: Ai
 }
 
+type DocsSearchResult = {
+	similarity: number
+	id: string
+	url: string
+	title: string
+	text: string
+}
+
+type DocsSearchOutput = {
+	results: DocsSearchResult[]
+}
+
 // Zod schema for AI Search response validation
 const AiSearchResponseSchema = z.object({
 	object: z.string(),
@@ -55,26 +67,29 @@ export function registerDocsTools(server: McpServer, env: RequiredEnv) {
 			inputSchema: {
 				query: z.string(),
 			},
+			outputSchema: {
+				results: z.array(
+					z.object({
+						similarity: z.number().describe('Similarity score from AI Search'),
+						id: z.string().describe('Source file ID'),
+						url: z.string().describe('Developer documentation URL'),
+						title: z.string().describe('Documentation page title'),
+						text: z.string().describe('Matching documentation chunk text'),
+					})
+				),
+			},
 			annotations: {
 				title: 'Search Cloudflare docs',
 				readOnlyHint: true,
 			},
 		},
 		async ({ query }) => {
-			const results = await queryAiSearch(env.AI, query)
-			const resultsAsXml = results
-				.map((result) => {
-					return `<result>
-<url>${result.url}</url>
-<title>${result.title}</title>
-<text>
-${result.text}
-</text>
-</result>`
-				})
-				.join('\n')
+			const structuredContent: DocsSearchOutput = {
+				results: await queryAiSearch(env.AI, query),
+			}
 			return {
-				content: [{ type: 'text', text: resultsAsXml }],
+				content: [{ type: 'text', text: formatDocsResults(structuredContent.results) }],
+				structuredContent,
 			}
 		}
 	)
@@ -117,7 +132,7 @@ ${result.text}
 	)
 }
 
-async function queryAiSearch(ai: Ai, query: string) {
+export async function queryAiSearch(ai: Ai, query: string): Promise<DocsSearchResult[]> {
 	const rawResponse = await doWithRetries(() =>
 		ai.autorag('docs-mcp-rag').search({
 			query,
@@ -134,6 +149,20 @@ async function queryAiSearch(ai: Ai, query: string) {
 		title: extractTitle(item.filename),
 		text: item.content.map((c) => c.text).join('\n'),
 	}))
+}
+
+export function formatDocsResults(results: DocsSearchResult[]): string {
+	return results
+		.map((result) => {
+			return `<result>
+<url>${result.url}</url>
+<title>${result.title}</title>
+<text>
+${result.text}
+</text>
+</result>`
+		})
+		.join('\n')
 }
 
 function sourceToUrl(filename: string): string {


### PR DESCRIPTION
## Summary

- add `outputSchema` for `search_cloudflare_documentation` results
- return typed `structuredContent` alongside the existing XML-style text content
- extract docs result formatting for test coverage
- add a changeset for `@repo/mcp-common`

## Notes

The text `content` remains unchanged as XML-style `<result>` blocks so older clients that do not support structured tool output continue to work as before.

## Tests

- `pnpm --filter @repo/mcp-common test -- docs-ai-search.tools.spec.ts`
- `pnpm --filter @repo/mcp-common check:types`
- `pnpm --filter @repo/mcp-common check:lint`
- `pnpm check:format`