### PR TITLE
Fix GraphQL response parsing for pathless errors

### DIFF
--- a/apps/graphql/src/tools/graphql.tools.spec.ts
+++ b/apps/graphql/src/tools/graphql.tools.spec.ts
@@ -1,0 +1,143 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { registerGraphQLTools } from './graphql.tools'
+
+import type { GraphQLMCP } from '../graphql.app'
+
+type ToolResult = {
+	content: Array<{
+		type: string
+		text: string
+	}>
+}
+
+type ToolHandler = (params: {
+	query: string
+	variables?: Record<string, unknown>
+}) => Promise<ToolResult>
+
+type AccountToolHandler = (
+	params: {
+		query: string
+		variables?: Record<string, unknown>
+	},
+	accountId: string
+) => Promise<ToolResult>
+
+function createGraphQLToolHandler() {
+	const tools: Record<string, AccountToolHandler> = {}
+
+	const agent = {
+		props: {
+			accessToken: 'test-api-token',
+		},
+		server: {
+			accountTool: (
+				name: string,
+				_description: string,
+				_schema: unknown,
+				handler: AccountToolHandler
+			) => {
+				tools[name] = handler
+			},
+			registerTool: vi.fn(),
+		},
+	} as unknown as GraphQLMCP
+
+	registerGraphQLTools(agent)
+
+	return ((params) => tools.graphql_query(params, 'test-account-id')) satisfies ToolHandler
+}
+
+afterEach(() => {
+	vi.unstubAllGlobals()
+	vi.restoreAllMocks()
+})
+
+describe('graphql_query', () => {
+	it('returns GraphQL error responses that omit optional error metadata', async () => {
+		vi.spyOn(console, 'warn').mockImplementation(() => {})
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async () => {
+				return new Response(
+					JSON.stringify({
+						data: null,
+						errors: [
+							{
+								message: 'not authorized for that account',
+							},
+						],
+					}),
+					{ status: 200 }
+				)
+			})
+		)
+
+		const graphqlQuery = createGraphQLToolHandler()
+		const result = await graphqlQuery({
+			query: 'query Viewer { viewer { accounts { id } } }',
+		})
+
+		expect(result.content[0]?.text).toContain('not authorized for that account')
+		expect(result.content[0]?.text).not.toContain('invalid_type')
+	})
+
+	it('returns successful GraphQL responses that omit the errors field', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async () => {
+				return new Response(
+					JSON.stringify({
+						data: {
+							viewer: {
+								accounts: [{ id: 'test-account-id' }],
+							},
+						},
+					}),
+					{ status: 200 }
+				)
+			})
+		)
+
+		const graphqlQuery = createGraphQLToolHandler()
+		const result = await graphqlQuery({
+			query: 'query Viewer { viewer { accounts { id } } }',
+		})
+
+		expect(result.content[0]?.text).toContain('"test-account-id"')
+		expect(result.content[0]?.text).not.toContain('Error executing GraphQL query')
+	})
+
+	it('returns GraphQL error responses with null path and custom extensions', async () => {
+		vi.spyOn(console, 'warn').mockImplementation(() => {})
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async () => {
+				return new Response(
+					JSON.stringify({
+						errors: [
+							{
+								message: 'Mutations are not supported',
+								path: null,
+								extensions: {
+									classification: 'ValidationError',
+								},
+							},
+						],
+					}),
+					{ status: 200 }
+				)
+			})
+		)
+
+		const graphqlQuery = createGraphQLToolHandler()
+		const result = await graphqlQuery({
+			query: 'mutation TestMutation { noop }',
+		})
+
+		expect(result.content[0]?.text).toContain('Mutations are not supported')
+		expect(result.content[0]?.text).toContain('ValidationError')
+		expect(result.content[0]?.text).not.toContain('invalid_union')
+	})
+})

--- a/apps/graphql/src/tools/graphql.tools.ts
+++ b/apps/graphql/src/tools/graphql.tools.ts
@@ -68,18 +68,15 @@ interface TypeDetailsResponse {
 // Define the structure of a single error
 const graphQLErrorSchema = z.object({
 	message: z.string(),
-	path: z.array(z.union([z.string(), z.number()])),
-	extensions: z.object({
-		code: z.string(),
-		timestamp: z.string(),
-		ray_id: z.string(),
-	}),
+	locations: z.array(z.object({ line: z.number(), column: z.number() })).nullish(),
+	path: z.array(z.union([z.string(), z.number()])).nullish(),
+	extensions: z.record(z.string(), z.unknown()).nullish(),
 })
 
 // Define the overall GraphQL response schema
 const graphQLResponseSchema = z.object({
-	data: z.union([z.record(z.string(), z.unknown()), z.null()]),
-	errors: z.union([z.array(graphQLErrorSchema), z.null()]),
+	data: z.union([z.record(z.string(), z.unknown()), z.null()]).nullish(),
+	errors: z.array(graphQLErrorSchema).nullish(),
 })
 
 /**

--- a/apps/graphql/tsconfig.json
+++ b/apps/graphql/tsconfig.json
@@ -1,4 +1,4 @@
 {
 	"extends": "@repo/typescript-config/workers.json",
-	"include": ["*/**.ts", "./vitest.config.ts", "./types.d.ts"]
+	"include": ["src/**/*.ts", "./vitest.config.ts", "./types.d.ts"]
 }

--- a/apps/graphql/vitest.config.ts
+++ b/apps/graphql/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+	test: {
+		include: ['src/**/*.spec.ts'],
+	},
+})


### PR DESCRIPTION
## Summary

Fix GraphQL MCP response parsing for valid GraphQL API responses that omit optional
error metadata. This keeps the tool from replacing actionable API messages with a
Zod `invalid_union` validation dump.

Fixes #402.

## Changes

- Relax the GraphQL error schema so `path`, `locations`, and `extensions` can be
  omitted or null where GraphQL permits it.
- Allow successful GraphQL responses to omit the top-level `errors` field.
- Add regression coverage for pathless GraphQL errors, `path: null` errors with
  custom extensions, and successful responses without `errors`.

## Verification

```bash
pnpm --filter graphql-mcp-server test
pnpm --filter graphql-mcp-server check:types
pnpm --filter graphql-mcp-server check:lint
pnpm exec prettier apps/graphql/src/tools/graphql.tools.ts apps/graphql/src/tools/graphql.tools.spec.ts apps/graphql/vitest.config.ts apps/graphql/tsconfig.json --check
```
