### PR TITLE
feat(browser-rendering): add quick-action tools for REST parity

### DIFF
--- a/.changeset/browser-mcp-quick-action-parity.md
+++ b/.changeset/browser-mcp-quick-action-parity.md
@@ -1,0 +1,5 @@
+---
+'cloudflare-browser-mcp-server': minor
+---
+
+Add MCP tools for the remaining Browser Rendering REST quick actions, bringing the Browser Run MCP server to parity with the REST API: `get_url_pdf`, `get_url_snapshot`, `scrape_url_elements`, `get_url_json`, `get_url_links`, `start_crawl`, `get_crawl_result`, `cancel_crawl`, `list_browser_sessions`, and `kill_browser_session`.

--- a/apps/browser-rendering/README.md
+++ b/apps/browser-rendering/README.md
@@ -10,11 +10,21 @@ web pages, convert them to markdown, and take screenshots.
 
 Currently available tools:
 
-| **Tool**               | **Description**                                                              |
-| ---------------------- | ---------------------------------------------------------------------------- |
-| `get_url_html_content` | Retrieves the HTML content of the specified URL.                             |
-| `get_url_markdown`     | Fetches the webpage content and converts it into Markdown format.            |
-| `get_url_screenshot`   | Captures a screenshot of the webpage. Optionally, specify the viewport size. |
+| **Tool**                | **Description**                                                                     |
+| ----------------------- | ----------------------------------------------------------------------------------- |
+| `get_url_html_content`  | Retrieves the HTML content of the specified URL.                                    |
+| `get_url_markdown`      | Fetches the webpage content and converts it into Markdown format.                   |
+| `get_url_screenshot`    | Captures a screenshot of the webpage. Optionally, specify the viewport size.        |
+| `get_url_pdf`           | Renders the webpage to a PDF document.                                              |
+| `get_url_snapshot`      | Returns the page HTML content and a screenshot in a single call.                    |
+| `scrape_url_elements`   | Scrapes elements from the page by CSS selector.                                     |
+| `get_url_json`          | Extracts structured JSON from the page using AI. Supports a prompt and JSON schema. |
+| `get_url_links`         | Returns the list of links on the page.                                              |
+| `start_crawl`           | Starts an asynchronous crawl of a website and returns a `job_id`.                   |
+| `get_crawl_result`      | Returns the status and records of a crawl job.                                      |
+| `cancel_crawl`          | Cancels a running crawl job.                                                        |
+| `list_browser_sessions` | Lists active Browser Rendering sessions for the account.                            |
+| `kill_browser_session`  | Closes (kills) a Browser Rendering session by its session ID.                       |
 
 **Note:** These tools are account-scoped. Single-account credentials (and account-scoped API tokens) are detected automatically. If your credentials can access multiple accounts, pass `account_id` to the tool, or set a `cf-account-id` request header in your MCP client config.
 
@@ -25,6 +35,11 @@ This MCP server is still a work in progress, and we plan to add more tools in th
 - `Get the HTML content of https://example.com.`
 - `Convert https://example.com to Markdown.`
 - `Take a screenshot of https://example.com.`
+- `Render https://example.com to a PDF.`
+- `Extract the product name and price from https://example.com as JSON.`
+- `List all the links on https://example.com.`
+- `Crawl https://example.com two levels deep and give me the results.`
+- `List my active browser sessions and kill the oldest one.`
 
 ## Access the remote MCP server from any MCP Client
 

--- a/apps/browser-rendering/src/tools/browser.tools.ts
+++ b/apps/browser-rendering/src/tools/browser.tools.ts
@@ -136,4 +136,435 @@ export function registerBrowserTools(agent: BrowserMCP) {
 			}
 		}
 	)
+
+	agent.server.accountTool(
+		'get_url_pdf',
+		'Render a page to PDF',
+		{
+			url: z.string().url(),
+		},
+		async (params, accountId) => {
+			try {
+				const props = getProps(agent)
+				const client = getCloudflareClient(props.accessToken)
+				const r = await client
+					.post(`/accounts/${accountId}/browser-rendering/pdf`, {
+						body: {
+							url: params.url,
+						},
+						__binaryResponse: true,
+					})
+					.asResponse()
+
+				const arrayBuffer = await r.arrayBuffer()
+				const base64Pdf = Buffer.from(arrayBuffer).toString('base64')
+
+				return {
+					content: [
+						{
+							type: 'resource',
+							resource: {
+								uri: params.url,
+								mimeType: 'application/pdf',
+								blob: base64Pdf,
+							},
+						},
+					],
+				}
+			} catch (error) {
+				return {
+					content: [
+						{
+							type: 'text',
+							text: `Error getting page pdf: ${error instanceof Error && error.message}`,
+						},
+					],
+					isError: true,
+				}
+			}
+		}
+	)
+
+	agent.server.accountTool(
+		'get_url_snapshot',
+		'Get page HTML content and a screenshot in a single call',
+		{
+			url: z.string().url(),
+		},
+		async (params, accountId) => {
+			try {
+				const props = getProps(agent)
+				const client = getCloudflareClient(props.accessToken)
+				const r = (await client.post(`/accounts/${accountId}/browser-rendering/snapshot`, {
+					body: {
+						url: params.url,
+					},
+				})) as { result: { content?: string; screenshot?: string } }
+
+				const content: Array<
+					{ type: 'text'; text: string } | { type: 'image'; mimeType: string; data: string }
+				> = [
+					{
+						type: 'text',
+						text: JSON.stringify({ content: r.result?.content }),
+					},
+				]
+
+				if (r.result?.screenshot) {
+					content.push({
+						type: 'image',
+						mimeType: 'image/png',
+						data: r.result.screenshot,
+					})
+				}
+
+				return { content }
+			} catch (error) {
+				return {
+					content: [
+						{
+							type: 'text',
+							text: `Error getting page snapshot: ${error instanceof Error && error.message}`,
+						},
+					],
+					isError: true,
+				}
+			}
+		}
+	)
+
+	agent.server.accountTool(
+		'scrape_url_elements',
+		'Scrape elements from a page by CSS selector',
+		{
+			url: z.string().url(),
+			elements: z
+				.array(
+					z.object({
+						selector: z.string(),
+					})
+				)
+				.min(1)
+				.describe('CSS selectors of the elements to scrape'),
+		},
+		async (params, accountId) => {
+			try {
+				const props = getProps(agent)
+				const client = getCloudflareClient(props.accessToken)
+				const r = (await client.post(`/accounts/${accountId}/browser-rendering/scrape`, {
+					body: {
+						url: params.url,
+						elements: params.elements,
+					},
+				})) as { result: unknown }
+
+				return {
+					content: [
+						{
+							type: 'text',
+							text: JSON.stringify({ result: r.result }),
+						},
+					],
+				}
+			} catch (error) {
+				return {
+					content: [
+						{
+							type: 'text',
+							text: `Error scraping page: ${error instanceof Error && error.message}`,
+						},
+					],
+					isError: true,
+				}
+			}
+		}
+	)
+
+	agent.server.accountTool(
+		'get_url_json',
+		'Extract structured JSON from a page using AI. Provide a prompt and/or a response_format JSON schema to guide extraction.',
+		{
+			url: z.string().url(),
+			prompt: z.string().optional().describe('Natural-language instruction for what to extract'),
+			response_format: z
+				.object({
+					type: z.string(),
+					json_schema: z.unknown().optional(),
+				})
+				.optional()
+				.describe('Optional JSON-schema response format to constrain the output'),
+		},
+		async (params, accountId) => {
+			try {
+				const props = getProps(agent)
+				const client = getCloudflareClient(props.accessToken)
+				const r = (await client.post(`/accounts/${accountId}/browser-rendering/json`, {
+					body: {
+						url: params.url,
+						...(params.prompt ? { prompt: params.prompt } : {}),
+						...(params.response_format ? { response_format: params.response_format } : {}),
+					},
+				})) as { result: unknown }
+
+				return {
+					content: [
+						{
+							type: 'text',
+							text: JSON.stringify({ result: r.result }),
+						},
+					],
+				}
+			} catch (error) {
+				return {
+					content: [
+						{
+							type: 'text',
+							text: `Error getting page json: ${error instanceof Error && error.message}`,
+						},
+					],
+					isError: true,
+				}
+			}
+		}
+	)
+
+	agent.server.accountTool(
+		'get_url_links',
+		'Get the list of links on a page',
+		{
+			url: z.string().url(),
+			visibleLinksOnly: z
+				.boolean()
+				.optional()
+				.describe('Only return links that are visible in the rendered page'),
+		},
+		async (params, accountId) => {
+			try {
+				const props = getProps(agent)
+				const client = getCloudflareClient(props.accessToken)
+				const r = (await client.post(`/accounts/${accountId}/browser-rendering/links`, {
+					body: {
+						url: params.url,
+						...(params.visibleLinksOnly !== undefined
+							? { visibleLinksOnly: params.visibleLinksOnly }
+							: {}),
+					},
+				})) as { result: unknown }
+
+				return {
+					content: [
+						{
+							type: 'text',
+							text: JSON.stringify({ result: r.result }),
+						},
+					],
+				}
+			} catch (error) {
+				return {
+					content: [
+						{
+							type: 'text',
+							text: `Error getting page links: ${error instanceof Error && error.message}`,
+						},
+					],
+					isError: true,
+				}
+			}
+		}
+	)
+
+	agent.server.accountTool(
+		'start_crawl',
+		'Start an asynchronous crawl of a website. Returns a job_id — poll get_crawl_result to retrieve records.',
+		{
+			url: z.string().url(),
+			render: z
+				.boolean()
+				.default(true)
+				.describe('Whether to render pages with a browser (vs. fetching raw HTML)'),
+			depth: z.number().int().min(0).optional().describe('How many links deep to crawl'),
+			limit: z.number().int().min(1).optional().describe('Maximum number of pages to crawl'),
+		},
+		async (params, accountId) => {
+			try {
+				const props = getProps(agent)
+				const client = getCloudflareClient(props.accessToken)
+				const r = (await client.post(`/accounts/${accountId}/browser-rendering/crawl`, {
+					body: {
+						url: params.url,
+						render: params.render,
+						...(params.depth !== undefined ? { depth: params.depth } : {}),
+						...(params.limit !== undefined ? { limit: params.limit } : {}),
+					},
+				})) as { result: string }
+
+				return {
+					content: [
+						{
+							type: 'text',
+							text: JSON.stringify({
+								job_id: r.result,
+								message: 'Crawl started. Poll get_crawl_result with this job_id.',
+							}),
+						},
+					],
+				}
+			} catch (error) {
+				return {
+					content: [
+						{
+							type: 'text',
+							text: `Error starting crawl: ${error instanceof Error && error.message}`,
+						},
+					],
+					isError: true,
+				}
+			}
+		}
+	)
+
+	agent.server.accountTool(
+		'get_crawl_result',
+		'Get the status and records of a crawl job started with start_crawl',
+		{
+			job_id: z.string(),
+		},
+		async (params, accountId) => {
+			try {
+				const props = getProps(agent)
+				const client = getCloudflareClient(props.accessToken)
+				const r = (await client.get(
+					`/accounts/${accountId}/browser-rendering/crawl/${params.job_id}`
+				)) as { result: unknown }
+
+				return {
+					content: [
+						{
+							type: 'text',
+							text: JSON.stringify({ result: r.result }),
+						},
+					],
+				}
+			} catch (error) {
+				return {
+					content: [
+						{
+							type: 'text',
+							text: `Error getting crawl result: ${error instanceof Error && error.message}`,
+						},
+					],
+					isError: true,
+				}
+			}
+		}
+	)
+
+	agent.server.accountTool(
+		'cancel_crawl',
+		'Cancel a running crawl job',
+		{
+			job_id: z.string(),
+		},
+		async (params, accountId) => {
+			try {
+				const props = getProps(agent)
+				const client = getCloudflareClient(props.accessToken)
+				const r = (await client.delete(
+					`/accounts/${accountId}/browser-rendering/crawl/${params.job_id}`
+				)) as { result: unknown }
+
+				return {
+					content: [
+						{
+							type: 'text',
+							text: JSON.stringify({ result: r.result ?? 'cancelled' }),
+						},
+					],
+				}
+			} catch (error) {
+				return {
+					content: [
+						{
+							type: 'text',
+							text: `Error cancelling crawl: ${error instanceof Error && error.message}`,
+						},
+					],
+					isError: true,
+				}
+			}
+		}
+	)
+
+	agent.server.accountTool(
+		'list_browser_sessions',
+		'List active Browser Run sessions for the account',
+		{},
+		async (_params, accountId) => {
+			try {
+				const props = getProps(agent)
+				const client = getCloudflareClient(props.accessToken)
+				const r = (await client.get(
+					`/accounts/${accountId}/browser-rendering/devtools/session`
+				)) as { result: unknown }
+
+				return {
+					content: [
+						{
+							type: 'text',
+							text: JSON.stringify({ result: r.result }),
+						},
+					],
+				}
+			} catch (error) {
+				return {
+					content: [
+						{
+							type: 'text',
+							text: `Error listing browser sessions: ${error instanceof Error && error.message}`,
+						},
+					],
+					isError: true,
+				}
+			}
+		}
+	)
+
+	agent.server.accountTool(
+		'kill_browser_session',
+		'Close (kill) a Browser Run session by its session ID',
+		{
+			session_id: z.string(),
+		},
+		async (params, accountId) => {
+			try {
+				const props = getProps(agent)
+				const client = getCloudflareClient(props.accessToken)
+				await client.delete(
+					`/accounts/${accountId}/browser-rendering/devtools/browser/${params.session_id}`
+				)
+
+				return {
+					content: [
+						{
+							type: 'text',
+							text: JSON.stringify({
+								session_id: params.session_id,
+								status: 'killed',
+							}),
+						},
+					],
+				}
+			} catch (error) {
+				return {
+					content: [
+						{
+							type: 'text',
+							text: `Error killing browser session: ${error instanceof Error && error.message}`,
+						},
+					],
+					isError: true,
+				}
+			}
+		}
+	)
 }

--- a/apps/browser-rendering/src/tools/browser.tools.ts
+++ b/apps/browser-rendering/src/tools/browser.tools.ts
@@ -503,15 +503,19 @@ export function registerBrowserTools(agent: BrowserMCP) {
 			try {
 				const props = getProps(agent)
 				const client = getCloudflareClient(props.accessToken)
+				// This endpoint returns a bare JSON array of sessions, not the
+				// usual `{ success, result }` envelope, so use the response as-is.
 				const r = (await client.get(
 					`/accounts/${accountId}/browser-rendering/devtools/session`
-				)) as { result: unknown }
+				)) as unknown
+				const result =
+					r && typeof r === 'object' && 'result' in r ? (r as { result: unknown }).result : r
 
 				return {
 					content: [
 						{
 							type: 'text',
-							text: JSON.stringify({ result: r.result }),
+							text: JSON.stringify({ result }),
 						},
 					],
 				}


### PR DESCRIPTION
## What

Brings the Browser Run MCP server (`apps/browser-rendering`) up to parity with the Browser Rendering REST API by exposing the remaining quick actions as MCP tools. Previously only `content`, `markdown`, and `screenshot` were available; agents had to drop to raw HTTP for everything else.

New tools:

| Tool | REST endpoint |
| --- | --- |
| `get_url_pdf` | `POST /browser-rendering/pdf` |
| `get_url_snapshot` | `POST /browser-rendering/snapshot` |
| `scrape_url_elements` | `POST /browser-rendering/scrape` |
| `get_url_json` | `POST /browser-rendering/json` |
| `get_url_links` | `POST /browser-rendering/links` |
| `start_crawl` | `POST /browser-rendering/crawl` |
| `get_crawl_result` | `GET /browser-rendering/crawl/{job_id}` |
| `cancel_crawl` | `DELETE /browser-rendering/crawl/{job_id}` |
| `list_browser_sessions` | `GET /browser-rendering/devtools/session` |
| `kill_browser_session` | `DELETE /browser-rendering/devtools/browser/{session_id}` |

## Notes

- Tools mirror the existing style (account-scoped, `url` input, pass-through of the most useful optional params).
- `get_url_pdf` returns the PDF as an MCP embedded resource (`mimeType: application/pdf`, base64 blob).
- `get_url_snapshot` returns the page HTML as text plus the screenshot as an image block.
- `get_url_json` accepts an optional `prompt` and `response_format` for AI extraction.
- `start_crawl` is async — it returns a `job_id` and instructs the agent to poll `get_crawl_result`.
- README tool table and prompt examples updated; changeset added (`cloudflare-browser-mcp-server` minor).

## Testing

- `pnpm --filter cloudflare-browser-mcp-server check:types` ✅
- `pnpm --filter cloudflare-browser-mcp-server check:lint` ✅
- Prettier ✅

Opened as a **draft** pending verification of each tool against the live REST API.

Tracked internally as RM-29118 / BRAPI-1319, BRAPI-1320, BRAPI-1321.
