### PR TITLE
fix(browser-rendering): start_crawl depth requires >=1 to match REST API

### DIFF
--- a/.changeset/browser-mcp-crawl-depth-min.md
+++ b/.changeset/browser-mcp-crawl-depth-min.md
@@ -1,0 +1,5 @@
+---
+'cloudflare-browser-mcp-server': patch
+---
+
+Fix `start_crawl` tool `depth` parameter validation: the REST `/crawl` endpoint requires `depth >= 1`, but the MCP tool schema allowed `depth: 0`, producing a confusing downstream 400 instead of a clear local validation error. Schema now uses `.min(1)`.

--- a/apps/browser-rendering/src/tools/browser.tools.ts
+++ b/apps/browser-rendering/src/tools/browser.tools.ts
@@ -382,7 +382,7 @@ export function registerBrowserTools(agent: BrowserMCP) {
 				.boolean()
 				.default(true)
 				.describe('Whether to render pages with a browser (vs. fetching raw HTML)'),
-			depth: z.number().int().min(0).optional().describe('How many links deep to crawl'),
+			depth: z.number().int().min(1).optional().describe('How many links deep to crawl'),
 			limit: z.number().int().min(1).optional().describe('Maximum number of pages to crawl'),
 		},
 		async (params, accountId) => {


### PR DESCRIPTION
## What

The `start_crawl` MCP tool declares `depth` as `z.number().int().min(0)`, but the Browser Rendering REST `/crawl` endpoint rejects `depth: 0` with `too_small (minimum: 1)`. An agent passing `depth: 0` clears local MCP validation and then hits a confusing downstream 400.

This changes the schema to `.min(1)` so the failure surfaces locally with a clear message.

```diff
- depth: z.number().int().min(0).optional().describe('How many links deep to crawl'),
+ depth: z.number().int().min(1).optional().describe('How many links deep to crawl'),
```

## Why

Found while validating the quick-action-parity tools from #407 against the live REST API on a real account:

```
POST /accounts/{acct}/browser-rendering/crawl  {"url":"...","depth":0}
-> success:false, errors:[{code:"too_small", minimum:1, path:["depth"]}]
```

`depth` omitted or `>= 1` works and returns a string `job_id`.

## Testing

- Verified against the live REST `/crawl` endpoint (depth 0 rejected, depth >= 1 / omitted accepted).
- Changeset added (`cloudflare-browser-mcp-server` patch).

## Tracking

BRAPI-1346