### PR TITLE
Rename Browser Rendering to Browser Run

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The following servers are included in this repository:
 | [**Workers Builds server**](/apps/workers-builds)              | Get insights and manage your Cloudflare Workers Builds                                          | `https://builds.mcp.cloudflare.com/mcp`        |
 | [**Observability server**](/apps/workers-observability)        | Debug and get insight into your application's logs and analytics                                | `https://observability.mcp.cloudflare.com/mcp` |
 | [**Container server**](/apps/sandbox-container)                | Spin up a sandbox development environment                                                       | `https://containers.mcp.cloudflare.com/mcp`    |
-| [**Browser rendering server**](/apps/browser-rendering)        | Fetch web pages, convert them to markdown and take screenshots                                  | `https://browser.mcp.cloudflare.com/mcp`       |
+| [**Browser Run server**](/apps/browser-rendering)              | Fetch web pages, convert them to markdown and take screenshots                                  | `https://browser.mcp.cloudflare.com/mcp`       |
 | [**Logpush server**](/apps/logpush)                            | Get quick summaries for Logpush job health                                                      | `https://logs.mcp.cloudflare.com/mcp`          |
 | [**AI Gateway server**](/apps/ai-gateway)                      | Search your logs, get details about the prompts and responses                                   | `https://ai-gateway.mcp.cloudflare.com/mcp`    |
 | [**Audit Logs server**](/apps/auditlogs)                       | Query audit logs and generate reports for review                                                | `https://auditlogs.mcp.cloudflare.com/mcp`     |
@@ -45,7 +45,7 @@ Use the **domain-specific servers** in this repository when:
 
 - you want purpose-built tools for a specific product area
 - you want more guided, typed interactions
-- you are working primarily within one Cloudflare domain such as observability, bindings, Radar, or Browser Rendering
+- you are working primarily within one Cloudflare domain such as observability, bindings, Radar, or Browser Run
 
 Learn more about the Code Mode server here: [`cloudflare/mcp`](https://github.com/cloudflare/mcp).
 
@@ -74,7 +74,7 @@ If your client does not yet support remote MCP servers, you will need to set up 
 
 To use one of Cloudflare's MCP servers with [OpenAI's responses API](https://openai.com/index/new-tools-and-features-in-the-responses-api/), you will need to provide the Responses API with an API token that has the scopes (permissions) required for that particular MCP server.
 
-For example, to use the [Browser Rendering MCP server](https://github.com/cloudflare/mcp-server-cloudflare/tree/main/apps/browser-rendering) with OpenAI, create an API token in the Cloudflare dashboard [here](https://dash.cloudflare.com/profile/api-tokens), with the following permissions:
+For example, to use the [Browser Run MCP server](https://github.com/cloudflare/mcp-server-cloudflare/tree/main/apps/browser-rendering) with OpenAI, create an API token in the Cloudflare dashboard [here](https://dash.cloudflare.com/profile/api-tokens), with the following permissions:
 
 <img width="937" alt="Screenshot 2025-05-21 at 10 38 02 AM" src="https://github.com/user-attachments/assets/872e253f-23ce-43b3-983c-45f9d0f66100" />
 

--- a/apps/browser-rendering/README.md
+++ b/apps/browser-rendering/README.md
@@ -1,9 +1,9 @@
-# Cloudflare Browser Rendering MCP Server 📡
+# Cloudflare Browser Run MCP Server 📡
 
 This is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction) server that supports remote MCP
 connections, with Cloudflare OAuth built-in.
 
-It integrates tools powered by the [Cloudflare Browser Rendering API](https://developers.cloudflare.com/browser-rendering/) to fetch
+It integrates tools powered by the [Cloudflare Browser Run API](https://developers.cloudflare.com/browser-run/) to fetch
 web pages, convert them to markdown, and take screenshots.
 
 ## 🔨 Available Tools
@@ -23,8 +23,8 @@ Currently available tools:
 | `start_crawl`           | Starts an asynchronous crawl of a website and returns a `job_id`.                   |
 | `get_crawl_result`      | Returns the status and records of a crawl job.                                      |
 | `cancel_crawl`          | Cancels a running crawl job.                                                        |
-| `list_browser_sessions` | Lists active Browser Rendering sessions for the account.                            |
-| `kill_browser_session`  | Closes (kills) a Browser Rendering session by its session ID.                       |
+| `list_browser_sessions` | Lists active Browser Run sessions for the account.                                  |
+| `kill_browser_session`  | Closes (kills) a Browser Run session by its session ID.                             |
 
 **Note:** These tools are account-scoped. Single-account credentials (and account-scoped API tokens) are detected automatically. If your credentials can access multiple accounts, pass `account_id` to the tool, or set a `cf-account-id` request header in your MCP client config.
 

--- a/apps/browser-rendering/src/browser.app.ts
+++ b/apps/browser-rendering/src/browser.app.ts
@@ -72,7 +72,7 @@ export class BrowserMCP extends McpAgent<Env, State, Props> {
 const BrowserScopes = {
 	...RequiredScopes,
 	'account:read': 'See your account info such as account details, analytics, and memberships.',
-	'browser:write': 'Grants write level access to Browser Rendering.',
+	'browser:write': 'Grants write level access to Browser Run.',
 } as const
 
 export default {

--- a/apps/browser-rendering/src/tools/browser.tools.ts
+++ b/apps/browser-rendering/src/tools/browser.tools.ts
@@ -16,7 +16,7 @@ export function registerBrowserTools(agent: BrowserMCP) {
 			try {
 				const props = getProps(agent)
 				const client = getCloudflareClient(props.accessToken)
-				const r = await client.browserRendering.content.create({
+				const r = await client.browserRun.content.create({
 					account_id: accountId,
 					url: params.url,
 				})
@@ -55,7 +55,7 @@ export function registerBrowserTools(agent: BrowserMCP) {
 			try {
 				const props = getProps(agent)
 				const client = getCloudflareClient(props.accessToken)
-				const r = (await client.post(`/accounts/${accountId}/browser-rendering/markdown`, {
+				const r = (await client.post(`/accounts/${accountId}/browser-run/markdown`, {
 					body: {
 						url: params.url,
 					},
@@ -102,7 +102,7 @@ export function registerBrowserTools(agent: BrowserMCP) {
 				const props = getProps(agent)
 				const client = getCloudflareClient(props.accessToken)
 				const r = await client
-					.post(`/accounts/${accountId}/browser-rendering/screenshot`, {
+					.post(`/accounts/${accountId}/browser-run/screenshot`, {
 						body: {
 							url: params.url,
 							viewport: params.viewport,
@@ -148,7 +148,7 @@ export function registerBrowserTools(agent: BrowserMCP) {
 				const props = getProps(agent)
 				const client = getCloudflareClient(props.accessToken)
 				const r = await client
-					.post(`/accounts/${accountId}/browser-rendering/pdf`, {
+					.post(`/accounts/${accountId}/browser-run/pdf`, {
 						body: {
 							url: params.url,
 						},
@@ -195,7 +195,7 @@ export function registerBrowserTools(agent: BrowserMCP) {
 			try {
 				const props = getProps(agent)
 				const client = getCloudflareClient(props.accessToken)
-				const r = (await client.post(`/accounts/${accountId}/browser-rendering/snapshot`, {
+				const r = (await client.post(`/accounts/${accountId}/browser-run/snapshot`, {
 					body: {
 						url: params.url,
 					},
@@ -251,7 +251,7 @@ export function registerBrowserTools(agent: BrowserMCP) {
 			try {
 				const props = getProps(agent)
 				const client = getCloudflareClient(props.accessToken)
-				const r = (await client.post(`/accounts/${accountId}/browser-rendering/scrape`, {
+				const r = (await client.post(`/accounts/${accountId}/browser-run/scrape`, {
 					body: {
 						url: params.url,
 						elements: params.elements,
@@ -298,7 +298,7 @@ export function registerBrowserTools(agent: BrowserMCP) {
 			try {
 				const props = getProps(agent)
 				const client = getCloudflareClient(props.accessToken)
-				const r = (await client.post(`/accounts/${accountId}/browser-rendering/json`, {
+				const r = (await client.post(`/accounts/${accountId}/browser-run/json`, {
 					body: {
 						url: params.url,
 						...(params.prompt ? { prompt: params.prompt } : {}),
@@ -342,7 +342,7 @@ export function registerBrowserTools(agent: BrowserMCP) {
 			try {
 				const props = getProps(agent)
 				const client = getCloudflareClient(props.accessToken)
-				const r = (await client.post(`/accounts/${accountId}/browser-rendering/links`, {
+				const r = (await client.post(`/accounts/${accountId}/browser-run/links`, {
 					body: {
 						url: params.url,
 						...(params.visibleLinksOnly !== undefined
@@ -389,7 +389,7 @@ export function registerBrowserTools(agent: BrowserMCP) {
 			try {
 				const props = getProps(agent)
 				const client = getCloudflareClient(props.accessToken)
-				const r = (await client.post(`/accounts/${accountId}/browser-rendering/crawl`, {
+				const r = (await client.post(`/accounts/${accountId}/browser-run/crawl`, {
 					body: {
 						url: params.url,
 						render: params.render,
@@ -434,7 +434,7 @@ export function registerBrowserTools(agent: BrowserMCP) {
 				const props = getProps(agent)
 				const client = getCloudflareClient(props.accessToken)
 				const r = (await client.get(
-					`/accounts/${accountId}/browser-rendering/crawl/${params.job_id}`
+					`/accounts/${accountId}/browser-run/crawl/${params.job_id}`
 				)) as { result: unknown }
 
 				return {
@@ -470,7 +470,7 @@ export function registerBrowserTools(agent: BrowserMCP) {
 				const props = getProps(agent)
 				const client = getCloudflareClient(props.accessToken)
 				const r = (await client.delete(
-					`/accounts/${accountId}/browser-rendering/crawl/${params.job_id}`
+					`/accounts/${accountId}/browser-run/crawl/${params.job_id}`
 				)) as { result: unknown }
 
 				return {
@@ -506,7 +506,7 @@ export function registerBrowserTools(agent: BrowserMCP) {
 				// This endpoint returns a bare JSON array of sessions, not the
 				// usual `{ success, result }` envelope, so use the response as-is.
 				const r = (await client.get(
-					`/accounts/${accountId}/browser-rendering/devtools/session`
+					`/accounts/${accountId}/browser-run/devtools/session`
 				)) as unknown
 				const result =
 					r && typeof r === 'object' && 'result' in r ? (r as { result: unknown }).result : r
@@ -544,7 +544,7 @@ export function registerBrowserTools(agent: BrowserMCP) {
 				const props = getProps(agent)
 				const client = getCloudflareClient(props.accessToken)
 				await client.delete(
-					`/accounts/${accountId}/browser-rendering/devtools/browser/${params.session_id}`
+					`/accounts/${accountId}/browser-run/devtools/browser/${params.session_id}`
 				)
 
 				return {

--- a/apps/browser-rendering/src/tools/browser.tools.ts
+++ b/apps/browser-rendering/src/tools/browser.tools.ts
@@ -16,7 +16,7 @@ export function registerBrowserTools(agent: BrowserMCP) {
 			try {
 				const props = getProps(agent)
 				const client = getCloudflareClient(props.accessToken)
-				const r = await client.browserRun.content.create({
+				const r = await client.browserRendering.content.create({
 					account_id: accountId,
 					url: params.url,
 				})

--- a/apps/browser-rendering/worker-configuration.d.ts
+++ b/apps/browser-rendering/worker-configuration.d.ts
@@ -5,7 +5,7 @@ interface __BaseEnv_Env {
 	OAUTH_KV: KVNamespace;
 	MCP_METRICS: AnalyticsEngineDataset;
 	ENVIRONMENT: "staging" | "production" | "development";
-	MCP_SERVER_NAME: "Cloudflare Browser Rendering Remote MCP Server - Staging" | "Cloudflare Browser Rendering Remote MCP Server" | "<PLACEHOLDER>";
+	MCP_SERVER_NAME: "Cloudflare Browser Run Remote MCP Server - Staging" | "Cloudflare Browser Run Remote MCP Server" | "<PLACEHOLDER>";
 	MCP_SERVER_VERSION: "1.0.0" | "<PLACEHOLDER>";
 	MCP_OBJECT: DurableObjectNamespace<import("./src/browser.app").BrowserMCP>;
 	CLOUDFLARE_CLIENT_ID?: "<PLACEHOLDER>";
@@ -20,7 +20,7 @@ declare namespace Cloudflare {
 		OAUTH_KV: KVNamespace;
 		MCP_METRICS: AnalyticsEngineDataset;
 		ENVIRONMENT: "staging";
-		MCP_SERVER_NAME: "Cloudflare Browser Rendering Remote MCP Server - Staging";
+		MCP_SERVER_NAME: "Cloudflare Browser Run Remote MCP Server - Staging";
 		MCP_SERVER_VERSION: "1.0.0";
 		MCP_OBJECT: DurableObjectNamespace<import("./src/browser.app").BrowserMCP>;
 	}
@@ -28,7 +28,7 @@ declare namespace Cloudflare {
 		OAUTH_KV: KVNamespace;
 		MCP_METRICS: AnalyticsEngineDataset;
 		ENVIRONMENT: "production";
-		MCP_SERVER_NAME: "Cloudflare Browser Rendering Remote MCP Server";
+		MCP_SERVER_NAME: "Cloudflare Browser Run Remote MCP Server";
 		MCP_SERVER_VERSION: "1.0.0";
 		MCP_OBJECT: DurableObjectNamespace<import("./src/browser.app").BrowserMCP>;
 	}

--- a/apps/browser-rendering/wrangler.jsonc
+++ b/apps/browser-rendering/wrangler.jsonc
@@ -74,7 +74,7 @@
 			],
 			"vars": {
 				"ENVIRONMENT": "staging",
-				"MCP_SERVER_NAME": "Cloudflare Browser Rendering Remote MCP Server - Staging",
+				"MCP_SERVER_NAME": "Cloudflare Browser Run Remote MCP Server - Staging",
 				"MCP_SERVER_VERSION": "1.0.0"
 			},
 			"analytics_engine_datasets": [
@@ -104,7 +104,7 @@
 			],
 			"vars": {
 				"ENVIRONMENT": "production",
-				"MCP_SERVER_NAME": "Cloudflare Browser Rendering Remote MCP Server",
+				"MCP_SERVER_NAME": "Cloudflare Browser Run Remote MCP Server",
 				"MCP_SERVER_VERSION": "1.0.0"
 			},
 			"analytics_engine_datasets": [

--- a/packages/mcp-common/src/tools/docs-ai-search.tools.ts
+++ b/packages/mcp-common/src/tools/docs-ai-search.tools.ts
@@ -58,7 +58,7 @@ export function registerDocsTools(server: McpServer, env: RequiredEnv) {
 
 		This tool should be used to answer any question about Cloudflare products or features, including:
 		- Workers, Pages, R2, Images, Stream, D1, Durable Objects, KV, Workflows, Hyperdrive, Queues
-		- AI Search, Workers AI, Vectorize, AI Gateway, Browser Rendering
+		- AI Search, Workers AI, Vectorize, AI Gateway, Browser Run
 		- Zero Trust, Access, Tunnel, Gateway, Browser Isolation, WARP, DDOS, Magic Transit, Magic WAN
 		- CDN, Cache, DNS, Zaraz, Argo, Rulesets, Terraform, Account and Billing
 

--- a/packages/mcp-common/src/tools/docs-vectorize.tools.ts
+++ b/packages/mcp-common/src/tools/docs-vectorize.tools.ts
@@ -22,7 +22,7 @@ export function registerDocsTools(server: McpServer, env: RequiredEnv) {
 
 		This tool should be used to answer any question about Cloudflare products or features, including:
 		- Workers, Pages, R2, Images, Stream, D1, Durable Objects, KV, Workflows, Hyperdrive, Queues
-		- AI Search, Workers AI, Vectorize, AI Gateway, Browser Rendering
+		- AI Search, Workers AI, Vectorize, AI Gateway, Browser Run
 		- Zero Trust, Access, Tunnel, Gateway, Browser Isolation, WARP, DDOS, Magic Transit, Magic WAN
 		- CDN, Cache, DNS, Zaraz, Argo, Rulesets, Terraform, Account and Billing
 


### PR DESCRIPTION
## What

Renames **Browser Rendering → Browser Run** across the `browser-rendering` MCP server and the shared docs product lists, following the product rebrand (docs now live at [`/browser-run/`](https://developers.cloudflare.com/browser-run/)).

## Changes

**Display / product name:**

- Top-level `README.md`: server table row, domain-picker guidance, OpenAI example
- `apps/browser-rendering/README.md`: title, API name + docs link (`/browser-rendering/` → `/browser-run/`), session tool descriptions
- `MCP_SERVER_NAME` in `wrangler.jsonc` + `worker-configuration.d.ts`
- `browser:write` permission description in `browser.app.ts`
- Product lists in `docs-ai-search.tools.ts` / `docs-vectorize.tools.ts`

**API routes:**

- API string paths `/accounts/{id}/browser-rendering/*` → `/browser-run/*` (all 12: content, markdown, screenshot, pdf, snapshot, scrape, json, links, crawl, crawl/{job_id}, devtools/session, devtools/browser/{session_id})

## Validation

The `/browser-run/*` REST routes are **confirmed working live** — the gateway aliases the new prefix, so no coordinated backend change is needed. Every changed route returns `200 success` against a real account:

| Route | Status |
|-------|--------|
| `browser-run/content` | 200 ✅ |
| `browser-run/snapshot` | 200 ✅ |
| `browser-run/scrape` | 200 ✅ |
| `browser-run/links` | 200 ✅ |
| `browser-run/markdown` | 200 ✅ |
| `browser-run/screenshot` | 200 ✅ |
| `browser-run/pdf` | 200 ✅ |
| `browser-run/json` | 200 ✅ |
| `browser-run/crawl` | 200 ✅ |
| `browser-run/devtools/session` | 200 ✅ |

`pnpm check:types` passes.

## SDK namespace: intentionally left on `browserRendering`

The `get_url_html_content` tool uses the typed SDK (`client.browserRendering.content.create`), not a string path. The `cloudflare` TS SDK — even latest `6.5.0` — still exports **only** `client.browserRendering`; there is no `browserRun` namespace yet:

```ts
import { BrowserRendering } from "./resources/browser-rendering/browser-rendering.js";
browserRendering: API.BrowserRendering;
```

So this one call stays on `browserRendering` (it hits the same working API and typechecks). Swap it to `browserRun` once the TS SDK ships that alias.

## Intentionally NOT changed

To avoid breaking deployment/infra: the `apps/browser-rendering` directory, the `*.mcp.cloudflare.com` custom-domain routes, the worker names, the `BrowserMCP` durable-object class, and KV namespace IDs.
