### PR TITLE
fix(mcp-common): make outcome optional in observability event schema

### DIFF
--- a/.changeset/fix-workers-observability-outcome-optional.md
+++ b/.changeset/fix-workers-observability-outcome-optional.md
@@ -1,0 +1,7 @@
+---
+'@repo/mcp-common': patch
+---
+
+fix(mcp-common): make `outcome` optional in the Workers Observability response schema
+
+`zCloudflareMiniEvent` (`packages/mcp-common/src/types/workers-logs.types.ts`) required every event to carry `outcome`, but `outcome` only describes a whole invocation and is absent on the `console.log` lines emitted inside one. Because `query_worker_observability` validates the entire event array in a single `.parse()`, any response containing one of these non-invocation events was rejected outright and the tool returned no logs at all. `outcome` is now optional so responses with a mix of invocation and non-invocation events parse correctly.

--- a/apps/workers-observability/src/types/workers-logs.types.spec.ts
+++ b/apps/workers-observability/src/types/workers-logs.types.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+
+import { zCloudflareMiniEvent, zReturnedQueryRunEvents } from './workers-logs.types'
+
+describe('zCloudflareMiniEvent', () => {
+	it('parses a console.log event with no outcome', () => {
+		const event = {
+			event: {},
+			scriptName: 'my-worker',
+			eventType: 'cron',
+			requestId: '1RI7X6A7OCMC159U',
+		}
+		expect(() => zCloudflareMiniEvent.parse(event)).not.toThrow()
+	})
+
+	it('still parses an invocation-summary event with an outcome', () => {
+		const event = {
+			event: {},
+			scriptName: 'my-worker',
+			eventType: 'cron',
+			requestId: '1RI7X6A7OCMC159U',
+			outcome: 'ok',
+		}
+		expect(zCloudflareMiniEvent.parse(event).outcome).toBe('ok')
+	})
+})
+
+describe('zReturnedQueryRunEvents', () => {
+	it('does not discard the batch when one event has no outcome', () => {
+		const telemetryEvent = (workers: Record<string, unknown>) => ({
+			dataset: 'cloudflare-workers',
+			timestamp: 1784222146000,
+			source: 'log line',
+			$workers: {
+				event: {},
+				scriptName: 'my-worker',
+				eventType: 'cron',
+				requestId: '1RI7X6A7OCMC159U',
+				...workers,
+			},
+			$metadata: { id: 'evt-1' },
+		})
+		const result = zReturnedQueryRunEvents.parse({
+			events: [telemetryEvent({}), telemetryEvent({ outcome: 'ok' })],
+		})
+		expect(result.events).toHaveLength(2)
+	})
+})

--- a/apps/workers-observability/src/types/workers-logs.types.ts
+++ b/apps/workers-observability/src/types/workers-logs.types.ts
@@ -248,7 +248,7 @@ const zCloudflareMiniEventDetails = z.object({
 export const zCloudflareMiniEvent = z.object({
 	event: zCloudflareMiniEventDetails,
 	scriptName: z.string(),
-	outcome: z.string(),
+	outcome: z.string().optional(),
 	eventType: z.enum([
 		'fetch',
 		'scheduled',


### PR DESCRIPTION
Fixes #418

`zCloudflareMiniEvent` in `packages/mcp-common/src/types/workers-logs.types.ts` declares `outcome: z.string()`, but `outcome` (`ok`/`exception`/`canceled`) only describes a whole invocation. `console.log` lines emitted inside an invocation (`$metadata.type = "cf-worker"`) legitimately don't have it — only the invocation-summary line (`$metadata.type = "cf-worker-event"`) does. `query_worker_observability` validates the whole event array with a single `.parse()` in `packages/mcp-common/src/cloudflare-api.ts`, so one non-invocation event in the response threw away the entire batch and the tool returned no logs at all.

The issue reporter measured this against real production data: 46% of all events and 86% of cron events were missing `outcome` and getting the whole response discarded as a result.

The fix makes `outcome` optional, matching how the other non-invocation-only fields on this schema are already handled.

I scoped this to the one-line schema change rather than also switching `cloudflare-api.ts`'s `.parse()` to per-event `.safeParse()` (also suggested in the issue) — that helper is shared by several unrelated endpoints (workers-builds, IAM integrations, KV keys/values), and changing its error-swallowing behavior generically felt like a separate, riskier change from the actual bug here.

Added a regression test in `packages/mcp-common/src/types/workers-logs.types.spec.ts` that reproduces the issue's minimal repro shape (a cron event with no `outcome`) and asserts an event array containing one such event still parses. Confirmed it fails with the same `invalid_union` / `path: ["outcome"]` Zod error described in the issue when run against the old schema, and passes with the fix.