### PR TITLE
docs: add mcpindex screened badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![mcpindex](https://mcpindex.ai/api/v1/badge/com-cloudflare-mcp-mcp)](https://mcpindex.ai/server/com-cloudflare-mcp-mcp)
+
 # Cloudflare MCP Server
 
 Model Context Protocol (MCP) is a [new, standardized protocol](https://modelcontextprotocol.io/introduction) for managing context between large language models (LLMs) and external systems. In this repository, you can find several MCP servers allowing you to connect to Cloudflare's service from an MCP client (e.g. Cursor, Claude) and use natural language to accomplish tasks through your Cloudflare account.


### PR DESCRIPTION
Hey, ran mcp-server-cloudflare through mcpindex's screen (description-level check for injection/manipulation patterns, nothing deeper). Came back clean, so added the badge to your README. Advisory signal, not a security certification. Close this if it's not a fit, no hard feelings.