### PR TITLE
Use direct MCP server connections in documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,7 +10,7 @@ assignees: ''
 **Client Information**
  - LLM Client: [e.g. Claude Desktop, claude.ai, Cursor, VSCode]
  - Client Config: [e.g. claude_desktop_config.json or screenshot of client configuration UI]
- - Using MCP Remote?: Yes/No
+ - Connection Method: [e.g. direct server URL or client integration]
  - MCP Server: [e.g. https://observability.mcp.cloudflare.com, https://docs.mcp.cloudflare.com]
  - Prompt: [if applicable, add the prompt used]
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,7 +10,6 @@ assignees: ''
 **Client Information**
  - LLM Client: [e.g. Claude Desktop, claude.ai, Cursor, VSCode]
  - Client Config: [e.g. claude_desktop_config.json or screenshot of client configuration UI]
- - Connection Method: [e.g. direct server URL or client integration]
  - MCP Server: [e.g. https://observability.mcp.cloudflare.com, https://docs.mcp.cloudflare.com]
  - Prompt: [if applicable, add the prompt used]
 

--- a/README.md
+++ b/README.md
@@ -53,26 +53,9 @@ Use the **domain-specific servers** in this repository when:
 
 Learn more about the Code Mode server here: [`cloudflare/mcp`](https://github.com/cloudflare/mcp).
 
-## Access the remote MCP server from any MCP client
+## Connect to an MCP server
 
-If your MCP client has first class support for remote MCP servers, the client will provide a way to accept the server URL directly within its interface (e.g. [Cloudflare AI Playground](https://playground.ai.cloudflare.com/))
-
-If your client does not yet support remote MCP servers, you will need to set up its respective configuration file using mcp-remote (https://www.npmjs.com/package/mcp-remote) to specify which servers your client can access.
-
-```json
-{
-	"mcpServers": {
-		"cloudflare-observability": {
-			"command": "npx",
-			"args": ["mcp-remote", "https://observability.mcp.cloudflare.com/mcp"]
-		},
-		"cloudflare-bindings": {
-			"command": "npx",
-			"args": ["mcp-remote", "https://bindings.mcp.cloudflare.com/mcp"]
-		}
-	}
-}
-```
+Connect any MCP client with remote-server support directly to a URL in the table above. [Cloudflare AI Playground](https://playground.ai.cloudflare.com/) also accepts server URLs in its interface.
 
 ## Using Cloudflare's MCP servers from the OpenAI Responses API
 

--- a/apps/ai-gateway/README.md
+++ b/apps/ai-gateway/README.md
@@ -30,25 +30,8 @@ This MCP server is still a work in progress, and we plan to add more tools in th
 - `Show logs for gateway 'gateway-001' between January 1, 2023, and January 31, 2023.`
 - `Fetch the latest errors from gateway-001 and debug what might have happened wrongly`
 
-## Access the remote MCP server from any MCP Client
+## Connect to the MCP server
 
-If your MCP client has first class support for remote MCP servers, the client will provide a way to accept the server URL (`https://ai-gateway.mcp.cloudflare.com/mcp`) directly within its interface (for example in [Cloudflare AI Playground](https://playground.ai.cloudflare.com/)).
-
-If your client does not yet support remote MCP servers, you will need to set up its respective configuration file using mcp-remote (https://www.npmjs.com/package/mcp-remote) to specify which servers your client can access.
-
-Replace the content with the following configuration:
-
-```json
-{
-	"mcpServers": {
-		"cloudflare": {
-			"command": "npx",
-			"args": ["mcp-remote", "https://ai-gateway.mcp.cloudflare.com/mcp"]
-		}
-	}
-}
-```
-
-Once you've set up your configuration file, restart MCP client and a browser window will open showing your OAuth login page. Proceed through the authentication flow to grant the client access to your MCP server. After you grant access, the tools will become available for you to use.
+Connect your MCP client directly to `https://ai-gateway.mcp.cloudflare.com/mcp`. If prompted, complete the Cloudflare OAuth flow in your browser. The tools become available after authorization.
 
 Interested in contributing, and running this server locally? See [CONTRIBUTING.md](CONTRIBUTING.md) to get started.

--- a/apps/auditlogs/README.md
+++ b/apps/auditlogs/README.md
@@ -22,23 +22,6 @@ Currently available tools:
 - `Were there any suspicious changes made to my Cloudflare account yesterday around lunch time?`
 - `When was the last activity that updated a DNS record?`
 
-## Access the remote MCP server from any MCP Client
+## Connect to the MCP server
 
-If your MCP client has first class support for remote MCP servers, the client will provide a way to accept the server URL (`https://auditlogs.mcp.cloudflare.com/mcp`) directly within its interface (for example in [Cloudflare AI Playground](https://playground.ai.cloudflare.com/)).
-
-If your client does not yet support remote MCP servers, you will need to set up its respective configuration file using [mcp-remote](https://www.npmjs.com/package/mcp-remote) to specify which servers your client can access.
-
-Replace the content with the following configuration:
-
-```json
-{
-	"mcpServers": {
-		"cloudflare": {
-			"command": "npx",
-			"args": ["mcp-remote", "https://auditlogs.mcp.cloudflare.com/mcp"]
-		}
-	}
-}
-```
-
-Once you've set up your configuration file, restart MCP client and a browser window will open showing your OAuth login page. Proceed through the authentication flow to grant the client access to your MCP server. After you grant access, the tools will become available for you to use.
+Connect your MCP client directly to `https://auditlogs.mcp.cloudflare.com/mcp`. If prompted, complete the Cloudflare OAuth flow in your browser. The tools become available after authorization.

--- a/apps/autorag/README.md
+++ b/apps/autorag/README.md
@@ -54,27 +54,10 @@ Currently available tools:
 - `Search for documents in AutoRAG with ID 'rag123' using the query 'cloudflare security'.`
 - `Perform an AI search in AutoRAG with ID 'rag456' for 'best practices for vector stores'.`
 
-## Access the remote MCP server from any MCP Client
+## Connect to the MCP server
 
 > The following setup documentation is retained for existing users. New users should follow the migration path to [`mcp.cloudflare.com/mcp`](https://mcp.cloudflare.com/mcp) documented above.
 
-If your MCP client has first class support for remote MCP servers, the client will provide a way to accept the server URL (`https://autorag.mcp.cloudflare.com/mcp`) directly within its interface (for example in [Cloudflare AI Playground](https://playground.ai.cloudflare.com/)).
-
-If your client does not yet support remote MCP servers, you will need to set up its respective configuration file using mcp-remote (https://www.npmjs.com/package/mcp-remote) to specify which servers your client can access.
-
-Replace the content with the following configuration:
-
-```json
-{
-	"mcpServers": {
-		"cloudflare": {
-			"command": "npx",
-			"args": ["mcp-remote", "https://autorag.mcp.cloudflare.com/mcp"]
-		}
-	}
-}
-```
-
-Once you've set up your configuration file, restart MCP client and a browser window will open showing your OAuth login page. Proceed through the authentication flow to grant the client access to your MCP server. After you grant access, the tools will become available for you to use.
+Connect your MCP client directly to `https://autorag.mcp.cloudflare.com/mcp`. If prompted, complete the Cloudflare OAuth flow in your browser. The tools become available after authorization.
 
 Interested in contributing, and running this server locally? See [CONTRIBUTING.md](CONTRIBUTING.md) to get started.

--- a/apps/browser-rendering/README.md
+++ b/apps/browser-rendering/README.md
@@ -43,25 +43,8 @@ This MCP server is still a work in progress, and we plan to add more tools in th
 - `Crawl https://example.com two levels deep and give me the results.`
 - `List my active browser sessions and kill the oldest one.`
 
-## Access the remote MCP server from any MCP Client
+## Connect to the MCP server
 
-If your MCP client has first class support for remote MCP servers, the client will provide a way to accept the server URL (`https://browser.mcp.cloudflare.com/mcp`) directly within its interface (for example in [Cloudflare AI Playground](https://playground.ai.cloudflare.com/)).
-
-If your client does not yet support remote MCP servers, you will need to set up its respective configuration file using mcp-remote (https://www.npmjs.com/package/mcp-remote) to specify which servers your client can access.
-
-Replace the content with the following configuration:
-
-```json
-{
-	"mcpServers": {
-		"cloudflare": {
-			"command": "npx",
-			"args": ["mcp-remote", "https://browser.mcp.cloudflare.com/mcp"]
-		}
-	}
-}
-```
-
-Once you've set up your configuration file, restart MCP client and a browser window will open showing your OAuth login page. Proceed through the authentication flow to grant the client access to your MCP server. After you grant access, the tools will become available for you to use.
+Connect your MCP client directly to `https://browser.mcp.cloudflare.com/mcp`. If prompted, complete the Cloudflare OAuth flow in your browser. The tools become available after authorization.
 
 Interested in contributing, and running this server locally? See [CONTRIBUTING.md](CONTRIBUTING.md) to get started.

--- a/apps/dex-analysis/README.md
+++ b/apps/dex-analysis/README.md
@@ -45,25 +45,8 @@ This MCP server is still a work in progress, and we plan to add more tools in th
 - `Which Cloudflare colo is most used by my users in the EU running DEX application tests?`
 - `Look at the latest WARP diag for user@cloudflare.com and tell me if you see anything notable in dns logs`
 
-## Access the remote MCP server from any MCP Client
+## Connect to the MCP server
 
-If your MCP client has first class support for remote MCP servers, the client will provide a way to accept the server URL (`https://dex.mcp.cloudflare.com/mcp`) directly within its interface (for example in [Cloudflare AI Playground](https://playground.ai.cloudflare.com/)).
-
-If your client does not yet support remote MCP servers, you will need to set up its respective configuration file using [mcp-remote](https://www.npmjs.com/package/mcp-remote) to specify which servers your client can access.
-
-Replace the content with the following configuration:
-
-```json
-{
-	"mcpServers": {
-		"cloudflare": {
-			"command": "npx",
-			"args": ["mcp-remote", "https://dex.mcp.cloudflare.com/mcp"]
-		}
-	}
-}
-```
-
-Once you've set up your configuration file, restart MCP client and a browser window will open showing your OAuth login page. Proceed through the authentication flow to grant the client access to your MCP server. After you grant access, the tools will become available for you to use.
+Connect your MCP client directly to `https://dex.mcp.cloudflare.com/mcp`. If prompted, complete the Cloudflare OAuth flow in your browser. The tools become available after authorization.
 
 Interested in contributing, and running this server locally? See [CONTRIBUTING.md](CONTRIBUTING.md) to get started.

--- a/apps/dns-analytics/README.md
+++ b/apps/dns-analytics/README.md
@@ -32,25 +32,8 @@ This MCP server is still a work in progress, and we plan to add more tools in th
 - `Read Cloudflare's documentation on managing DNS records and tell me how to optimize my DNS settings.`
 - `Show me DNS Report for https://example.com in the last X days.`
 
-## Access the remote MCP server from any MCP Client
+## Connect to the MCP server
 
-If your MCP client has first class support for remote MCP servers, the client will provide a way to accept the server URL (`https://dns-analytics.mcp.cloudflare.com/mcp`) directly within its interface (for example in [Cloudflare AI Playground](https://playground.ai.cloudflare.com/)).
-
-If your client does not yet support remote MCP servers, you will need to set up its respective configuration file using [mcp-remote](https://www.npmjs.com/package/mcp-remote) to specify which servers your client can access.
-
-Replace the content with the following configuration:
-
-```json
-{
-	"mcpServers": {
-		"cloudflare": {
-			"command": "npx",
-			"args": ["mcp-remote", "https://dns-analytics.mcp.cloudflare.com/mcp"]
-		}
-	}
-}
-```
-
-Once you've set up your configuration file, restart MCP client and a browser window will open showing your OAuth login page. Proceed through the authentication flow to grant the client access to your MCP server. After you grant access, the tools will become available for you to use.
+Connect your MCP client directly to `https://dns-analytics.mcp.cloudflare.com/mcp`. If prompted, complete the Cloudflare OAuth flow in your browser. The tools become available after authorization.
 
 Interested in contributing, and running this server locally? See [CONTRIBUTING.md](CONTRIBUTING.md) to get started.

--- a/apps/docs-ai-search/README.md
+++ b/apps/docs-ai-search/README.md
@@ -20,25 +20,8 @@ Currently available tools:
 - `How many indexes are supported in Workers Analytics Engine? Give an example using the Workers binding api.`
 - `Can you give me some information on how to use the Workers AI Search binding`
 
-## Access the remote MCP server from any MCP Client
+## Connect to the MCP server
 
-If your MCP client has first class support for remote MCP servers, the client will provide a way to accept the server URL (`https://docs.mcp.cloudflare.com/mcp`) directly within its interface (for example in [Cloudflare AI Playground](https://playground.ai.cloudflare.com/)).
-
-If your client does not yet support remote MCP servers, you will need to set up its respective configuration file using [mcp-remote](https://www.npmjs.com/package/mcp-remote) to specify which servers your client can access.
-
-Replace the content with the following configuration:
-
-```json
-{
-	"mcpServers": {
-		"cloudflare": {
-			"command": "npx",
-			"args": ["mcp-remote", "https://docs.mcp.cloudflare.com/mcp"]
-		}
-	}
-}
-```
-
-Once you have set up the configuration file, restart your MCP client. The documentation tools will become available without an OAuth login.
+Connect your MCP client directly to `https://docs.mcp.cloudflare.com/mcp`. This server does not require OAuth.
 
 Interested in contributing, and running this server locally? See the [CONTRIBUTING.md](../../CONTRIBUTING.md) in the repo root to get started.

--- a/apps/graphql/README.md
+++ b/apps/graphql/README.md
@@ -25,23 +25,6 @@ Currently available tools:
 - `Can you generate a link to the Cloudflare GraphQL API Explorer with a pre-populated query and variables?`
 - `I need to monitor HTTP requests and responses for a specific domain. Can you help me with that using the Cloudflare GraphQL API?`
 
-## Access the remote MCP server from Claude Desktop
+## Connect to the MCP server
 
-If your MCP client has first class support for remote MCP servers, the client will provide a way to accept the server URL (`https://graphql.mcp.cloudflare.com/mcp`) directly within its interface (for example in [Cloudflare AI Playground](https://playground.ai.cloudflare.com/)).
-
-If your client does not yet support remote MCP servers, you will need to set up its respective configuration file using [mcp-remote](https://www.npmjs.com/package/mcp-remote) to specify which servers your client can access.
-
-Replace the content with the following configuration:
-
-```json
-{
-	"mcpServers": {
-		"cloudflare": {
-			"command": "npx",
-			"args": ["mcp-remote", "https://graphql.mcp.cloudflare.com/mcp"]
-		}
-	}
-}
-```
-
-Once you've set up your configuration file, restart MCP client and a browser window will open showing your OAuth login page. Proceed through the authentication flow to grant the client access to your MCP server. After you grant access, the tools will become available for you to use.
+Connect your MCP client directly to `https://graphql.mcp.cloudflare.com/mcp`. If prompted, complete the Cloudflare OAuth flow in your browser. The tools become available after authorization.

--- a/apps/logpush/README.md
+++ b/apps/logpush/README.md
@@ -23,23 +23,6 @@ This MCP server is still a work in progress, and we plan to add more tools in th
 - `Do any of my Logpush jobs in my <insert name> account have errors?`
 - `Can you list all the enabled job failures from today?`
 
-## Access the remote MCP server from any MCP Client
+## Connect to the MCP server
 
-If your MCP client has first class support for remote MCP servers, the client will provide a way to accept the server URL (`https://logs.mcp.cloudflare.com/mcp`) directly within its interface (for example in [Cloudflare AI Playground](https://playground.ai.cloudflare.com/)).
-
-If your client does not yet support remote MCP servers, you will need to set up its respective configuration file using [mcp-remote](https://www.npmjs.com/package/mcp-remote) to specify which servers your client can access.
-
-Replace the content with the following configuration:
-
-```json
-{
-	"mcpServers": {
-		"cloudflare": {
-			"command": "npx",
-			"args": ["mcp-remote", "https://logs.mcp.cloudflare.com/mcp"]
-		}
-	}
-}
-```
-
-Once you've set up your configuration file, restart MCP client and a browser window will open showing your OAuth login page. Proceed through the authentication flow to grant the client access to your MCP server. After you grant access, the tools will become available for you to use.
+Connect your MCP client directly to `https://logs.mcp.cloudflare.com/mcp`. If prompted, complete the Cloudflare OAuth flow in your browser. The tools become available after authorization.

--- a/apps/radar/README.md
+++ b/apps/radar/README.md
@@ -202,25 +202,8 @@ Currently available tools:
 - `What are the details of IP address 8.8.8.8?`
 - `Give me full information about IP 1.1.1.1 including ASN details.`
 
-## Access the remote MCP server from any MCP Client
+## Connect to the MCP server
 
-If your MCP client has first class support for remote MCP servers, the client will provide a way to accept the server URL (`https://radar.mcp.cloudflare.com/mcp`) directly within its interface (for example in [Cloudflare AI Playground](https://playground.ai.cloudflare.com/)).
-
-If your client does not yet support remote MCP servers, you will need to set up its respective configuration file using [mcp-remote](https://www.npmjs.com/package/mcp-remote) to specify which servers your client can access.
-
-Replace the content with the following configuration:
-
-```json
-{
-	"mcpServers": {
-		"cloudflare": {
-			"command": "npx",
-			"args": ["mcp-remote", "https://radar.mcp.cloudflare.com/mcp"]
-		}
-	}
-}
-```
-
-Once you've set up your configuration file, restart MCP client and a browser window will open showing your OAuth login page. Proceed through the authentication flow to grant the client access to your MCP server. After you grant access, the tools will become available for you to use.
+Connect your MCP client directly to `https://radar.mcp.cloudflare.com/mcp`. If prompted, complete the Cloudflare OAuth flow in your browser. The tools become available after authorization.
 
 Interested in contributing, and running this server locally? See [CONTRIBUTING.md](CONTRIBUTING.md) to get started.

--- a/apps/sandbox-container/CONTRIBUTING.md
+++ b/apps/sandbox-container/CONTRIBUTING.md
@@ -26,19 +26,4 @@ Note: Temporary files created through files tool calls are stored in the workdir
 npx https://prerelease-registry.devprod.cloudflare.dev/workers-sdk/runs/14387504770/npm-package-wrangler-8740 deploy
 ```
 
-3. Add to your Claude config. If using with Claude, you'll need to disable WARP:
-
-```
-{
-    "mcpServers": {
-        "container": {
-            "command": "npx",
-            "args": [
-                "mcp-remote",
-                // this is my deployed instance
-                "https://container-starter-2.cmsparks.workers.dev/mcp"
-            ]
-        }
-    }
-}
-```
+3. Connect an MCP client directly to your deployed `/mcp` URL. If you use Claude Desktop, disable WARP first.

--- a/apps/sandbox-container/README.md
+++ b/apps/sandbox-container/README.md
@@ -26,25 +26,8 @@ This MCP server is still a work in progress, and we plan to add more tools in th
 - `Clone and explore this github repo: [repo link]. Setup and run the tests in your development environment`
 - `Analyze this data using Python`
 
-## Access the remote MCP server from any MCP Client
+## Connect to the MCP server
 
-If your MCP client has first class support for remote MCP servers, the client will provide a way to accept the server URL (`https://containers.mcp.cloudflare.com/mcp`) directly within its interface (for example in [Cloudflare AI Playground](https://playground.ai.cloudflare.com/)).
-
-If your client does not yet support remote MCP servers, you will need to set up its respective configuration file using [mcp-remote](https://www.npmjs.com/package/mcp-remote) to specify which servers your client can access.
-
-Replace the content with the following configuration:
-
-```json
-{
-	"mcpServers": {
-		"cloudflare": {
-			"command": "npx",
-			"args": ["mcp-remote", "https://containers.mcp.cloudflare.com/mcp"]
-		}
-	}
-}
-```
-
-Once you've set up your configuration file, restart MCP client and a browser window will open showing your OAuth login page. Proceed through the authentication flow to grant the client access to your MCP server. After you grant access, the tools will become available for you to use.
+Connect your MCP client directly to `https://containers.mcp.cloudflare.com/mcp`. If prompted, complete the Cloudflare OAuth flow in your browser. The tools become available after authorization.
 
 Interested in contributing, and running this server locally? See [CONTRIBUTING.md](CONTRIBUTING.md) to get started.

--- a/apps/workers-bindings/README.md
+++ b/apps/workers-bindings/README.md
@@ -62,25 +62,8 @@ This MCP server is still a work in progress, and we plan to add more tools in th
 - `Update the cache settings for Hyperdrive config 'YOUR_HYPERDRIVE_ID'.` (Replace YOUR_HYPERDRIVE_ID)
 - `Delete the Hyperdrive config 'OLD_HYPERDRIVE_ID'.` (Replace OLD_HYPERDRIVE_ID)
 
-## Access the remote MCP server from any MCP Client
+## Connect to the MCP server
 
-If your MCP client has first class support for remote MCP servers, the client will provide a way to accept the server URL (`https://bindings.mcp.cloudflare.com/mcp`) directly within its interface (for example in [Cloudflare AI Playground](https://playground.ai.cloudflare.com/)).
-
-If your client does not yet support remote MCP servers, you will need to set up its respective configuration file using [mcp-remote](https://www.npmjs.com/package/mcp-remote) to specify which servers your client can access.
-
-Replace the content with the following configuration:
-
-```json
-{
-	"mcpServers": {
-		"cloudflare": {
-			"command": "npx",
-			"args": ["mcp-remote", "https://bindings.mcp.cloudflare.com/mcp"]
-		}
-	}
-}
-```
-
-Once you've set up your configuration file, restart MCP client and a browser window will open showing your OAuth login page. Proceed through the authentication flow to grant the client access to your MCP server. After you grant access, the tools will become available for you to use.
+Connect your MCP client directly to `https://bindings.mcp.cloudflare.com/mcp`. If prompted, complete the Cloudflare OAuth flow in your browser. The tools become available after authorization.
 
 Interested in contributing, and running this server locally? See [CONTRIBUTING.md](CONTRIBUTING.md) to get started.

--- a/apps/workers-builds/README.md
+++ b/apps/workers-builds/README.md
@@ -26,25 +26,8 @@ This MCP server is still a work in progress, and we plan to add more tools in th
 - `Show me the logs for build 'xxxx-xxxx-xxxx-xxxx'.`
 - `Did the latest build for worker frontend-app succeed?`
 
-## Access the remote MCP server from from any MCP Client
+## Connect to the MCP server
 
-If your MCP client has first class support for remote MCP servers, the client will provide a way to accept the server URL (`https://builds.mcp.cloudflare.com/mcp`) directly within its interface (for example in [Cloudflare AI Playground](https://playground.ai.cloudflare.com/)).
-
-If your client does not yet support remote MCP servers, you will need to set up its respective configuration file using [mcp-remote](https://www.npmjs.com/package/mcp-remote) to specify which servers your client can access.
-
-Replace the content with the following configuration:
-
-```json
-{
-	"mcpServers": {
-		"cloudflare": {
-			"command": "npx",
-			"args": ["mcp-remote@latest", "https://builds.mcp.cloudflare.com/mcp"]
-		}
-	}
-}
-```
-
-Once you've set up your configuration file, restart MCP client and a browser window will open showing your OAuth login page. Proceed through the authentication flow to grant the client access to your MCP server. After you grant access, the tools will become available for you to use.
+Connect your MCP client directly to `https://builds.mcp.cloudflare.com/mcp`. If prompted, complete the Cloudflare OAuth flow in your browser. The tools become available after authorization.
 
 Interested in contributing, and running this server locally? See [CONTRIBUTING.md](CONTRIBUTING.md) to get started.

--- a/apps/workers-observability/README.md
+++ b/apps/workers-observability/README.md
@@ -28,25 +28,8 @@ This MCP server is still a work in progress, and we plan to add more tools in th
 - `How many requests were made to my worker 'my-app' broken down by HTTP status code?`
 - `Compare the error rates between my production and staging workers`
 
-## Access the remote MCP server from any MCP Client
+## Connect to the MCP server
 
-If your MCP client has first class support for remote MCP servers, the client will provide a way to accept the server URL (`https://observability.mcp.cloudflare.com/mcp`) directly within its interface (for example in [Cloudflare AI Playground](https://playground.ai.cloudflare.com/)).
-
-If your client does not yet support remote MCP servers, you will need to set up its respective configuration file using [mcp-remote](https://www.npmjs.com/package/mcp-remote) to specify which servers your client can access.
-
-Replace the content with the following configuration:
-
-```json
-{
-	"mcpServers": {
-		"cloudflare": {
-			"command": "npx",
-			"args": ["mcp-remote", "https://observability.mcp.cloudflare.com/mcp"]
-		}
-	}
-}
-```
-
-Once you've set up your configuration file, restart MCP client and a browser window will open showing your OAuth login page. Proceed through the authentication flow to grant the client access to your MCP server. After you grant access, the tools will become available for you to use.
+Connect your MCP client directly to `https://observability.mcp.cloudflare.com/mcp`. If prompted, complete the Cloudflare OAuth flow in your browser. The tools become available after authorization.
 
 Interested in contributing, and running this server locally? See [CONTRIBUTING.md](CONTRIBUTING.md) to get started.


### PR DESCRIPTION
## Summary

- remove obsolete proxy-based setup examples from the root and application documentation
- point clients directly at each hosted `/mcp` endpoint
- remove the obsolete transport-specific field from the bug-report template

## Validation

- `pnpm check:format`
- `pnpm check:deps`
- repository-wide tracked-file scan confirms no stale proxy package references remain
