### PR TITLE
chore: upgrade Workers OAuth provider to 0.9.0

### DIFF
--- a/.changeset/upgrade-oauth-provider-090.md
+++ b/.changeset/upgrade-oauth-provider-090.md
@@ -1,0 +1,6 @@
+---
+'cloudflare-ai-gateway-mcp-server': patch
+'@repo/mcp-common': patch
+---
+
+Upgrade `@cloudflare/workers-oauth-provider` from 0.8.2 to 0.9.0. Migrate the AI Gateway authentication integration fixture from the implicit flow to a valid S256 authorization-code exchange.

--- a/apps/ai-gateway/src/auth-integration.spec.ts
+++ b/apps/ai-gateway/src/auth-integration.spec.ts
@@ -1,4 +1,4 @@
-import { getOAuthApi } from '@cloudflare/workers-oauth-provider'
+import { getOAuthApi, OAuthProvider } from '@cloudflare/workers-oauth-provider'
 import { env, reset } from 'cloudflare:test'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
@@ -82,23 +82,34 @@ function helperOptions(): OAuthProviderOptions<Env> {
 		defaultHandler: { fetch: () => new Response('unused') },
 		authorizeEndpoint: '/oauth/authorize',
 		tokenEndpoint: '/token',
-		allowImplicitFlow: true,
 	}
 }
 
+async function s256Challenge(verifier: string): Promise<string> {
+	const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(verifier))
+	return btoa(String.fromCharCode(...new Uint8Array(digest)))
+		.replace(/\+/g, '-')
+		.replace(/\//g, '_')
+		.replace(/=+$/, '')
+}
+
 async function issueOAuthToken(resource: string) {
-	const helpers = getOAuthApi(helperOptions(), testEnv)
+	const options = helperOptions()
+	const helpers = getOAuthApi(options, testEnv)
 	const client = await helpers.createClient({
 		redirectUris: ['https://client.example.com/callback'],
 		tokenEndpointAuthMethod: 'none',
 	})
+	const codeVerifier = 'a'.repeat(43)
 	const result = await helpers.completeAuthorization({
 		request: {
-			responseType: 'token',
+			responseType: 'code',
 			clientId: client.clientId,
 			redirectUri: client.redirectUris[0],
 			scope: ['account:read', 'aig:read'],
 			state: 'test-state',
+			codeChallenge: await s256Challenge(codeVerifier),
+			codeChallengeMethod: 'S256',
 			resource,
 		},
 		userId: 'oauth-user',
@@ -110,9 +121,31 @@ async function issueOAuthToken(resource: string) {
 			account: { id: 'oauth-account', name: 'OAuth account' },
 		},
 	})
-	const token = new URLSearchParams(new URL(result.redirectTo).hash.slice(1)).get('access_token')
-	if (!token) throw new Error('OAuth helper did not issue an access token')
-	return token
+	const code = new URL(result.redirectTo).searchParams.get('code')
+	if (!code) throw new Error('OAuth helper did not issue an authorization code')
+
+	const provider = new OAuthProvider(options)
+	const tokenResponse = await provider.fetch(
+		new Request('https://ai-gateway.mcp.cloudflare.com/token', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+			body: new URLSearchParams({
+				grant_type: 'authorization_code',
+				code,
+				redirect_uri: client.redirectUris[0],
+				client_id: client.clientId,
+				code_verifier: codeVerifier,
+				resource,
+			}),
+		}),
+		testEnv,
+		executionContext()
+	)
+	const tokenDocument = (await tokenResponse.json()) as { access_token?: string }
+	if (tokenResponse.status !== 200 || !tokenDocument.access_token) {
+		throw new Error(`OAuth token exchange failed: ${tokenResponse.status}`)
+	}
+	return tokenDocument.access_token
 }
 
 afterEach(async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 catalogs:
   default:
     '@cloudflare/workers-oauth-provider':
-      specifier: 0.8.2
-      version: 0.8.2
+      specifier: 0.9.0
+      version: 0.9.0
     '@modelcontextprotocol/client':
       specifier: 2.0.0
       version: 2.0.0
@@ -71,7 +71,7 @@ importers:
     dependencies:
       '@cloudflare/workers-oauth-provider':
         specifier: 'catalog:'
-        version: 0.8.2
+        version: 0.9.0
       '@repo/mcp-common':
         specifier: workspace:*
         version: link:../../packages/mcp-common
@@ -756,7 +756,7 @@ importers:
     dependencies:
       '@cloudflare/workers-oauth-provider':
         specifier: 'catalog:'
-        version: 0.8.2
+        version: 0.9.0
       '@fast-csv/format':
         specifier: 5.0.2
         version: 5.0.2
@@ -1351,8 +1351,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@cloudflare/workers-oauth-provider@0.8.2':
-    resolution: {integrity: sha512-Pho5qWDl4qj1STI5QYMQfPmJBBkxyrFpXyDl9BrtYOfWHxThabEzdi9p3ezS2cUkbjA0E6L5ki/kq2pcbRUtlg==}
+  '@cloudflare/workers-oauth-provider@0.9.0':
+    resolution: {integrity: sha512-ulg0ixJ/5TCLypQVLeFAeQ9y/oz0Qju9k3uAMYtEYz1CXcyoxIUirkWz+exjv8LTsmJ5f+ethIKQeyJmZdqdBg==}
 
   '@cloudflare/workers-types@4.20250416.0':
     resolution: {integrity: sha512-i37TX0Clp+MrPdXMBdvKZM7JghCrWD9GtG7E+8ANOAPmtZjUkZfEy9qq46IG3XlNpagPaWDkY3SgJ3s01gPxCw==}
@@ -5765,7 +5765,7 @@ snapshots:
   '@cloudflare/workerd-windows-64@1.20260529.1':
     optional: true
 
-  '@cloudflare/workers-oauth-provider@0.8.2': {}
+  '@cloudflare/workers-oauth-provider@0.9.0': {}
 
   '@cloudflare/workers-types@4.20250416.0': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,7 +6,7 @@ packages:
 # supported by Agents. SDK v1 is retained only for eval-tools' non-server Agents
 # client legacy interoperability.
 catalog:
-  '@cloudflare/workers-oauth-provider': '0.8.2'
+  '@cloudflare/workers-oauth-provider': '0.9.0'
   '@modelcontextprotocol/client': '2.0.0'
   '@modelcontextprotocol/sdk': '1.30.0'
   '@modelcontextprotocol/server': '2.0.0'


### PR DESCRIPTION
## Summary

- upgrade the shared `@cloudflare/workers-oauth-provider` catalog entry from `0.8.2` to `0.9.0`
- refresh the pnpm lockfile and add patch changesets for the direct consumers; Changesets propagates patch releases to every dependent Worker
- migrate the AI Gateway authentication integration fixture from the implicit flow to a real S256 authorization-code exchange, matching the stricter OAuth 2.1 validation in `0.9.0`

## Validation

- `pnpm check:deps`
- `pnpm check:turbo`
- `pnpm check:format`
- `pnpm test` (303 tests)
- `pnpm turbo deploy -- -e staging --dry-run` (18 Workers)
- `pnpm changeset status`
- `git diff --check`
