### PR TITLE
refactor(auth): delegate API-token validation to the OAuth provider

### DIFF
--- a/.changeset/delegate-api-token-auth-to-provider.md
+++ b/.changeset/delegate-api-token-auth-to-provider.md
@@ -1,0 +1,5 @@
+---
+'@repo/mcp-common': patch
+---
+
+Delegate direct Cloudflare API-token and OAuth credential validation to the Workers OAuth Provider's resolveExternalToken hook on provider 0.10.1. Expected verification failures now become structured 401/403/429 responses with WWW-Authenticate challenges instead of escaping as Worker exceptions, verified identities are cached against a credential digest so repeat MCP requests skip the Cloudflare API probes, and authorize-endpoint validation failures redirect to validated client redirect URIs or render locally per OAuth 2.1.

--- a/apps/ai-gateway/src/auth-integration.spec.ts
+++ b/apps/ai-gateway/src/auth-integration.spec.ts
@@ -91,6 +91,10 @@ async function issueOAuthToken(resource: string) {
 	const client = await helpers.createClient({
 		redirectUris: ['https://client.example.com/callback'],
 		tokenEndpointAuthMethod: 'none',
+		// The provider validates registered capabilities, so the implicit flow
+		// this helper uses to mint a token must be registered explicitly.
+		grantTypes: ['implicit'],
+		responseTypes: ['token'],
 	})
 	const result = await helpers.completeAuthorization({
 		request: {

--- a/packages/mcp-common/src/api-token-mode.spec.ts
+++ b/packages/mcp-common/src/api-token-mode.spec.ts
@@ -1,88 +1,135 @@
+import { ExternalTokenError } from '@cloudflare/workers-oauth-provider'
 import { http, HttpResponse } from 'msw'
 import { describe, expect, it } from 'vitest'
 
-import { getApiTokenProps, handleApiTokenMode, isApiTokenRequest } from './api-token-mode'
+import {
+	cloudflareTokenOwner,
+	handleDevApiTokenMode,
+	isDevApiTokenRequest,
+	resolveExternalToken,
+} from './api-token-mode'
 import { server } from './test/msw-server'
 
-const env = {
-	DEV_CLOUDFLARE_API_TOKEN: '',
-	DEV_CLOUDFLARE_EMAIL: '',
-	DEV_DISABLE_OAUTH: 'false',
+function kvStub() {
+	const store = new Map<string, string>()
+	return {
+		store,
+		namespace: {
+			async get(key: string) {
+				const value = store.get(key)
+				return value === undefined ? null : JSON.parse(value)
+			},
+			async put(key: string, value: string) {
+				store.set(key, value)
+			},
+		} as unknown as KVNamespace,
+	}
 }
 
-function request(token = 'api-token') {
-	return new Request('https://mcp.example.com/mcp', {
-		headers: { Authorization: `Bearer ${token}` },
-	})
+function resolveInput(token: string, kv: KVNamespace) {
+	return {
+		token,
+		request: new Request('https://mcp.example.com/mcp'),
+		env: { OAUTH_KV: kv },
+	}
 }
 
 function mockCloudflareIdentity() {
+	const calls = { user: 0, accounts: 0 }
 	server.use(
-		http.get('https://api.cloudflare.com/client/v4/user', () =>
-			HttpResponse.json({
+		http.get('https://api.cloudflare.com/client/v4/user', () => {
+			calls.user += 1
+			return HttpResponse.json({
 				success: true,
 				result: { id: 'user-1', email: 'user@example.com' },
 				errors: [],
 				messages: [],
 			})
-		),
-		http.get('https://api.cloudflare.com/client/v4/accounts', () =>
-			HttpResponse.json({
+		}),
+		http.get('https://api.cloudflare.com/client/v4/accounts', () => {
+			calls.accounts += 1
+			return HttpResponse.json({
 				success: true,
 				result: [{ id: 'account-1', name: 'Account One' }],
 				errors: [],
 				messages: [],
 			})
-		)
+		})
 	)
+	return calls
 }
 
-describe('API-token request scope', () => {
-	it('distinguishes Cloudflare bearer credentials from MCP provider tokens', async () => {
-		expect(await isApiTokenRequest(request('cfut_test-user-token'), env)).toBe(true)
-		expect(await isApiTokenRequest(request('cfat_test-account-token'), env)).toBe(true)
-		expect(await isApiTokenRequest(request('cfoat_test-wrangler-token'), env)).toBe(true)
-		expect(await isApiTokenRequest(request('a'.repeat(40)), env)).toBe(true)
-		expect(await isApiTokenRequest(request('legacy-unknown-shape'), env)).toBe(true)
-		expect(await isApiTokenRequest(request('user:grant:secret'), env)).toBe(false)
+describe('cloudflareTokenOwner', () => {
+	it('reads documented credential ownership prefixes as hints', () => {
+		expect(cloudflareTokenOwner('cfat_test-account-token')).toBe('account')
+		expect(cloudflareTokenOwner('cfut_test-user-token')).toBe('user')
+		expect(cloudflareTokenOwner('cfoat_test-wrangler-token')).toBe('user')
+		expect(cloudflareTokenOwner('legacy-unknown-shape')).toBe('unknown')
 	})
+})
 
+describe('resolveExternalToken', () => {
 	it('validates the token into the shared AuthProps shape', async () => {
 		mockCloudflareIdentity()
-		expect(await getApiTokenProps(request(), env)).toEqual({
-			type: 'user_token',
-			accessToken: 'api-token',
-			user: { id: 'user-1', email: 'user@example.com' },
-			accounts: [{ id: 'account-1', name: 'Account One' }],
+		await expect(
+			resolveExternalToken(resolveInput('api-token', kvStub().namespace))
+		).resolves.toEqual({
+			props: {
+				type: 'user_token',
+				accessToken: 'api-token',
+				user: { id: 'user-1', email: 'user@example.com' },
+				accounts: [{ id: 'account-1', name: 'Account One' }],
+			},
 		})
+	})
+
+	it('caches a verified identity so repeat requests skip the probes', async () => {
+		const calls = mockCloudflareIdentity()
+		const kv = kvStub()
+
+		const first = await resolveExternalToken(resolveInput('secret-credential', kv.namespace))
+		const second = await resolveExternalToken(resolveInput('secret-credential', kv.namespace))
+
+		expect(second).toEqual(first)
+		expect(calls).toEqual({ user: 1, accounts: 1 })
+		expect(kv.store.size).toBe(1)
+		const [cacheKey] = [...kv.store.keys()]
+		expect(cacheKey).toMatch(/^api-token-identity:v1:[0-9a-f]{64}$/)
+		expect(cacheKey).not.toContain('secret-credential')
+	})
+
+	it('ignores a cache entry that does not match the expected shape', async () => {
+		const calls = mockCloudflareIdentity()
+		const kv = kvStub()
+
+		await resolveExternalToken(resolveInput('api-token', kv.namespace))
+		const [cacheKey] = [...kv.store.keys()]
+		kv.store.set(cacheKey, JSON.stringify({ unexpected: true }))
+
+		await expect(resolveExternalToken(resolveInput('api-token', kv.namespace))).resolves.toEqual({
+			props: {
+				type: 'user_token',
+				accessToken: 'api-token',
+				user: { id: 'user-1', email: 'user@example.com' },
+				accounts: [{ id: 'account-1', name: 'Account One' }],
+			},
+		})
+		expect(calls).toEqual({ user: 2, accounts: 2 })
 	})
 
 	it('uses only the accounts probe for a prefixed account token', async () => {
-		let userCalls = 0
-		let accountsCalls = 0
-		server.use(
-			http.get('https://api.cloudflare.com/client/v4/user', () => {
-				userCalls += 1
-				return HttpResponse.json({ success: false }, { status: 500 })
-			}),
-			http.get('https://api.cloudflare.com/client/v4/accounts', () => {
-				accountsCalls += 1
-				return HttpResponse.json({
-					success: true,
-					result: [{ id: 'account-1', name: 'Account One' }],
-					errors: [],
-					messages: [],
-				})
-			})
-		)
+		const calls = mockCloudflareIdentity()
 
-		await expect(getApiTokenProps(request('cfat_test-account-token'), env)).resolves.toEqual({
-			type: 'account_token',
-			accessToken: 'cfat_test-account-token',
-			account: { id: 'account-1', name: 'Account One' },
+		await expect(
+			resolveExternalToken(resolveInput('cfat_test-account-token', kvStub().namespace))
+		).resolves.toEqual({
+			props: {
+				type: 'account_token',
+				accessToken: 'cfat_test-account-token',
+				account: { id: 'account-1', name: 'Account One' },
+			},
 		})
-		expect(userCalls).toBe(0)
-		expect(accountsCalls).toBe(1)
+		expect(calls).toEqual({ user: 0, accounts: 1 })
 	})
 
 	it('rejects a prefixed account token that does not resolve to exactly one account', async () => {
@@ -100,40 +147,96 @@ describe('API-token request scope', () => {
 			)
 		)
 
-		await expect(getApiTokenProps(request('cfat_test-account-token'), env)).rejects.toMatchObject({
-			code: 401,
+		await expect(
+			resolveExternalToken(resolveInput('cfat_test-account-token', kvStub().namespace))
+		).rejects.toMatchObject({
+			name: 'ExternalTokenError',
+			code: 'invalid_token',
+			statusCode: 401,
 		})
 	})
 
-	it('keeps both identity probes for user, Wrangler OAuth, and legacy tokens', async () => {
-		let userCalls = 0
-		let accountsCalls = 0
+	it('preserves Retry-After when an identity probe is rate limited', async () => {
 		server.use(
-			http.get('https://api.cloudflare.com/client/v4/user', () => {
-				userCalls += 1
-				return HttpResponse.json({
-					success: true,
-					result: { id: 'user-1', email: 'user@example.com' },
-					errors: [],
-					messages: [],
-				})
-			}),
-			http.get('https://api.cloudflare.com/client/v4/accounts', () => {
-				accountsCalls += 1
-				return HttpResponse.json({
+			http.get('https://api.cloudflare.com/client/v4/user', () =>
+				HttpResponse.json({ success: false }, { status: 429, headers: { 'Retry-After': '17' } })
+			),
+			http.get('https://api.cloudflare.com/client/v4/accounts', () =>
+				HttpResponse.json({
 					success: true,
 					result: [{ id: 'account-1', name: 'Account One' }],
 					errors: [],
 					messages: [],
 				})
-			})
+			)
 		)
 
-		await getApiTokenProps(request('cfut_test-user-token'), env)
-		await getApiTokenProps(request('cfoat_test-wrangler-token'), env)
-		await getApiTokenProps(request('l'.repeat(40)), env)
-		expect(userCalls).toBe(3)
-		expect(accountsCalls).toBe(3)
+		await expect(
+			resolveExternalToken(resolveInput('cfoat_test-wrangler-token', kvStub().namespace))
+		).rejects.toMatchObject({
+			code: 'temporarily_unavailable',
+			statusCode: 429,
+			headers: { 'Retry-After': '17' },
+		})
+	})
+
+	it('maps malformed-token 400s to a structured invalid_token error', async () => {
+		server.use(
+			http.get('https://api.cloudflare.com/client/v4/user', () =>
+				HttpResponse.json({ success: false }, { status: 400 })
+			),
+			http.get('https://api.cloudflare.com/client/v4/accounts', () =>
+				HttpResponse.json({ success: false }, { status: 400 })
+			)
+		)
+
+		const rejection = await resolveExternalToken(
+			resolveInput('malformed-token', kvStub().namespace)
+		).then(
+			() => {
+				throw new Error('expected resolveExternalToken to reject')
+			},
+			(error: unknown) => error
+		)
+		expect(rejection).toBeInstanceOf(ExternalTokenError)
+		expect(rejection).toMatchObject({
+			code: 'invalid_token',
+			statusCode: 401,
+			description: 'Access token appears malformed; reauthenticate and try again',
+		})
+	})
+
+	it('maps insufficient permissions to insufficient_scope with step-up guidance', async () => {
+		server.use(
+			http.get('https://api.cloudflare.com/client/v4/user', () =>
+				HttpResponse.json({ success: false }, { status: 403 })
+			),
+			http.get('https://api.cloudflare.com/client/v4/accounts', () =>
+				HttpResponse.json({ success: false }, { status: 403 })
+			)
+		)
+
+		await expect(
+			resolveExternalToken(resolveInput('l'.repeat(40), kvStub().namespace))
+		).rejects.toMatchObject({
+			code: 'insufficient_scope',
+			statusCode: 403,
+			requiredScopes: ['user:read', 'account:read'],
+		})
+	})
+})
+
+describe('local development API-token mode', () => {
+	const devEnv = {
+		DEV_CLOUDFLARE_API_TOKEN: 'dev-token',
+		DEV_CLOUDFLARE_EMAIL: 'dev@example.com',
+		DEV_DISABLE_OAUTH: 'true',
+	}
+
+	it('activates only when a token is configured and OAuth is disabled', () => {
+		expect(isDevApiTokenRequest(devEnv)).toBe(true)
+		expect(isDevApiTokenRequest({ ...devEnv, DEV_DISABLE_OAUTH: 'false' })).toBe(false)
+		expect(isDevApiTokenRequest({ ...devEnv, DEV_CLOUDFLARE_API_TOKEN: '' })).toBe(false)
 	})
 
 	it('sets props only on the request ExecutionContext passed to the stateless handler', async () => {
@@ -145,15 +248,20 @@ describe('API-token request scope', () => {
 		} as ExecutionContext
 		let seenProps: unknown
 		const handler = {
-			fetch(_request: Request, _env: typeof env, requestCtx: ExecutionContext) {
+			fetch(_request: Request, _env: typeof devEnv, requestCtx: ExecutionContext) {
 				seenProps = requestCtx.props
 				return new Response('ok')
 			},
 		}
 
-		const response = await handleApiTokenMode(handler, request(), env, ctx)
+		const response = await handleDevApiTokenMode(
+			handler,
+			new Request('https://localhost/mcp'),
+			devEnv,
+			ctx
+		)
 		expect(await response.text()).toBe('ok')
-		expect(seenProps).toMatchObject({ type: 'user_token', accessToken: 'api-token' })
+		expect(seenProps).toMatchObject({ type: 'user_token', accessToken: 'dev-token' })
 		expect(ctx.props).toBe(seenProps)
 	})
 })

--- a/packages/mcp-common/src/api-token-mode.spec.ts
+++ b/packages/mcp-common/src/api-token-mode.spec.ts
@@ -4,8 +4,8 @@ import { describe, expect, it } from 'vitest'
 
 import {
 	cloudflareTokenOwner,
+	devApiTokenModeEnabled,
 	handleDevApiTokenMode,
-	isDevApiTokenRequest,
 	resolveExternalToken,
 } from './api-token-mode'
 import { server } from './test/msw-server'
@@ -234,9 +234,9 @@ describe('local development API-token mode', () => {
 	}
 
 	it('activates only when a token is configured and OAuth is disabled', () => {
-		expect(isDevApiTokenRequest(devEnv)).toBe(true)
-		expect(isDevApiTokenRequest({ ...devEnv, DEV_DISABLE_OAUTH: 'false' })).toBe(false)
-		expect(isDevApiTokenRequest({ ...devEnv, DEV_CLOUDFLARE_API_TOKEN: '' })).toBe(false)
+		expect(devApiTokenModeEnabled(devEnv)).toBe(true)
+		expect(devApiTokenModeEnabled({ ...devEnv, DEV_DISABLE_OAUTH: 'false' })).toBe(false)
+		expect(devApiTokenModeEnabled({ ...devEnv, DEV_CLOUDFLARE_API_TOKEN: '' })).toBe(false)
 	})
 
 	it('sets props only on the request ExecutionContext passed to the stateless handler', async () => {

--- a/packages/mcp-common/src/api-token-mode.spec.ts
+++ b/packages/mcp-common/src/api-token-mode.spec.ts
@@ -264,4 +264,105 @@ describe('local development API-token mode', () => {
 		expect(seenProps).toMatchObject({ type: 'user_token', accessToken: 'dev-token' })
 		expect(ctx.props).toBe(seenProps)
 	})
+
+	it('returns a structured error instead of throwing when the dev token is rejected', async () => {
+		server.use(
+			http.get('https://api.cloudflare.com/client/v4/user', () =>
+				HttpResponse.json({ success: false }, { status: 401 })
+			),
+			http.get('https://api.cloudflare.com/client/v4/accounts', () =>
+				HttpResponse.json({ success: false }, { status: 401 })
+			)
+		)
+		const ctx = {
+			props: {},
+			waitUntil() {},
+			passThroughOnException() {},
+		} as ExecutionContext
+		const handler = {
+			fetch() {
+				return new Response('ok')
+			},
+		}
+
+		const response = await handleDevApiTokenMode(
+			handler,
+			new Request('https://localhost/mcp'),
+			devEnv,
+			ctx
+		)
+		expect(response.status).toBe(401)
+		await expect(response.json()).resolves.toEqual({
+			error: 'invalid_token',
+			error_description: 'Access token is invalid or expired',
+		})
+	})
+})
+
+describe('identity cache safety', () => {
+	it('never caches a failed verification and re-probes after recovery', async () => {
+		const kv = kvStub()
+		server.use(
+			http.get('https://api.cloudflare.com/client/v4/user', () =>
+				HttpResponse.json({ success: false }, { status: 401 })
+			),
+			http.get('https://api.cloudflare.com/client/v4/accounts', () =>
+				HttpResponse.json({ success: false }, { status: 401 })
+			)
+		)
+
+		await expect(
+			resolveExternalToken(resolveInput('cfut_recovering-token', kv.namespace))
+		).rejects.toMatchObject({ code: 'invalid_token' })
+		expect(kv.store.size).toBe(0)
+
+		const calls = mockCloudflareIdentity()
+		await expect(
+			resolveExternalToken(resolveInput('cfut_recovering-token', kv.namespace))
+		).resolves.toMatchObject({ props: { type: 'user_token' } })
+		expect(calls).toEqual({ user: 1, accounts: 1 })
+		expect(kv.store.size).toBe(1)
+	})
+
+	it('serves but never caches an identity degraded by an unparseable payload', async () => {
+		const kv = kvStub()
+		server.use(
+			http.get('https://api.cloudflare.com/client/v4/user', () =>
+				HttpResponse.json({
+					success: true,
+					result: { id: 'user-1', email: 'user@example.com' },
+					errors: [],
+					messages: [],
+				})
+			),
+			http.get('https://api.cloudflare.com/client/v4/accounts', () => HttpResponse.text('not json'))
+		)
+
+		await expect(resolveExternalToken(resolveInput('api-token', kv.namespace))).resolves.toEqual({
+			props: {
+				type: 'user_token',
+				accessToken: 'api-token',
+				user: { id: 'user-1', email: 'user@example.com' },
+				accounts: [],
+			},
+		})
+		expect(kv.store.size).toBe(0)
+	})
+
+	it('verifies the credential even when the cache itself is unavailable', async () => {
+		const calls = mockCloudflareIdentity()
+		const brokenKv = {
+			async get() {
+				throw new Error('KV read outage')
+			},
+			async put() {
+				throw new Error('KV write outage')
+			},
+		} as unknown as KVNamespace
+
+		await expect(resolveExternalToken(resolveInput('api-token', brokenKv))).resolves.toMatchObject({
+			props: { type: 'user_token' },
+		})
+		expect(calls).toEqual({ user: 1, accounts: 1 })
+	})
 })

--- a/packages/mcp-common/src/api-token-mode.ts
+++ b/packages/mcp-common/src/api-token-mode.ts
@@ -141,7 +141,7 @@ export async function resolveExternalToken({
 }
 
 /** Local development can disable OAuth entirely and use one fixed API token. */
-export function isDevApiTokenRequest(env: DevAuthEnv): boolean {
+export function devApiTokenModeEnabled(env: DevAuthEnv): boolean {
 	return Boolean(env.DEV_CLOUDFLARE_API_TOKEN) && env.DEV_DISABLE_OAUTH === 'true'
 }
 

--- a/packages/mcp-common/src/api-token-mode.ts
+++ b/packages/mcp-common/src/api-token-mode.ts
@@ -69,14 +69,19 @@ async function getCachedIdentity(
 		console.warn('API-token identity cache read failed', error)
 	}
 
-	const identity = await getUserAndAccounts(token, undefined, tokenOwner)
+	const { user, accounts, degraded } = await getUserAndAccounts(token, undefined, tokenOwner)
+	const identity: CachedIdentity = { user, accounts }
 
-	try {
-		await kv.put(cacheKey, JSON.stringify(identity), {
-			expirationTtl: API_TOKEN_IDENTITY_CACHE_TTL_SECONDS,
-		})
-	} catch (error) {
-		console.warn('API-token identity cache write failed', error)
+	// A degraded identity may serve this request, but caching it would pin the
+	// data loss for the full TTL; leaving it uncached self-heals on re-probe.
+	if (!degraded) {
+		try {
+			await kv.put(cacheKey, JSON.stringify(identity), {
+				expirationTtl: API_TOKEN_IDENTITY_CACHE_TTL_SECONDS,
+			})
+		} catch (error) {
+			console.warn('API-token identity cache write failed', error)
+		}
 	}
 
 	return identity
@@ -157,7 +162,18 @@ export async function handleDevApiTokenMode<Env extends DevAuthEnv>(
 	ctx: ExecutionContext
 ): Promise<Response> {
 	const token = env.DEV_CLOUDFLARE_API_TOKEN
-	const identity = await getUserAndAccounts(token, undefined, cloudflareTokenOwner(token))
+	let identity: CachedIdentity
+	try {
+		identity = await getUserAndAccounts(token, undefined, cloudflareTokenOwner(token))
+	} catch (error) {
+		if (error instanceof McpError) {
+			return new Response(
+				JSON.stringify({ error: 'invalid_token', error_description: error.message }),
+				{ status: error.code, headers: { 'Content-Type': 'application/json', ...error.headers } }
+			)
+		}
+		throw error
+	}
 	;(ctx as { props: AuthProps }).props = buildAuthProps(token, identity)
 	return handler.fetch(req, env, ctx)
 }

--- a/packages/mcp-common/src/api-token-mode.ts
+++ b/packages/mcp-common/src/api-token-mode.ts
@@ -1,136 +1,163 @@
+import { ExternalTokenError } from '@cloudflare/workers-oauth-provider'
+import { z } from 'zod'
+
+import { CloudflareAccountsSchema, CloudflareUserSchema } from './auth-props'
 import { getUserAndAccounts } from './cloudflare-oauth-handler'
 import { McpError } from './mcp-error'
 
+import type {
+	ResolveExternalTokenInput,
+	ResolveExternalTokenResult,
+} from '@cloudflare/workers-oauth-provider'
 import type { AuthProps } from './auth-props'
 import type { CloudflareTokenOwner } from './cloudflare-oauth-handler'
 
-interface RequiredEnv {
+export interface DevAuthEnv {
 	DEV_CLOUDFLARE_API_TOKEN: string
 	DEV_CLOUDFLARE_EMAIL: string
 	DEV_DISABLE_OAUTH: string
+}
+
+export interface ExternalTokenEnv {
+	OAUTH_KV: KVNamespace
 }
 
 export interface RequestHandler<Env> {
 	fetch(req: Request, env: Env, ctx: ExecutionContext): Response | Promise<Response>
 }
 
-function cloudflareTokenOwner(token: string): CloudflareTokenOwner {
+/**
+ * Verified identities are cached against a digest of the credential so repeat
+ * MCP requests do not re-probe the Cloudflare API. Revoking a credential still
+ * revokes access: tool calls use the token itself, not the cached identity.
+ */
+const API_TOKEN_IDENTITY_CACHE_TTL_SECONDS = 2_592_000
+
+const CachedIdentitySchema = z.object({
+	user: CloudflareUserSchema.nullable(),
+	accounts: CloudflareAccountsSchema,
+})
+type CachedIdentity = z.infer<typeof CachedIdentitySchema>
+
+/** Prefixes are ownership hints; unprefixed legacy credentials remain supported. */
+export function cloudflareTokenOwner(token: string): CloudflareTokenOwner {
 	if (token.startsWith('cfat_')) return 'account'
 	if (token.startsWith('cfoat_') || token.startsWith('cfut_')) return 'user'
 	return 'unknown'
 }
 
-export async function isApiTokenRequest(req: Request, env: RequiredEnv) {
-	if (env.DEV_CLOUDFLARE_API_TOKEN && env.DEV_DISABLE_OAUTH === 'true') {
-		return true
-	}
-
-	const authHeader = req.headers.get('Authorization')
-	if (!authHeader) return false
-
-	const [type, token] = authHeader.split(' ')
-	if (type !== 'Bearer' || !token) return false
-
-	// MCP OAuth Provider tokens have a separate user:grant:secret format.
-	// Every other bearer value may be a Cloudflare API/OAuth credential; ownership
-	// prefixes are optimization hints, not an allowlist, so legacy values still work.
-	return token.split(':').length !== 3
+async function hashApiToken(token: string): Promise<string> {
+	const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(token))
+	return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, '0')).join('')
 }
 
-/** Validates an API token and returns the same request props shape as OAuth. */
-export async function getApiTokenProps(req: Request, env: RequiredEnv): Promise<AuthProps> {
-	let headers: HeadersInit | undefined
-	let token: string
+async function getCachedIdentity(
+	token: string,
+	tokenOwner: CloudflareTokenOwner,
+	kv: KVNamespace
+): Promise<CachedIdentity> {
+	const cacheKey = `api-token-identity:v1:${await hashApiToken(token)}`
 
-	if (env.DEV_CLOUDFLARE_API_TOKEN && env.DEV_DISABLE_OAUTH === 'true') {
-		token = env.DEV_CLOUDFLARE_API_TOKEN
-		headers = { Authorization: `Bearer ${token}` }
-	} else {
-		const authHeader = req.headers.get('Authorization')
-		if (!authHeader) {
-			throw new Error('Authorization header is required')
+	try {
+		const cachedValue = await kv.get(cacheKey, 'json')
+		if (cachedValue !== null) {
+			const cached = CachedIdentitySchema.safeParse(cachedValue)
+			if (cached.success) return cached.data
+			console.warn('API-token identity cache entry did not match expected shape; ignoring')
 		}
-
-		const [type, tokenValue] = authHeader.split(' ')
-		if (type !== 'Bearer' || !tokenValue) {
-			throw new Error('Invalid authorization type, must be Bearer')
-		}
-		token = tokenValue
+	} catch (error) {
+		console.warn('API-token identity cache read failed', error)
 	}
 
-	const { user, accounts } = await getUserAndAccounts(token, headers, cloudflareTokenOwner(token))
-	if (user === null) {
-		const account = accounts[0]
+	const identity = await getUserAndAccounts(token, undefined, tokenOwner)
+
+	try {
+		await kv.put(cacheKey, JSON.stringify(identity), {
+			expirationTtl: API_TOKEN_IDENTITY_CACHE_TTL_SECONDS,
+		})
+	} catch (error) {
+		console.warn('API-token identity cache write failed', error)
+	}
+
+	return identity
+}
+
+/** Converts a verified Cloudflare identity into the shared request props shape. */
+function buildAuthProps(token: string, identity: CachedIdentity): AuthProps {
+	if (identity.user === null) {
+		const account = identity.accounts.at(0)
 		if (!account) {
-			throw new Error('API token cannot access a Cloudflare account')
+			throw new McpError('API token cannot access a Cloudflare account', 401, {
+				reportToSentry: false,
+			})
 		}
-		return {
-			type: 'account_token',
-			accessToken: token,
-			account,
-		}
+		return { type: 'account_token', accessToken: token, account }
 	}
-
 	return {
 		type: 'user_token',
 		accessToken: token,
-		user,
-		accounts,
+		user: identity.user,
+		accounts: identity.accounts,
 	}
 }
 
+function externalTokenError(error: McpError, tokenOwner: CloudflareTokenOwner): ExternalTokenError {
+	const common = { description: error.message, headers: error.headers }
+
+	if (error.code >= 500) {
+		return new ExternalTokenError('server_error', { ...common, statusCode: error.code })
+	}
+	if (error.code === 429) {
+		return new ExternalTokenError('temporarily_unavailable', { ...common, statusCode: 429 })
+	}
+	if (error.code === 403) {
+		return new ExternalTokenError('insufficient_scope', {
+			...common,
+			statusCode: 403,
+			requiredScopes: tokenOwner === 'account' ? ['account:read'] : ['user:read', 'account:read'],
+		})
+	}
+	return new ExternalTokenError('invalid_token', { ...common, statusCode: 401 })
+}
+
 /**
- * Serves one API-token request through the same stateless handler as OAuth.
- * Props live on this request's ExecutionContext only; no Agent or MCP session is used.
+ * Resolves direct Cloudflare API/OAuth credentials after the OAuth Provider's
+ * internal token lookup misses. Expected validation failures become
+ * ExternalTokenError so the provider returns a structured 401/403 with a
+ * WWW-Authenticate challenge instead of an uncaught Worker exception.
  */
-export async function handleApiTokenMode<Env extends RequiredEnv>(
+export async function resolveExternalToken({
+	token,
+	env,
+}: ResolveExternalTokenInput<ExternalTokenEnv>): Promise<ResolveExternalTokenResult> {
+	const tokenOwner = cloudflareTokenOwner(token)
+	try {
+		const identity = await getCachedIdentity(token, tokenOwner, env.OAUTH_KV)
+		return { props: buildAuthProps(token, identity) }
+	} catch (error) {
+		if (error instanceof McpError) throw externalTokenError(error, tokenOwner)
+		throw error
+	}
+}
+
+/** Local development can disable OAuth entirely and use one fixed API token. */
+export function isDevApiTokenRequest(env: DevAuthEnv): boolean {
+	return Boolean(env.DEV_CLOUDFLARE_API_TOKEN) && env.DEV_DISABLE_OAUTH === 'true'
+}
+
+/**
+ * Serves one local-development request through the same stateless handler as
+ * OAuth, bypassing the OAuth Provider. Props live on this request's
+ * ExecutionContext only; no Agent or MCP session is used.
+ */
+export async function handleDevApiTokenMode<Env extends DevAuthEnv>(
 	handler: RequestHandler<Env>,
 	req: Request,
 	env: Env,
 	ctx: ExecutionContext
 ): Promise<Response> {
-	let props: AuthProps
-	try {
-		props = await getApiTokenProps(req, env)
-	} catch (error) {
-		if (error instanceof McpError) return apiTokenErrorResponse(req, error)
-		throw error
-	}
-	;(ctx as { props: AuthProps }).props = props
+	const token = env.DEV_CLOUDFLARE_API_TOKEN
+	const identity = await getUserAndAccounts(token, undefined, cloudflareTokenOwner(token))
+	;(ctx as { props: AuthProps }).props = buildAuthProps(token, identity)
 	return handler.fetch(req, env, ctx)
-}
-
-function apiTokenErrorResponse(request: Request, error: McpError): Response {
-	let oauthCode: string
-	if (error.code >= 500) {
-		oauthCode = 'server_error'
-	} else if (error.code === 429) {
-		oauthCode = 'temporarily_unavailable'
-	} else if (error.code === 401) {
-		oauthCode = 'invalid_token'
-	} else if (error.code === 403) {
-		oauthCode = 'insufficient_scope'
-	} else {
-		oauthCode = 'invalid_request'
-	}
-	const headers: Record<string, string> = {
-		'Cache-Control': 'no-store',
-		'Content-Type': 'application/json',
-		Pragma: 'no-cache',
-		...error.headers,
-	}
-	if (error.code === 401 || error.code === 403) {
-		const url = new URL(request.url)
-		const resourceMetadata = `${url.origin}/.well-known/oauth-protected-resource${url.pathname}`
-		headers['WWW-Authenticate'] =
-			`Bearer realm="OAuth", resource_metadata="${resourceMetadata}", error="${oauthCode}"`
-	}
-
-	return new Response(
-		JSON.stringify({
-			error: oauthCode,
-			error_description: error.message,
-		}),
-		{ status: error.code, headers }
-	)
 }

--- a/packages/mcp-common/src/cloudflare-oauth-handler.spec.ts
+++ b/packages/mcp-common/src/cloudflare-oauth-handler.spec.ts
@@ -1,13 +1,23 @@
-import { GrantType, OAuthError as ProviderOAuthError } from '@cloudflare/workers-oauth-provider'
+import {
+	AuthorizationError,
+	CimdFetchError,
+	GrantType,
+	OAuthError as ProviderOAuthError,
+} from '@cloudflare/workers-oauth-provider'
 import { http, HttpResponse } from 'msw'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { refreshAuthToken } from './cloudflare-auth'
-import { getUserAndAccounts, handleTokenExchangeCallback } from './cloudflare-oauth-handler'
+import {
+	createAuthHandlers,
+	getUserAndAccounts,
+	handleTokenExchangeCallback,
+} from './cloudflare-oauth-handler'
 import { McpError } from './mcp-error'
 import { server } from './test/msw-server'
 
-import type { TokenExchangeCallbackOptions } from '@cloudflare/workers-oauth-provider'
+import type { OAuthHelpers, TokenExchangeCallbackOptions } from '@cloudflare/workers-oauth-provider'
+import type { MetricsTracker } from '@repo/mcp-observability'
 
 // Mock the refreshAuthToken function
 vi.mock('./cloudflare-auth', () => ({
@@ -543,5 +553,93 @@ describe('getUserAndAccounts', () => {
 				expect(err.reportToSentry).toBe(false)
 			}
 		})
+	})
+})
+
+describe('createAuthHandlers authorize route', () => {
+	const metrics = { logEvent() {} } as unknown as MetricsTracker
+	const executionCtx = {
+		props: {},
+		waitUntil() {},
+		passThroughOnException() {},
+	} as ExecutionContext
+
+	function authorizeEnv(oauthProvider: Partial<OAuthHelpers>) {
+		return {
+			OAUTH_PROVIDER: oauthProvider as OAuthHelpers,
+			OAUTH_KV: undefined as unknown as KVNamespace,
+			MCP_COOKIE_ENCRYPTION_KEY: 'test-key',
+			CLOUDFLARE_CLIENT_ID: 'client',
+			CLOUDFLARE_CLIENT_SECRET: 'secret',
+		}
+	}
+
+	it('redirects expected authorization failures to the validated client redirect URI', async () => {
+		const app = createAuthHandlers({ scopes: {}, metrics })
+		const response = await app.fetch(
+			new Request('https://mcp.example.com/oauth/authorize?client_id=abc'),
+			authorizeEnv({
+				parseAuthRequest() {
+					throw new AuthorizationError('invalid_scope', {
+						description: 'Requested scope is not registered',
+						redirectUri: 'https://client.example.com/callback',
+						state: 'client-state',
+						issuer: 'https://mcp.example.com',
+					})
+				},
+			}),
+			executionCtx
+		)
+
+		expect(response.status).toBe(302)
+		const location = new URL(response.headers.get('location') ?? '')
+		expect(`${location.origin}${location.pathname}`).toBe('https://client.example.com/callback')
+		expect(location.searchParams.get('error')).toBe('invalid_scope')
+		expect(location.searchParams.get('error_description')).toBe('Requested scope is not registered')
+		expect(location.searchParams.get('state')).toBe('client-state')
+		expect(location.searchParams.get('iss')).toBe('https://mcp.example.com')
+		expect(response.headers.get('cache-control')).toBe('no-store')
+	})
+
+	it('renders locally when the failure precedes redirect URI validation', async () => {
+		const app = createAuthHandlers({ scopes: {}, metrics })
+		const response = await app.fetch(
+			new Request('https://mcp.example.com/oauth/authorize'),
+			authorizeEnv({
+				parseAuthRequest() {
+					throw new AuthorizationError('invalid_request', {
+						description: 'client_id is required',
+					})
+				},
+			}),
+			executionCtx
+		)
+
+		expect(response.status).toBe(400)
+		await expect(response.json()).resolves.toEqual({
+			error: 'invalid_request',
+			error_description: 'client_id is required',
+		})
+	})
+
+	it('returns a retryable 503 when client metadata resolution fails', async () => {
+		const clientId = 'https://client.example.com/metadata.json'
+		const app = createAuthHandlers({ scopes: {}, metrics })
+		const response = await app.fetch(
+			new Request(`https://mcp.example.com/oauth/authorize?client_id=${clientId}`),
+			authorizeEnv({
+				async parseAuthRequest() {
+					return { clientId } as Awaited<ReturnType<OAuthHelpers['parseAuthRequest']>>
+				},
+				async lookupClient() {
+					throw new CimdFetchError(clientId, new Error('HTTP 403'))
+				},
+			}),
+			executionCtx
+		)
+
+		expect(response.status).toBe(503)
+		expect(response.headers.get('retry-after')).toBe('30')
+		await expect(response.json()).resolves.toMatchObject({ error: 'temporarily_unavailable' })
 	})
 })

--- a/packages/mcp-common/src/cloudflare-oauth-handler.spec.ts
+++ b/packages/mcp-common/src/cloudflare-oauth-handler.spec.ts
@@ -313,6 +313,31 @@ describe('getUserAndAccounts', () => {
 		const result = await getUserAndAccounts('test-token')
 		expect(result.user).toEqual({ id: 'user-1', email: 'user@example.com' })
 		expect(result.accounts).toEqual([{ id: 'acc-1', name: 'My Account' }])
+		expect(result.degraded).toBe(false)
+	})
+
+	it('flags an identity as degraded when an ok-status payload is unparseable', async () => {
+		mockUserResponse(200, v4User)
+		server.use(
+			http.get('https://api.cloudflare.com/client/v4/accounts', () => HttpResponse.text('not json'))
+		)
+
+		const result = await getUserAndAccounts('test-token')
+		expect(result.user).toEqual({ id: 'user-1', email: 'user@example.com' })
+		expect(result.accounts).toEqual([])
+		expect(result.degraded).toBe(true)
+	})
+
+	it('flags legacy account-token inference from an unparseable user payload as degraded', async () => {
+		server.use(
+			http.get('https://api.cloudflare.com/client/v4/user', () => HttpResponse.text('not json'))
+		)
+		mockAccountsResponse(200, v4Accounts)
+
+		const result = await getUserAndAccounts('legacy-token')
+		expect(result.user).toBeNull()
+		expect(result.accounts).toEqual([{ id: 'acc-1', name: 'My Account' }])
+		expect(result.degraded).toBe(true)
 	})
 
 	it('returns user=null for account-scoped tokens (user 401, accounts 200)', async () => {

--- a/packages/mcp-common/src/cloudflare-oauth-handler.ts
+++ b/packages/mcp-common/src/cloudflare-oauth-handler.ts
@@ -146,11 +146,23 @@ function throwCombinedApiError(userResponse: Response, accountsResponse: Respons
 
 export type CloudflareTokenOwner = 'account' | 'unknown' | 'user'
 
+export interface VerifiedIdentity {
+	user: UserSchema | null
+	accounts: AccountsSchema
+	/**
+	 * True when an ok-status probe returned an unparseable payload and the
+	 * identity was filled in with less information than the credential has.
+	 * Degraded identities may serve the current request but must never be
+	 * cached: they would pin the data loss until the cache entry expires.
+	 */
+	degraded: boolean
+}
+
 export async function getUserAndAccounts(
 	accessToken: string,
 	devModeHeaders?: HeadersInit,
 	tokenOwner: CloudflareTokenOwner = 'unknown'
-): Promise<{ user: UserSchema | null; accounts: AccountsSchema }> {
+): Promise<VerifiedIdentity> {
 	const headers = devModeHeaders
 		? devModeHeaders
 		: {
@@ -203,6 +215,7 @@ export async function getUserAndAccounts(
 	}
 
 	// Parse accounts with safeParse for graceful degradation
+	let degraded = false
 	let accounts: AccountsSchema = []
 	if (accountsResponse.ok) {
 		try {
@@ -211,9 +224,11 @@ export async function getUserAndAccounts(
 			if (parsed.success) {
 				accounts = parsed.data.result ?? []
 			} else {
+				degraded = true
 				console.error('Cloudflare API /accounts payload did not match expected shape', parsed.error)
 			}
 		} catch (error) {
+			degraded = true
 			console.error('Cloudflare API /accounts response is not valid JSON', error)
 		}
 	} else if (userResponse?.ok) {
@@ -233,7 +248,7 @@ export async function getUserAndAccounts(
 	}
 
 	if (userResponse === undefined) {
-		if (accounts.length === 1) return { user: null, accounts }
+		if (accounts.length === 1) return { user: null, accounts, degraded }
 		throw new McpError('Account token must resolve to exactly one Cloudflare account', 401, {
 			reportToSentry: false,
 			internalMessage: `accounts=${accountsResponse.status}, count=${accounts.length}`,
@@ -249,15 +264,17 @@ export async function getUserAndAccounts(
 			if (parsed.success) {
 				user = parsed.data.result ?? null
 			} else {
+				degraded = true
 				console.error('Cloudflare API /user payload did not match expected shape', parsed.error)
 			}
 		} catch (error) {
+			degraded = true
 			console.error('Cloudflare API /user response is not valid JSON', error)
 		}
 	} else if (accounts.length > 0 && tokenOwner === 'unknown' && userResponse.status < 429) {
 		// Only legacy credentials need response-based account-token inference.
 		// Transient failures must never change the inferred credential owner.
-		return { user: null, accounts }
+		return { user: null, accounts, degraded }
 	} else {
 		throwIdentityProbeError(
 			[userResponse.status],
@@ -267,12 +284,12 @@ export async function getUserAndAccounts(
 	}
 
 	if (user) {
-		return { user, accounts }
+		return { user, accounts, degraded }
 	}
 
 	// Only legacy unprefixed tokens need response-based account-token inference.
 	if (accounts.length > 0 && tokenOwner === 'unknown') {
-		return { user: null, accounts }
+		return { user: null, accounts, degraded }
 	}
 
 	throw new McpError('Failed to verify token: no user or account information', 401, {
@@ -689,6 +706,12 @@ export function createAuthHandlers({
 					errorMessage: `Callback Error: ${message}`,
 				})
 			)
+			// completeAuthorization revalidates the reconstructed request; grants
+			// started under an older provider version can fail here as expected
+			// client errors rather than server faults.
+			if (e instanceof AuthorizationError) {
+				return new OAuthError(e.code, e.description, 400).toResponse()
+			}
 			if (e instanceof OAuthError) {
 				return e.toResponse()
 			}

--- a/packages/mcp-common/src/cloudflare-oauth-handler.ts
+++ b/packages/mcp-common/src/cloudflare-oauth-handler.ts
@@ -633,14 +633,14 @@ export function createAuthHandlers({
 				return new OAuthError('invalid_request', 'Invalid OAuth request info', 400).toResponse()
 			}
 
-			// Exchange code for tokens and get user details
-			const [{ accessToken, refreshToken, user, accounts }] = await Promise.all([
-				getTokenAndUserDetails(c, code, codeVerifier), // use codeVerifier from KV
-				c.env.OAUTH_PROVIDER.createClient({
-					clientId: oauthReqInfo.clientId,
-					tokenEndpointAuthMethod: 'none',
-				}),
-			])
+			// Exchange code for tokens and get user details, using the codeVerifier from KV.
+			// MCP clients register themselves through the provider's /register endpoint;
+			// the authorize flow only completes grants for clients that already exist.
+			const { accessToken, refreshToken, user, accounts } = await getTokenAndUserDetails(
+				c,
+				code,
+				codeVerifier
+			)
 
 			// Complete authorization and issue token to MCP client
 			const { redirectTo } = await c.env.OAUTH_PROVIDER.completeAuthorization({

--- a/packages/mcp-common/src/cloudflare-oauth-handler.ts
+++ b/packages/mcp-common/src/cloudflare-oauth-handler.ts
@@ -1,4 +1,9 @@
-import { GrantType, OAuthError as ProviderOAuthError } from '@cloudflare/workers-oauth-provider'
+import {
+	AuthorizationError,
+	CimdFetchError,
+	GrantType,
+	OAuthError as ProviderOAuthError,
+} from '@cloudflare/workers-oauth-provider'
 import { zValidator } from '@hono/zod-validator'
 import { Hono } from 'hono'
 import { z } from 'zod'
@@ -446,12 +451,29 @@ export function createAuthHandlers({
 	 */
 	app.get(`/oauth/authorize`, async (c) => {
 		try {
-			const oauthReqInfo = await c.env.OAUTH_PROVIDER.parseAuthRequest(c.req.raw)
-			oauthReqInfo.scope = Object.keys(scopes)
-
-			if (!oauthReqInfo.clientId) {
-				return new OAuthError('invalid_request', 'Missing client_id parameter', 400).toResponse()
+			let oauthReqInfo: AuthRequest
+			try {
+				oauthReqInfo = await c.env.OAUTH_PROVIDER.parseAuthRequest(c.req.raw)
+			} catch (e) {
+				// Expected request-validation failures: redirect when the provider has
+				// already validated the client's redirect URI, render locally otherwise.
+				if (e instanceof AuthorizationError) {
+					if (!e.redirectUri) {
+						return new OAuthError(e.code, e.description, 400).toResponse()
+					}
+					const redirect = new URL(e.redirectUri)
+					redirect.searchParams.set('error', e.code)
+					redirect.searchParams.set('error_description', e.description)
+					if (e.state) redirect.searchParams.set('state', e.state)
+					if (e.issuer) redirect.searchParams.set('iss', e.issuer)
+					return new Response(null, {
+						status: 302,
+						headers: { Location: redirect.href, 'Cache-Control': 'no-store' },
+					})
+				}
+				throw e
 			}
+			oauthReqInfo.scope = Object.keys(scopes)
 
 			// Check if client was previously approved (skip consent if so)
 			if (
@@ -506,6 +528,14 @@ export function createAuthHandlers({
 					errorMessage: `Authorize Error: ${message}`,
 				})
 			)
+			if (e instanceof CimdFetchError) {
+				return new OAuthError(
+					'temporarily_unavailable',
+					'Client metadata is temporarily unavailable. Please try again.',
+					503,
+					{ 'Retry-After': '30' }
+				).toResponse()
+			}
 			if (e instanceof OAuthError) {
 				return e.toResponse()
 			}

--- a/packages/mcp-common/src/oauth-router.spec.ts
+++ b/packages/mcp-common/src/oauth-router.spec.ts
@@ -141,4 +141,45 @@ describe('OAuth router resource policy', () => {
 			error_description: 'Access token appears malformed; reauthenticate and try again',
 		})
 	})
+
+	it('serves /sse with a direct API token through the provider hook', async () => {
+		server.use(
+			http.get('https://api.cloudflare.com/client/v4/user', () =>
+				HttpResponse.json({
+					success: true,
+					result: { id: 'user-1', email: 'user@example.com' },
+					errors: [],
+					messages: [],
+				})
+			),
+			http.get('https://api.cloudflare.com/client/v4/accounts', () =>
+				HttpResponse.json({
+					success: true,
+					result: [{ id: 'account-1', name: 'Account One' }],
+					errors: [],
+					messages: [],
+				})
+			)
+		)
+		const router = createCloudflareOAuthRouter<CloudflareOAuthEnv>({
+			apiHandler,
+			scopes: {},
+			metrics,
+			mcpRequestPolicy,
+		})
+
+		const response = await router.fetch(
+			new Request('https://mcp.example.com/sse', {
+				headers: {
+					Authorization: `Bearer ${'a'.repeat(40)}`,
+					Host: 'mcp.example.com',
+				},
+			}),
+			testEnv(),
+			executionContext
+		)
+
+		expect(response.status).toBe(200)
+		await expect(response.text()).resolves.toBe('ok')
+	})
 })

--- a/packages/mcp-common/src/oauth-router.spec.ts
+++ b/packages/mcp-common/src/oauth-router.spec.ts
@@ -19,11 +19,23 @@ const mcpRequestPolicy = {
 	allowedHostnames: ['mcp.example.com'],
 	allowedOriginHostnames: ['mcp.example.com'],
 }
-const env = {
-	DEV_CLOUDFLARE_API_TOKEN: '',
-	DEV_CLOUDFLARE_EMAIL: '',
-	DEV_DISABLE_OAUTH: 'false',
-} as CloudflareOAuthEnv
+function testEnv() {
+	const store = new Map<string, string>()
+	return {
+		DEV_CLOUDFLARE_API_TOKEN: '',
+		DEV_CLOUDFLARE_EMAIL: '',
+		DEV_DISABLE_OAUTH: 'false',
+		OAUTH_KV: {
+			async get(key: string) {
+				const value = store.get(key)
+				return value === undefined ? null : JSON.parse(value)
+			},
+			async put(key: string, value: string) {
+				store.set(key, value)
+			},
+		} as unknown as KVNamespace,
+	} as CloudflareOAuthEnv
+}
 const executionContext = {
 	props: {},
 	waitUntil() {},
@@ -80,7 +92,7 @@ describe('OAuth router resource policy', () => {
 					Host: 'mcp.example.com',
 				},
 			}),
-			env,
+			testEnv(),
 			executionContext
 		)
 
@@ -115,7 +127,7 @@ describe('OAuth router resource policy', () => {
 					Host: 'mcp.example.com',
 				},
 			}),
-			env,
+			testEnv(),
 			executionContext
 		)
 

--- a/packages/mcp-common/src/oauth-router.ts
+++ b/packages/mcp-common/src/oauth-router.ts
@@ -4,7 +4,11 @@ import {
 	originValidationResponse,
 } from '@modelcontextprotocol/server'
 
-import { handleDevApiTokenMode, isDevApiTokenRequest, resolveExternalToken } from './api-token-mode'
+import {
+	devApiTokenModeEnabled,
+	handleDevApiTokenMode,
+	resolveExternalToken,
+} from './api-token-mode'
 import { createAuthHandlers, handleTokenExchangeCallback } from './cloudflare-oauth-handler'
 
 import type { OAuthProviderOptions } from '@cloudflare/workers-oauth-provider'
@@ -84,7 +88,7 @@ export function createCloudflareOAuthRouter<Env extends CloudflareOAuthEnv>({
 				if (request.method === 'OPTIONS') return apiHandler.fetch(request, env, ctx)
 			}
 
-			if (isDevApiTokenRequest(env)) {
+			if (devApiTokenModeEnabled(env)) {
 				return handleDevApiTokenMode(apiHandler, request, env, ctx)
 			}
 

--- a/packages/mcp-common/src/oauth-router.ts
+++ b/packages/mcp-common/src/oauth-router.ts
@@ -4,7 +4,7 @@ import {
 	originValidationResponse,
 } from '@modelcontextprotocol/server'
 
-import { handleApiTokenMode, isApiTokenRequest } from './api-token-mode'
+import { handleDevApiTokenMode, isDevApiTokenRequest, resolveExternalToken } from './api-token-mode'
 import { createAuthHandlers, handleTokenExchangeCallback } from './cloudflare-oauth-handler'
 
 import type { OAuthProviderOptions } from '@cloudflare/workers-oauth-provider'
@@ -12,6 +12,7 @@ import type { MetricsTracker } from '@repo/mcp-observability'
 import type { RequestHandler } from './api-token-mode'
 
 export interface CloudflareOAuthEnv extends Cloudflare.Env {
+	OAUTH_KV: KVNamespace
 	CLOUDFLARE_CLIENT_ID: string
 	CLOUDFLARE_CLIENT_SECRET: string
 	DEV_CLOUDFLARE_API_TOKEN: string
@@ -39,6 +40,7 @@ export interface CreateCloudflareOAuthRouterOptions<Env extends CloudflareOAuthE
 		| 'authorizeEndpoint'
 		| 'tokenEndpoint'
 		| 'tokenExchangeCallback'
+		| 'resolveExternalToken'
 		| 'resourceMatchOriginOnly'
 	>
 }
@@ -82,8 +84,8 @@ export function createCloudflareOAuthRouter<Env extends CloudflareOAuthEnv>({
 				if (request.method === 'OPTIONS') return apiHandler.fetch(request, env, ctx)
 			}
 
-			if (await isApiTokenRequest(request, env)) {
-				return handleApiTokenMode(apiHandler, request, env, ctx)
+			if (isDevApiTokenRequest(env)) {
+				return handleDevApiTokenMode(apiHandler, request, env, ctx)
 			}
 
 			return new OAuthProvider<Env>({
@@ -96,6 +98,9 @@ export function createCloudflareOAuthRouter<Env extends CloudflareOAuthEnv>({
 				defaultHandler,
 				authorizeEndpoint: '/oauth/authorize',
 				tokenEndpoint: '/token',
+				// The provider resolves its own access tokens first, then delegates
+				// direct Cloudflare API/OAuth credentials to resolveExternalToken.
+				resolveExternalToken,
 				tokenExchangeCallback: (options) =>
 					handleTokenExchangeCallback(
 						options,

--- a/packages/mcp-common/src/oauth-router.ts
+++ b/packages/mcp-common/src/oauth-router.ts
@@ -63,7 +63,7 @@ export function createCloudflareOAuthRouter<Env extends CloudflareOAuthEnv>({
 }: CreateCloudflareOAuthRouterOptions<Env>): RequestHandler<Env> {
 	if (provider && 'resourceMatchOriginOnly' in provider) {
 		throw new TypeError(
-			'resourceMatchOriginOnly is no longer supported; OAuth resources must match exactly'
+			'resourceMatchOriginOnly is deprecated and not supported here; OAuth resources must match exactly'
 		)
 	}
 	const defaultHandler = createAuthHandlers({ scopes, metrics })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 catalogs:
   default:
     '@cloudflare/workers-oauth-provider':
-      specifier: 0.8.2
-      version: 0.8.2
+      specifier: 0.10.1
+      version: 0.10.1
     '@modelcontextprotocol/client':
       specifier: 2.0.0
       version: 2.0.0
@@ -71,7 +71,7 @@ importers:
     dependencies:
       '@cloudflare/workers-oauth-provider':
         specifier: 'catalog:'
-        version: 0.8.2
+        version: 0.10.1
       '@repo/mcp-common':
         specifier: workspace:*
         version: link:../../packages/mcp-common
@@ -756,7 +756,7 @@ importers:
     dependencies:
       '@cloudflare/workers-oauth-provider':
         specifier: 'catalog:'
-        version: 0.8.2
+        version: 0.10.1
       '@fast-csv/format':
         specifier: 5.0.2
         version: 5.0.2
@@ -1351,8 +1351,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@cloudflare/workers-oauth-provider@0.8.2':
-    resolution: {integrity: sha512-Pho5qWDl4qj1STI5QYMQfPmJBBkxyrFpXyDl9BrtYOfWHxThabEzdi9p3ezS2cUkbjA0E6L5ki/kq2pcbRUtlg==}
+  '@cloudflare/workers-oauth-provider@0.10.1':
+    resolution: {integrity: sha512-F0uoROWOdWYmpUKPXhibX2hs69jBeEvSmBGyy6iwZmjfn+TAU6U9Qk6n2PaEQFsj5UvnoX9cQMqWSZ4MRIXuHQ==}
 
   '@cloudflare/workers-types@4.20250416.0':
     resolution: {integrity: sha512-i37TX0Clp+MrPdXMBdvKZM7JghCrWD9GtG7E+8ANOAPmtZjUkZfEy9qq46IG3XlNpagPaWDkY3SgJ3s01gPxCw==}
@@ -5765,7 +5765,7 @@ snapshots:
   '@cloudflare/workerd-windows-64@1.20260529.1':
     optional: true
 
-  '@cloudflare/workers-oauth-provider@0.8.2': {}
+  '@cloudflare/workers-oauth-provider@0.10.1': {}
 
   '@cloudflare/workers-types@4.20250416.0': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 catalogs:
   default:
     '@cloudflare/workers-oauth-provider':
-      specifier: 0.10.1
-      version: 0.10.1
+      specifier: 0.10.2
+      version: 0.10.2
     '@modelcontextprotocol/client':
       specifier: 2.0.0
       version: 2.0.0
@@ -71,7 +71,7 @@ importers:
     dependencies:
       '@cloudflare/workers-oauth-provider':
         specifier: 'catalog:'
-        version: 0.10.1
+        version: 0.10.2
       '@repo/mcp-common':
         specifier: workspace:*
         version: link:../../packages/mcp-common
@@ -756,7 +756,7 @@ importers:
     dependencies:
       '@cloudflare/workers-oauth-provider':
         specifier: 'catalog:'
-        version: 0.10.1
+        version: 0.10.2
       '@fast-csv/format':
         specifier: 5.0.2
         version: 5.0.2
@@ -1351,8 +1351,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@cloudflare/workers-oauth-provider@0.10.1':
-    resolution: {integrity: sha512-F0uoROWOdWYmpUKPXhibX2hs69jBeEvSmBGyy6iwZmjfn+TAU6U9Qk6n2PaEQFsj5UvnoX9cQMqWSZ4MRIXuHQ==}
+  '@cloudflare/workers-oauth-provider@0.10.2':
+    resolution: {integrity: sha512-3yWtnPaZyNaiLuv9tWkWfEyqbILFsvfG0Q5RwZGJ2jkSkrOMM8IxKYaGCFakSGbMXmatvyrhFDCDZ70S6TVnqQ==}
 
   '@cloudflare/workers-types@4.20250416.0':
     resolution: {integrity: sha512-i37TX0Clp+MrPdXMBdvKZM7JghCrWD9GtG7E+8ANOAPmtZjUkZfEy9qq46IG3XlNpagPaWDkY3SgJ3s01gPxCw==}
@@ -5765,7 +5765,7 @@ snapshots:
   '@cloudflare/workerd-windows-64@1.20260529.1':
     optional: true
 
-  '@cloudflare/workers-oauth-provider@0.10.1': {}
+  '@cloudflare/workers-oauth-provider@0.10.2': {}
 
   '@cloudflare/workers-types@4.20250416.0': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 catalogs:
   default:
     '@cloudflare/workers-oauth-provider':
-      specifier: 0.10.2
-      version: 0.10.2
+      specifier: 0.10.3
+      version: 0.10.3
     '@modelcontextprotocol/client':
       specifier: 2.0.0
       version: 2.0.0
@@ -71,7 +71,7 @@ importers:
     dependencies:
       '@cloudflare/workers-oauth-provider':
         specifier: 'catalog:'
-        version: 0.10.2
+        version: 0.10.3
       '@repo/mcp-common':
         specifier: workspace:*
         version: link:../../packages/mcp-common
@@ -756,7 +756,7 @@ importers:
     dependencies:
       '@cloudflare/workers-oauth-provider':
         specifier: 'catalog:'
-        version: 0.10.2
+        version: 0.10.3
       '@fast-csv/format':
         specifier: 5.0.2
         version: 5.0.2
@@ -1351,8 +1351,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@cloudflare/workers-oauth-provider@0.10.2':
-    resolution: {integrity: sha512-3yWtnPaZyNaiLuv9tWkWfEyqbILFsvfG0Q5RwZGJ2jkSkrOMM8IxKYaGCFakSGbMXmatvyrhFDCDZ70S6TVnqQ==}
+  '@cloudflare/workers-oauth-provider@0.10.3':
+    resolution: {integrity: sha512-25ufMONJir9PllqVpK4GwOOoSFgpYm3+bM6NBedj7ufMCIfNf5jk4OI0LPuTJBaJgLl2lGCLqFqEPJXcSuPopQ==}
 
   '@cloudflare/workers-types@4.20250416.0':
     resolution: {integrity: sha512-i37TX0Clp+MrPdXMBdvKZM7JghCrWD9GtG7E+8ANOAPmtZjUkZfEy9qq46IG3XlNpagPaWDkY3SgJ3s01gPxCw==}
@@ -5765,7 +5765,7 @@ snapshots:
   '@cloudflare/workerd-windows-64@1.20260529.1':
     optional: true
 
-  '@cloudflare/workers-oauth-provider@0.10.2': {}
+  '@cloudflare/workers-oauth-provider@0.10.3': {}
 
   '@cloudflare/workers-types@4.20250416.0': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,7 +6,7 @@ packages:
 # supported by Agents. SDK v1 is retained only for eval-tools' non-server Agents
 # client legacy interoperability.
 catalog:
-  '@cloudflare/workers-oauth-provider': '0.8.2'
+  '@cloudflare/workers-oauth-provider': '0.10.1'
   '@modelcontextprotocol/client': '2.0.0'
   '@modelcontextprotocol/sdk': '1.30.0'
   '@modelcontextprotocol/server': '2.0.0'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,7 +6,7 @@ packages:
 # supported by Agents. SDK v1 is retained only for eval-tools' non-server Agents
 # client legacy interoperability.
 catalog:
-  '@cloudflare/workers-oauth-provider': '0.10.1'
+  '@cloudflare/workers-oauth-provider': '0.10.2'
   '@modelcontextprotocol/client': '2.0.0'
   '@modelcontextprotocol/sdk': '1.30.0'
   '@modelcontextprotocol/server': '2.0.0'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,7 +6,7 @@ packages:
 # supported by Agents. SDK v1 is retained only for eval-tools' non-server Agents
 # client legacy interoperability.
 catalog:
-  '@cloudflare/workers-oauth-provider': '0.10.2'
+  '@cloudflare/workers-oauth-provider': '0.10.3'
   '@modelcontextprotocol/client': '2.0.0'
   '@modelcontextprotocol/sdk': '1.30.0'
   '@modelcontextprotocol/server': '2.0.0'


### PR DESCRIPTION
## What

Replaces the hand-rolled bearer-token fork in front of `OAuthProvider` with the provider's `resolveExternalToken` hook, on `@cloudflare/workers-oauth-provider` 0.10.3 (was 0.8.2). This is the same architecture cloudflare/mcp adopted in cloudflare/mcp#185 and cloudflare/mcp#193.

- `packages/mcp-common/src/api-token-mode.ts`: direct Cloudflare API/OAuth credentials are now resolved inside the provider via `resolveExternalToken`. Expected verification failures throw `ExternalTokenError`, which the provider converts to structured `401 invalid_token` / `403 insufficient_scope` (with `WWW-Authenticate` challenges and step-up scope guidance) / `429 temporarily_unavailable` (preserving `Retry-After`) / `5xx server_error` responses. Nothing in this path can escape as an uncaught Worker exception (HTTP 500 / error 1101) anymore.
- Verified identities are cached in `OAUTH_KV` for 30 days, keyed by a SHA-256 digest of the credential, so repeat MCP requests skip the `/user` + `/accounts` identity probes (~500ms and 2 subrequests per request today). Failed verifications are never cached, and identities degraded by an ok-status-but-unparseable API payload are served but never cached, so transient API payload problems self-heal on the next probe. Revoking a credential still revokes access — tool calls use the token itself, not the cached identity.
- The only remaining pre-provider branch is the local-development `DEV_DISABLE_OAUTH` short-circuit, which now returns structured errors for rejected dev tokens instead of throwing.
- `/oauth/authorize` classifies the provider 0.10 `AuthorizationError` (redirect to the validated client redirect URI with `error`/`state`/`iss`, or render locally when no redirect URI was validated) and `CimdFetchError` (retryable 503) instead of collapsing them into a 500. `/oauth/callback` returns a client error when `completeAuthorization` rejects a grant reconstructed from an older provider version (relevant only during the deploy window).
- Removes a vestigial `createClient` call in `/oauth/callback` that never registered the requesting client (the provider generates a random client ID) and only wrote an orphan KV record per authorization. Clients register through `/register` and are validated before the callback can run.
- Provider 0.10.x also brings its own hardening to the fleet: OAuth 2.1 PKCE S256 enforcement for public clients, registered-capability validation, strict RFC 8707 resource handling, and RFC-compliant bare bearer challenges.

## Why

A well-formed bearer token that fails verification (invalid credential, revoked token, malformed value) previously threw an `MCPError` that escaped the Worker as an exception, returning HTTP 500 / Cloudflare error 1101 to MCP clients instead of a spec-correct `401` with `WWW-Authenticate`. #393 converted most of these inside the fork; this PR removes the fork entirely so the provider owns the protected-resource error contract, and upgrades the fleet to the current provider.

## Notes for review

- Account-scoped tokens (no `/user` identity) remain supported: `cfat_`-prefixed tokens use only the `/accounts` probe and must resolve to exactly one account; legacy unprefixed tokens keep response-based inference.
- Provider-issued tokens that miss the KV lookup (expired/revoked) now cost one identity-probe round-trip before returning `invalid_token` — same trade-off cloudflare/mcp accepted.
- Legacy clients that authorize without PKCE, or with `plain` PKCE, are rejected by provider 0.10.x per OAuth 2.1; MCP-spec clients are unaffected. In-flight authorizations started under 0.8.2 without a code challenge fail as client errors during the deploy window.
- The ai-gateway integration spec's implicit-flow helper now registers `grantTypes: ['implicit']` / `responseTypes: ['token']` because provider 0.10 validates registered client capabilities at `completeAuthorization()`.

## Testing

- `pnpm test`: 318 tests green across 35 files, including new coverage for `resolveExternalToken` (identity caching, failed-verification and degraded-identity cache exclusion, KV-outage fallback, prefixed-owner probes, 400/401/403/429 mapping), `/sse` with a direct API token through the router, dev-mode structured errors, and the authorize-route error classification.
- `pnpm types`, `pnpm check:turbo`, `pnpm check:format`, `pnpm check:deps` all green.
