### PR TITLE
Add context-cost badge to docs-ai-search (422 tokens — among the leanest we measured)

### DIFF
--- a/apps/docs-ai-search/README.md
+++ b/apps/docs-ai-search/README.md
@@ -1,5 +1,7 @@
 # Cloudflare Documentation MCP Server (via AI Search) 🔭
 
+[![context cost](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fathakur3%2Fmcp-context-cost%2Fmain%2Fbadges%2Fcloudflare-docs.json)](https://athakur3.github.io/mcp-context-cost/METHODOLOGY)
+
 This is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction) server that supports remote MCP connections. It uses Cloudflare AI Search (AutoRAG) to provide contextual search of the Cloudflare Developer Documentation.
 
 The Cloudflare account this worker is deployed on has an AI Search instance configured with the complete Cloudflare Developer Documentation.


### PR DESCRIPTION
One line in the docs-ai-search README: a shields.io badge showing what the public docs MCP server's tool schemas cost in context tokens — currently **422 tokens across 2 tools** (measured 2026-08-16 over https://docs.mcp.cloudflare.com/sse via the mcp-remote bridge). That's among the leanest of the 57 popular MCP servers we measured (median: 2,636) — worth letting the README say.

The badge JSON lives in [our repo](https://github.com/athakur3/mcp-context-cost) and refreshes weekly; the number links to a reproducible methodology — raw `tools/list` capture + pinned `o200k_base` tokenizer, re-derivable in five lines from [results/cloudflare-docs/measurement.json](https://github.com/athakur3/mcp-context-cost/blob/main/results/cloudflare-docs/measurement.json).

If you'd rather not carry this, close freely — no hard feelings. To own the number in your own CI instead: sd2k/mcp-tokens-action (badge support proposed in sd2k/mcp-tokens-action#5).