### PR TITLE
feat: add Agent Plugins 1.0 packages

### DIFF
--- a/apps/docs-ai-search/README.md
+++ b/apps/docs-ai-search/README.md
@@ -24,4 +24,14 @@ Currently available tools:
 
 Connect your MCP client directly to `https://docs.mcp.cloudflare.com/mcp`. This server does not require OAuth.
 
+### Agent Plugins 1.0
+
+From a checkout of this repository, install the [bundled Agent Plugins 1.0 package](./agent-plugin) with the community-maintained Universal Agent Plugins CLI (Node.js 22+):
+
+```bash
+npx universal-agent-plugins add ./apps/docs-ai-search/agent-plugin
+```
+
+Run this from the repository root and choose your installed agents in the prompt. To select agents explicitly, append `--target codex,cursor,kiro`. Follow any client activation instructions printed by the CLI.
+
 Interested in contributing, and running this server locally? See the [CONTRIBUTING.md](../../CONTRIBUTING.md) in the repo root to get started.

--- a/apps/docs-ai-search/README.md
+++ b/apps/docs-ai-search/README.md
@@ -26,12 +26,10 @@ Connect your MCP client directly to `https://docs.mcp.cloudflare.com/mcp`. This 
 
 ### Agent Plugins 1.0
 
-Install the community-packaged Cloudflare Docs plugin (Node.js 22+):
+Connect to Cloudflare's documentation MCP server with Universal Agent Plugins:
 
 ```bash
 npx universal-agent-plugins add cloudflare-docs
 ```
-
-Choose your agents in the prompt.
 
 Interested in contributing, and running this server locally? See the [CONTRIBUTING.md](../../CONTRIBUTING.md) in the repo root to get started.

--- a/apps/docs-ai-search/README.md
+++ b/apps/docs-ai-search/README.md
@@ -26,12 +26,12 @@ Connect your MCP client directly to `https://docs.mcp.cloudflare.com/mcp`. This 
 
 ### Agent Plugins 1.0
 
-From a checkout of this repository, install the [bundled Agent Plugins 1.0 package](./agent-plugin) with the community-maintained Universal Agent Plugins CLI (Node.js 22+):
+Install the community-packaged Cloudflare Docs plugin (Node.js 22+):
 
 ```bash
-npx universal-agent-plugins add ./apps/docs-ai-search/agent-plugin
+npx universal-agent-plugins add cloudflare-docs
 ```
 
-Run this from the repository root and choose your installed agents in the prompt. To select agents explicitly, append `--target codex,cursor,kiro`. Follow any client activation instructions printed by the CLI.
+Choose your agents in the prompt.
 
 Interested in contributing, and running this server locally? See the [CONTRIBUTING.md](../../CONTRIBUTING.md) in the repo root to get started.

--- a/apps/docs-ai-search/agent-plugin/mcp.json
+++ b/apps/docs-ai-search/agent-plugin/mcp.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+  "mcpServers": {
+    "cloudflare-docs": {
+      "type": "streamable-http",
+      "url": "https://docs.mcp.cloudflare.com/mcp"
+    }
+  }
+}

--- a/apps/docs-ai-search/agent-plugin/mcp.json
+++ b/apps/docs-ai-search/agent-plugin/mcp.json
@@ -1,9 +1,9 @@
 {
-  "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
-  "mcpServers": {
-    "cloudflare-docs": {
-      "type": "streamable-http",
-      "url": "https://docs.mcp.cloudflare.com/mcp"
-    }
-  }
+	"$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+	"mcpServers": {
+		"cloudflare-docs": {
+			"type": "streamable-http",
+			"url": "https://docs.mcp.cloudflare.com/mcp"
+		}
+	}
 }

--- a/apps/docs-ai-search/agent-plugin/plugin.json
+++ b/apps/docs-ai-search/agent-plugin/plugin.json
@@ -1,13 +1,13 @@
 {
-  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
-  "name": "cloudflare-docs",
-  "description": "Search current Cloudflare documentation through Cloudflare's hosted MCP server.",
-  "author": {
-    "name": "Cloudflare",
-    "url": "https://www.cloudflare.com/"
-  },
-  "homepage": "https://developers.cloudflare.com/agents/model-context-protocol/mcp-servers-for-cloudflare/",
-  "repository": "https://github.com/cloudflare/mcp-server-cloudflare",
-  "license": "Apache-2.0",
-  "keywords": ["cloudflare", "documentation", "mcp", "research"]
+	"$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+	"name": "cloudflare-docs",
+	"description": "Search current Cloudflare documentation through Cloudflare's hosted MCP server.",
+	"author": {
+		"name": "Cloudflare",
+		"url": "https://www.cloudflare.com/"
+	},
+	"homepage": "https://developers.cloudflare.com/agents/model-context-protocol/mcp-servers-for-cloudflare/",
+	"repository": "https://github.com/cloudflare/mcp-server-cloudflare",
+	"license": "Apache-2.0",
+	"keywords": ["cloudflare", "documentation", "mcp", "research"]
 }

--- a/apps/docs-ai-search/agent-plugin/plugin.json
+++ b/apps/docs-ai-search/agent-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "cloudflare-docs",
+  "description": "Search current Cloudflare documentation through Cloudflare's hosted MCP server.",
+  "author": {
+    "name": "Cloudflare",
+    "url": "https://www.cloudflare.com/"
+  },
+  "homepage": "https://developers.cloudflare.com/agents/model-context-protocol/mcp-servers-for-cloudflare/",
+  "repository": "https://github.com/cloudflare/mcp-server-cloudflare",
+  "license": "Apache-2.0",
+  "keywords": ["cloudflare", "documentation", "mcp", "research"]
+}

--- a/apps/workers-bindings/README.md
+++ b/apps/workers-bindings/README.md
@@ -66,4 +66,12 @@ This MCP server is still a work in progress, and we plan to add more tools in th
 
 Connect your MCP client directly to `https://bindings.mcp.cloudflare.com/mcp`. If prompted, complete the Cloudflare OAuth flow in your browser. The tools become available after authorization.
 
+### Agent Plugins 1.0
+
+Connect to Cloudflare's Workers Bindings MCP server with Universal Agent Plugins:
+
+```bash
+npx universal-agent-plugins add cloudflare-bindings
+```
+
 Interested in contributing, and running this server locally? See [CONTRIBUTING.md](CONTRIBUTING.md) to get started.

--- a/apps/workers-bindings/agent-plugin/mcp.json
+++ b/apps/workers-bindings/agent-plugin/mcp.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+  "mcpServers": {
+    "cloudflare-bindings": {
+      "type": "streamable-http",
+      "url": "https://bindings.mcp.cloudflare.com/mcp"
+    }
+  }
+}

--- a/apps/workers-bindings/agent-plugin/mcp.json
+++ b/apps/workers-bindings/agent-plugin/mcp.json
@@ -1,9 +1,9 @@
 {
-  "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
-  "mcpServers": {
-    "cloudflare-bindings": {
-      "type": "streamable-http",
-      "url": "https://bindings.mcp.cloudflare.com/mcp"
-    }
-  }
+	"$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+	"mcpServers": {
+		"cloudflare-bindings": {
+			"type": "streamable-http",
+			"url": "https://bindings.mcp.cloudflare.com/mcp"
+		}
+	}
 }

--- a/apps/workers-bindings/agent-plugin/plugin.json
+++ b/apps/workers-bindings/agent-plugin/plugin.json
@@ -1,13 +1,13 @@
 {
-  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
-  "name": "cloudflare-bindings",
-  "description": "Manage Cloudflare Workers platform resources through Cloudflare's hosted Bindings MCP server.",
-  "author": {
-    "name": "Cloudflare",
-    "url": "https://www.cloudflare.com/"
-  },
-  "homepage": "https://developers.cloudflare.com/agents/model-context-protocol/mcp-servers-for-cloudflare/",
-  "repository": "https://github.com/cloudflare/mcp-server-cloudflare",
-  "license": "Apache-2.0",
-  "keywords": ["cloudflare", "workers", "bindings", "mcp"]
+	"$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+	"name": "cloudflare-bindings",
+	"description": "Manage Cloudflare Workers platform resources through Cloudflare's hosted Bindings MCP server.",
+	"author": {
+		"name": "Cloudflare",
+		"url": "https://www.cloudflare.com/"
+	},
+	"homepage": "https://developers.cloudflare.com/agents/model-context-protocol/mcp-servers-for-cloudflare/",
+	"repository": "https://github.com/cloudflare/mcp-server-cloudflare",
+	"license": "Apache-2.0",
+	"keywords": ["cloudflare", "workers", "bindings", "mcp"]
 }

--- a/apps/workers-bindings/agent-plugin/plugin.json
+++ b/apps/workers-bindings/agent-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "cloudflare-bindings",
+  "description": "Manage Cloudflare Workers platform resources through Cloudflare's hosted Bindings MCP server.",
+  "author": {
+    "name": "Cloudflare",
+    "url": "https://www.cloudflare.com/"
+  },
+  "homepage": "https://developers.cloudflare.com/agents/model-context-protocol/mcp-servers-for-cloudflare/",
+  "repository": "https://github.com/cloudflare/mcp-server-cloudflare",
+  "license": "Apache-2.0",
+  "keywords": ["cloudflare", "workers", "bindings", "mcp"]
+}

--- a/apps/workers-observability/README.md
+++ b/apps/workers-observability/README.md
@@ -32,4 +32,12 @@ This MCP server is still a work in progress, and we plan to add more tools in th
 
 Connect your MCP client directly to `https://observability.mcp.cloudflare.com/mcp`. If prompted, complete the Cloudflare OAuth flow in your browser. The tools become available after authorization.
 
+### Agent Plugins 1.0
+
+Connect to Cloudflare's Workers Observability MCP server with Universal Agent Plugins:
+
+```bash
+npx universal-agent-plugins add cloudflare-observability
+```
+
 Interested in contributing, and running this server locally? See [CONTRIBUTING.md](CONTRIBUTING.md) to get started.

--- a/apps/workers-observability/agent-plugin/mcp.json
+++ b/apps/workers-observability/agent-plugin/mcp.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+  "mcpServers": {
+    "cloudflare-observability": {
+      "type": "streamable-http",
+      "url": "https://observability.mcp.cloudflare.com/mcp"
+    }
+  }
+}

--- a/apps/workers-observability/agent-plugin/mcp.json
+++ b/apps/workers-observability/agent-plugin/mcp.json
@@ -1,9 +1,9 @@
 {
-  "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
-  "mcpServers": {
-    "cloudflare-observability": {
-      "type": "streamable-http",
-      "url": "https://observability.mcp.cloudflare.com/mcp"
-    }
-  }
+	"$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+	"mcpServers": {
+		"cloudflare-observability": {
+			"type": "streamable-http",
+			"url": "https://observability.mcp.cloudflare.com/mcp"
+		}
+	}
 }

--- a/apps/workers-observability/agent-plugin/plugin.json
+++ b/apps/workers-observability/agent-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "cloudflare-observability",
+  "description": "Query Cloudflare Workers logs and analytics through Cloudflare's hosted Observability MCP server.",
+  "author": {
+    "name": "Cloudflare",
+    "url": "https://www.cloudflare.com/"
+  },
+  "homepage": "https://developers.cloudflare.com/agents/model-context-protocol/mcp-servers-for-cloudflare/",
+  "repository": "https://github.com/cloudflare/mcp-server-cloudflare",
+  "license": "Apache-2.0",
+  "keywords": ["cloudflare", "workers", "observability", "mcp"]
+}

--- a/apps/workers-observability/agent-plugin/plugin.json
+++ b/apps/workers-observability/agent-plugin/plugin.json
@@ -1,13 +1,13 @@
 {
-  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
-  "name": "cloudflare-observability",
-  "description": "Query Cloudflare Workers logs and analytics through Cloudflare's hosted Observability MCP server.",
-  "author": {
-    "name": "Cloudflare",
-    "url": "https://www.cloudflare.com/"
-  },
-  "homepage": "https://developers.cloudflare.com/agents/model-context-protocol/mcp-servers-for-cloudflare/",
-  "repository": "https://github.com/cloudflare/mcp-server-cloudflare",
-  "license": "Apache-2.0",
-  "keywords": ["cloudflare", "workers", "observability", "mcp"]
+	"$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+	"name": "cloudflare-observability",
+	"description": "Query Cloudflare Workers logs and analytics through Cloudflare's hosted Observability MCP server.",
+	"author": {
+		"name": "Cloudflare",
+		"url": "https://www.cloudflare.com/"
+	},
+	"homepage": "https://developers.cloudflare.com/agents/model-context-protocol/mcp-servers-for-cloudflare/",
+	"repository": "https://github.com/cloudflare/mcp-server-cloudflare",
+	"license": "Apache-2.0",
+	"keywords": ["cloudflare", "workers", "observability", "mcp"]
 }


### PR DESCRIPTION
## Summary

Add portable Agent Plugins 1.0 packages alongside three existing MCP servers:

| Server | Package path | MCP endpoint |
| --- | --- | --- |
| Documentation | `apps/docs-ai-search/agent-plugin` | `https://docs.mcp.cloudflare.com/mcp` |
| Workers Bindings | `apps/workers-bindings/agent-plugin` | `https://bindings.mcp.cloudflare.com/mcp` |
| Workers Observability | `apps/workers-observability/agent-plugin` | `https://observability.mcp.cloudflare.com/mcp` |

Each package contains standard `plugin.json` and `mcp.json` files. The server implementations, authentication flows, permissions, and repository layout are unchanged. No installer-specific fields are added.

The matching app READMEs include a short-name installation command. Those aliases are community-packaged distributions; they do not imply that this proposed upstream package has already been merged or published by Cloudflare.

Radar is deliberately excluded because its documentation directs new integrations to the unified API MCP. The broader community `cloudflare` package combines the official `cloudflare/skills` skill set with Cloudflare's unified API MCP, and remains separate from these domain-specific packages.

## Verification

- All six JSON files pass the canonical Agent Plugins 1.0 schemas.
- Each package passed `add`, `info`, `update`, and `remove` using Universal Agent Plugins 0.1.45 in isolated profiles for Codex, Cursor, Kiro, Gemini CLI, OpenCode, Cline, Windsurf, and VS Code.
- The same lifecycle passed with the real Claude Code 2.1.260 plugin manager in an isolated profile.
- Removal left no managed client bindings and preserved unrelated test MCP configuration.
- These are package installation/materialization checks. They do not prove Cloudflare OAuth, account access, or tool execution. Copilot CLI and ChatGPT UI were not exercised in this run.
