### PR TITLE
fix(dns-analytics): clarify zone ID inputs

### DIFF
--- a/.changeset/fix-dns-analytics-zone-id.md
+++ b/.changeset/fix-dns-analytics-zone-id.md
@@ -1,0 +1,5 @@
+---
+'dns-analytics': patch
+---
+
+Clarify that DNS Analytics report and zone-settings tools require a zone ID.

--- a/apps/dns-analytics/src/dns-analytics.spec.ts
+++ b/apps/dns-analytics/src/dns-analytics.spec.ts
@@ -14,4 +14,8 @@ testStatelessMcpApp<Env>({
 	authenticated: true,
 	authenticatedWorker: worker,
 	expectedTools: ['dns_report', 'show_account_dns_settings', 'show_zone_dns_settings'],
+	requiredToolInputs: {
+		dns_report: ['zoneId', 'days'],
+		show_zone_dns_settings: ['zoneId'],
+	},
 })

--- a/apps/dns-analytics/src/tools/dex-analytics.tools.ts
+++ b/apps/dns-analytics/src/tools/dex-analytics.tools.ts
@@ -19,13 +19,13 @@ export function registerAnalyticTools<Env>(context: McpRegistrationContext<Env>)
 	context.registerTool(
 		'dns_report',
 		{
-			description: 'Fetch the DNS Report for a given zone since a date',
+			description: 'Fetch the DNS Report for a given zone ID since a date',
 			inputSchema: z.object({
-				zone: z.string(),
+				zoneId: z.string().describe('The ID of the zone to get the report for'),
 				days: z.number(),
 			}),
 		},
-		async ({ zone, days }) => {
+		async ({ zoneId: zone, days }) => {
 			try {
 				const props = requireRequestProps(context)
 				const client = getCloudflareClient(props.accessToken)
@@ -102,12 +102,12 @@ export function registerAnalyticTools<Env>(context: McpRegistrationContext<Env>)
 	context.registerTool(
 		'show_zone_dns_settings',
 		{
-			description: 'Show DNS settings for a zone',
+			description: 'Show DNS settings for a zone ID',
 			inputSchema: z.object({
-				zone: z.string(),
+				zoneId: z.string().describe('The ID of the zone to get settings for'),
 			}),
 		},
-		async ({ zone }) => {
+		async ({ zoneId: zone }) => {
 			try {
 				const props = requireRequestProps(context)
 				const client = getCloudflareClient(props.accessToken)


### PR DESCRIPTION
## Summary

- Rename the `dns_report` and `show_zone_dns_settings` inputs from `zone` to `zoneId`.
- Describe both inputs as Cloudflare zone IDs and cover their published MCP schemas.
- Keep the separate DNS report plan-compatibility change out of this patch.

## Why

Zone names previously reached the Cloudflare API as zone IDs and produced a misleading missing-zone response. The tools now make the required identifier kind explicit before an API request.

## Testing

- Before, the DNS Analytics tool schemas required `zone`, so the new contract assertion failed on current `main`.
- `pnpm --filter dns-analytics test`
- `pnpm --filter dns-analytics check:types`
- `pnpm --filter dns-analytics check:lint`

Fixes #456
