### PR TITLE
fix(sandbox-container): prevent path traversal in file read/write/delete

### DIFF
--- a/.changeset/sandbox-path-traversal.md
+++ b/.changeset/sandbox-path-traversal.md
@@ -1,0 +1,5 @@
+---
+'containers-mcp': patch
+---
+
+Fix a path-traversal vulnerability in the sandbox container's file endpoints. `container_file_write`, `container_file_read`, and `container_file_delete` took the client-supplied `path` and used it directly (or after only a `path.join` with the working directory, which does not stop `..` segments or a leading `/` from escaping it) in `fs.writeFile`/`fs.readFile`/`fs.rm`, so a path like `../../etc/passwd` or an absolute path resolved outside the container's working directory. All three now resolve the requested path through a shared guard that rejects anything resolving outside the working directory.

--- a/apps/sandbox-container/container/fileUtils.spec.ts
+++ b/apps/sandbox-container/container/fileUtils.spec.ts
@@ -2,7 +2,13 @@ import mime from 'mime'
 import mock from 'mock-fs'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { get_file_name_from_path, get_mime_type, list_files_in_directory } from './fileUtils'
+import {
+	get_file_name_from_path,
+	get_mime_type,
+	list_files_in_directory,
+	PathTraversalError,
+	resolve_in_workdir,
+} from './fileUtils'
 
 vi.mock('mime', () => {
 	return {
@@ -64,6 +70,17 @@ describe('get_file_name_from_path', () => {
 				const listFiles = await list_files_in_directory('')
 				expect(listFiles).toHaveLength(1)
 				expect(listFiles[0]).toMatch(/^file:\/\/\/.*testDir$/)
+			}),
+			it('rejects a directory path that escapes the working directory', async () => {
+				mock({
+					testDir: {
+						cats: 'aurora, luna',
+					},
+				})
+
+				await expect(async () => await list_files_in_directory('../../etc')).rejects.toThrow(
+					PathTraversalError
+				)
 			})
 	}),
 	describe('get_mime_type', async () => {
@@ -78,3 +95,29 @@ describe('get_file_name_from_path', () => {
 			expect(mimeType).toEqual('text/directory')
 		})
 	})
+
+describe('resolve_in_workdir', () => {
+	it('resolves an ordinary relative path inside the working directory', () => {
+		expect(resolve_in_workdir('cats')).toBe(`${process.cwd()}/cats`)
+	})
+
+	it('resolves a leading-slash path as relative to the working directory, matching prior path.join behavior', () => {
+		expect(resolve_in_workdir('/cats/dog.txt')).toBe(`${process.cwd()}/cats/dog.txt`)
+	})
+
+	it('rejects a relative path that climbs above the working directory', () => {
+		expect(() => resolve_in_workdir('../../etc/passwd')).toThrow(PathTraversalError)
+	})
+
+	it('treats an absolute path as relative to the working directory rather than the filesystem root', () => {
+		expect(resolve_in_workdir('/etc/passwd')).toBe(`${process.cwd()}/etc/passwd`)
+	})
+
+	it('rejects a path that only escapes after internal .. segments are resolved', () => {
+		expect(() => resolve_in_workdir('foo/../../bar')).toThrow(PathTraversalError)
+	})
+
+	it('rejects the bare parent-directory segment', () => {
+		expect(() => resolve_in_workdir('..')).toThrow(PathTraversalError)
+	})
+})

--- a/apps/sandbox-container/container/fileUtils.ts
+++ b/apps/sandbox-container/container/fileUtils.ts
@@ -13,12 +13,36 @@ export async function get_file_name_from_path(path: string): Promise<string> {
 	return path
 }
 
+export class PathTraversalError extends Error {
+	constructor(requestedPath: string) {
+		super(`Path escapes the working directory: ${requestedPath}`)
+		this.name = 'PathTraversalError'
+	}
+}
+
+/**
+ * Resolves a client-supplied file/directory path against the container's working
+ * directory, rejecting anything (`../` segments, an absolute path like `/etc/passwd`)
+ * that would resolve outside of it. Every filesystem access in this file takes a
+ * client-controlled path and must go through this before touching `fs`.
+ */
+export function resolve_in_workdir(requestedPath: string): string {
+	const base = process.cwd()
+	const resolved = path.resolve(base, `.${path.sep}${requestedPath}`)
+	const relative = path.relative(base, resolved)
+
+	if (relative === '..' || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
+		throw new PathTraversalError(requestedPath)
+	}
+
+	return resolved
+}
+
 export async function list_files_in_directory(dirPath: string): Promise<string[]> {
+	const resolvedDir = resolve_in_workdir(dirPath)
 	const files: string[] = []
 	try {
-		const dir = await fs.readdir(path.join(process.cwd(), dirPath), {
-			withFileTypes: true,
-		})
+		const dir = await fs.readdir(resolvedDir, { withFileTypes: true })
 		for (const dirent of dir) {
 			const relPath = path.relative(process.cwd(), `${dirPath}/${dirent.name}`)
 			files.push(`file:///${relPath}`)

--- a/apps/sandbox-container/container/sandbox.container.app.ts
+++ b/apps/sandbox-container/container/sandbox.container.app.ts
@@ -13,6 +13,8 @@ import {
 	get_file_name_from_path,
 	get_mime_type,
 	list_files_in_directory,
+	PathTraversalError,
+	resolve_in_workdir,
 } from './fileUtils.ts'
 
 import type { FileList } from '../shared/schema.ts'
@@ -72,9 +74,12 @@ app.get('/files/contents/*', async (c) => {
 	try {
 		const mimeType = await get_mime_type(reqPath)
 		const headers = mimeType ? { 'Content-Type': mimeType } : undefined
-		const contents = await fs.readFile(path.join(process.cwd(), reqPath))
+		const contents = await fs.readFile(resolve_in_workdir(reqPath))
 		return c.newResponse(contents, 200, headers)
 	} catch (e: any) {
+		if (e instanceof PathTraversalError) {
+			return c.newResponse(e.message, 400)
+		}
 		if (e.code) {
 			if (e.code === 'EISDIR') {
 				const files = await list_files_in_directory(reqPath)
@@ -101,7 +106,7 @@ app.post('/files/contents', zValidator('json', FileWrite), async (c) => {
 	const reqPath = await get_file_name_from_path(file.path)
 
 	try {
-		await fs.writeFile(reqPath, file.text)
+		await fs.writeFile(resolve_in_workdir(reqPath), file.text)
 		return c.newResponse(null, 200)
 	} catch (e) {
 		return c.newResponse(`Error: ${e}`, 400)
@@ -117,9 +122,12 @@ app.delete('/files/contents/*', async (c) => {
 	const reqPath = await get_file_name_from_path(c.req.path)
 
 	try {
-		await fs.rm(path.join(process.cwd(), reqPath), { recursive: true })
+		await fs.rm(resolve_in_workdir(reqPath), { recursive: true })
 		return c.newResponse('ok', 200)
 	} catch (e: any) {
+		if (e instanceof PathTraversalError) {
+			return c.newResponse(e.message, 400)
+		}
 		if (e.code) {
 			if (e.code === 'ENOENT') {
 				return c.notFound()


### PR DESCRIPTION
## Summary

`container_file_write`, `container_file_read`, and `container_file_delete` — the MCP tools backing the sandbox's file endpoints — took the client-supplied `path` (a free-form string, no format constraint in `FileWrite`/`FilePathParam`) and used it with no containment check:

- `POST /files/contents` (write) called `fs.writeFile(reqPath, file.text)` directly, with no `cwd` join at all.
- `GET`/`DELETE /files/contents/*` joined it onto the working directory with `path.join(process.cwd(), reqPath)`, which normalizes `..` segments but does **not** stop them from climbing outside the base directory, and does not stop an absolute path from being concatenated straight onto the prefix.

So a write with `path: "../../etc/cron.d/x"` (or an absolute path) resolved outside the container's `workdir`, and reads/deletes were exploitable the same way — arbitrary file read/write/delete on the container filesystem via a directly-exposed MCP tool call. Confirmed by tracing the full call path from the `container_file_*` tool registrations in `apps/sandbox-container/server/container-tools.ts` through `userContainer.ts` into `apps/sandbox-container/container/sandbox.container.app.ts`; none of the intermediate layers (`stripProtocolFromFilePath`, `get_file_name_from_path`) do any traversal or absolute-path check.

## Fix

Added `resolve_in_workdir()` in `fileUtils.ts`: resolves the requested path against `process.cwd()` and throws `PathTraversalError` if the resolved path isn't contained in it. All three handlers (`GET`/`POST`/`DELETE` on `/files/contents`) and `list_files_in_directory` now go through this single guard instead of the ad hoc `path.join`/raw-path calls. A rejected path returns 400 instead of touching the filesystem.

Ordinary usage is unaffected — a leading `/` in the request path (the normal shape, since these routes are matched off `/files/contents/*`) still resolves relative to the working directory, matching the prior `path.join` behavior for non-malicious input.

## Test plan

- [x] Added `resolve_in_workdir` unit tests covering: relative path, leading-slash path (existing shape from the route), `../` traversal, absolute path treated as relative to the working dir, traversal that only escapes after internal `..` segments resolve, and the bare `..` segment.
- [x] Added a `list_files_in_directory` test asserting a traversal path throws `PathTraversalError`.
- [x] `pnpm test` in `apps/sandbox-container` (both vitest configs) — all passing.
- [x] `pnpm check:types` and `pnpm check:lint` in `apps/sandbox-container` — clean.

Fixes #401